### PR TITLE
Add a "PYENV-SHIM-SCRIPT" marker in 2nd line of every shim file

### DIFF
--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -38,6 +38,7 @@ remove_prototype_shim() {
 create_prototype_shim() {
   cat > "$PROTOTYPE_SHIM_PATH" <<SH
 #!/usr/bin/env bash
+# PYENV-SHIM-SCRIPT
 set -e
 [ -n "\$PYENV_DEBUG" ] && set -x
 


### PR DESCRIPTION
Rationale: argcomplete library and possibily other tools that have
to follow the "wrapper chain" need to identify pyenv shims to be able
to read the target executable. setuptools do the same with its stubs.

see https://github.com/kislyuk/argcomplete/issues/58#issuecomment-23205305
