### PR TITLE
Fix grep matcher option conflict in 'pyenv install -l' command.

### DIFF
--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -44,7 +44,7 @@ usage() {
 
 definitions() {
   local query="$1"
-  python-build --definitions | env --unset=GREP_OPTIONS grep -F "$query" || true
+  python-build --definitions | GREP_OPTIONS= grep -F "$query" || true
 }
 
 indent() {


### PR DESCRIPTION
I have set `GREP_OPTIONS="-E"` in my `~/.bashrc` as I normally want grep to work regular expression enabled. 
But in this case, `pyenv install -l` command does not work as followings:

```
$ pyenv install -l
Available versions:
grep: conflicting matchers specified
$
```

This is because grep option -F(Fixed strings matcher) is used in the script and this matcher option conflicts with the other option like -E(Extended regexp matcher), -G(Basic regexp matcher), -P(Perl regexp matcher).

So I prefixed `env --unset=GREP_OPTIONS` to the `grep` in the script, and this worked for me.

```
$ pyenv install -l
Available versions:
  2.4
  2.4.1
  2.4.2
  ...
```

It is much appreciated if you would take a look at this pull request.

Thanks.
