### PR TITLE
fix: anaconda_architecture mispelled MacOSX as MaxOSX

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -773,7 +773,7 @@ build_package_pypy_builder() {
 
 anaconda_architecture() {
   case "$(uname -s)" in
-  "Darwin" ) echo "MaxOSX-x86_64" ;;
+  "Darwin" ) echo "MacOSX-x86_64" ;;
   "Linux" )
     case "$(uname -m)" in
     "i386" | "i486" | "i586" | "i686" | "i786" ) echo "Linux-x86" ;;


### PR DESCRIPTION
This references [issue 135](https://github.com/yyuu/pyenv/issues/135).
