### PR TITLE
Support shims that are sourced in bash

### DIFF
--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -42,10 +42,10 @@ remove_prototype_shim() {
 create_prototype_shim() {
   cat > "$PROTOTYPE_SHIM_PATH" <<SH
 #!/usr/bin/env bash
-set -e
+[ "\$BASH_LINENO" == 0 ] && set -e
 [ -n "\$PYENV_DEBUG" ] && set -x
 
-program="\${0##*/}"
+program="\${BASH_SOURCE[0]##*/}"
 if [ "\$program" = "python" ]; then
   for arg; do
     case "\$arg" in
@@ -61,7 +61,11 @@ if [ "\$program" = "python" ]; then
 fi
 
 export PYENV_ROOT="$PYENV_ROOT"
-exec "$(command -v pyenv)" exec "\$program" "\$@"
+if [ "\$BASH_LINENO" == 0 ]; then
+    exec "$(command -v pyenv)" exec "\$program" "\$@"
+else
+    . \$("$(command -v pyenv)" which "\$program") "\$@"
+fi
 SH
   chmod +x "$PROTOTYPE_SHIM_PATH"
 }


### PR DESCRIPTION
This change was done specifically to support virtualenvwrapper which
provides scripts that are supposed to be sourced into your current shell.
The BASH_SOURCE variable can be used determine the current file that is
being included.  BASH_LINENO can be used to determine if the current
execution is an invocations or sourcing of a file.  BASH_LINENO will
be 0 in a script invocation because there are no functions currently
on the stack.  Finally, if your a currently sourcing a file, do not
do "set -e" as that will cause the interactive shell to close on any
error.
