### PR TITLE
Fix pyenv-prefix to trim "/bin" in `pyenv prefix system`

### DIFF
--- a/libexec/pyenv-prefix
+++ b/libexec/pyenv-prefix
@@ -31,8 +31,7 @@ PYENV_PREFIX_PATHS=()
 for version in "${versions[@]}"; do
   if [ "$version" = "system" ]; then
     PYTHON_PATH="$(PYENV_VERSION="${version}" pyenv-which python || true)"
-    PYENV_PREFIX_PATH="${PYTHON_PATH%/*}"
-    PYENV_PREFIX_PATH="${PYENV_PREFIX_PATH%/bin}"
+    PYENV_PREFIX_PATH="${PYTHON_PATH%/bin/*}"
   else
     PYENV_PREFIX_PATH="${PYENV_ROOT}/versions/${version}"
   fi


### PR DESCRIPTION
We have '/bin' at the end of a result of pyenv-prefix with 'system', such as '/usr/local/bin'.
It is inconsistent with a return value of the command with a specific version, such as '.../.pyenv/versions/3.3.x'.
