### PR TITLE
Update python-build

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -287,7 +287,7 @@ fetch_tarball() {
     download_tarball "$package_url" "$package_filename" "$checksum"
   }
 
-  { if tar xvf "$package_filename"; then
+  { if tar xzvf "$package_filename"; then
       if [ -z "$KEEP_BUILD_PATH" ]; then
         rm -f "$package_filename"
       else


### PR DESCRIPTION
Adds -z to tar command to make OpenBSD's tar command not mistake the tarball as a cpio archive
