### PR TITLE
Use default cc to build CPython

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -969,17 +969,20 @@ verify_gcc() {
 }
 
 require_cc() {
-  local cc=("$@")
-  while [ -n "${cc}" ]; do
-    { if [ "${#cc[@]}" -le 1 ]; then
-        "require_${cc}" # display last error
-      else
-        "require_${cc}" 3>/dev/null
-      fi
-    } && return 0
-    cc=("${cc[@]:1}")
-  done
-  return 1
+  local cc="$(command -v "$CC" || command -v "cc" || true)"
+
+  if [ -z "$cc" ]; then
+    { echo
+      colorize 1 "ERROR"
+      echo ": This package must be compiled with cc, but python-build couldn't"
+      echo "find a suitable \`cc\` executable on your system. Please install cc"
+      echo "and try again."
+      echo
+    } >&3
+    return 1
+  fi
+
+  export CC
 }
 
 require_clang() {

--- a/plugins/python-build/share/python-build/2.4
+++ b/plugins/python-build/share/python-build/2.4
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.4" "http://python.org/ftp/python/2.4/Python-2.4.tgz#149ad508f936eccf669d52682cf8e606" ldflags_dirs standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python

--- a/plugins/python-build/share/python-build/2.4.1
+++ b/plugins/python-build/share/python-build/2.4.1
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.4.1" "http://python.org/ftp/python/2.4.1/Python-2.4.1.tgz#7bb2416a4f421c3452d306694d3efbba" ldflags_dirs standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python

--- a/plugins/python-build/share/python-build/2.4.2
+++ b/plugins/python-build/share/python-build/2.4.2
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.4.2" "http://python.org/ftp/python/2.4.2/Python-2.4.2.tgz#07cfc759546f6723bb367be5b1ce9875" ldflags_dirs standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python

--- a/plugins/python-build/share/python-build/2.4.3
+++ b/plugins/python-build/share/python-build/2.4.3
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.4.3" "http://python.org/ftp/python/2.4.3/Python-2.4.3.tgz#edf994473a8c1a963aaa71e442b285b7" ldflags_dirs standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python

--- a/plugins/python-build/share/python-build/2.4.4
+++ b/plugins/python-build/share/python-build/2.4.4
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.4.4" "http://python.org/ftp/python/2.4.4/Python-2.4.4.tgz#82d000617baaef269ad5795c595fdc58" ldflags_dirs standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python

--- a/plugins/python-build/share/python-build/2.4.5
+++ b/plugins/python-build/share/python-build/2.4.5
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.4.5" "http://python.org/ftp/python/2.4.5/Python-2.4.5.tgz#750b652bfdd12675e102bbe25e5e9893" ldflags_dirs standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python

--- a/plugins/python-build/share/python-build/2.4.6
+++ b/plugins/python-build/share/python-build/2.4.6
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.4.6" "http://python.org/ftp/python/2.4.6/Python-2.4.6.tgz#7564b2b142b1b8345cd5358b7aaaa482" ldflags_dirs standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python

--- a/plugins/python-build/share/python-build/2.5
+++ b/plugins/python-build/share/python-build/2.5
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.5" "http://python.org/ftp/python/2.5/Python-2.5.tgz#bc1b74f90a472a6c0a85481aaeb43f95" ldflags_dirs standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python

--- a/plugins/python-build/share/python-build/2.5.1
+++ b/plugins/python-build/share/python-build/2.5.1
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.5.1" "http://python.org/ftp/python/2.5.1/Python-2.5.1.tgz#cca695828df8adc3e69b637af07522e1" ldflags_dirs standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python

--- a/plugins/python-build/share/python-build/2.5.2
+++ b/plugins/python-build/share/python-build/2.5.2
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.5.2" "http://python.org/ftp/python/2.5.2/Python-2.5.2.tgz#3f7ca8aa86c6bd275426d63b46e07992" ldflags_dirs standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python

--- a/plugins/python-build/share/python-build/2.5.3
+++ b/plugins/python-build/share/python-build/2.5.3
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.5.3" "http://python.org/ftp/python/2.5.3/Python-2.5.3.tgz#a971f8928d6beb31ae0de56f7034d6a2" ldflags_dirs standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python

--- a/plugins/python-build/share/python-build/2.5.4
+++ b/plugins/python-build/share/python-build/2.5.4
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.5.4" "http://python.org/ftp/python/2.5.4/Python-2.5.4.tgz#ad47b23778f64edadaaa8b5534986eed" ldflags_dirs standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python

--- a/plugins/python-build/share/python-build/2.5.5
+++ b/plugins/python-build/share/python-build/2.5.5
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.5.5" "http://python.org/ftp/python/2.5.5/Python-2.5.5.tgz#abc02139ca38f4258e8e372f7da05c88" ldflags_dirs standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python

--- a/plugins/python-build/share/python-build/2.5.6
+++ b/plugins/python-build/share/python-build/2.5.6
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.5.6" "http://python.org/ftp/python/2.5.6/Python-2.5.6.tgz#d1d9c83928561addf11d00b22a18ca50" ldflags_dirs standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python

--- a/plugins/python-build/share/python-build/2.6-dev
+++ b/plugins/python-build/share/python-build/2.6-dev
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_hg "Python-2.6-dev" "https://bitbucket.org/mirror/cpython" "2.6" standard verify_py26
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/2.6.6
+++ b/plugins/python-build/share/python-build/2.6.6
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.6.6" "http://python.org/ftp/python/2.6.6/Python-2.6.6.tgz#b2f209df270a33315e62c1ffac1937f0" ldflags_dirs standard verify_py26
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/2.6.7
+++ b/plugins/python-build/share/python-build/2.6.7
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.6.7" "http://python.org/ftp/python/2.6.7/Python-2.6.7.tgz#af474f85a3af69ea50438a2a48039d7d" ldflags_dirs standard verify_py26
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/2.6.8
+++ b/plugins/python-build/share/python-build/2.6.8
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.6.8" "http://python.org/ftp/python/2.6.8/Python-2.6.8.tgz#f6c1781f5d73ab7dfa5181f43ea065f6" ldflags_dirs standard verify_py26
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/2.6.9
+++ b/plugins/python-build/share/python-build/2.6.9
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.6.9" "http://python.org/ftp/python/2.6.9/Python-2.6.9.tgz#bddbd64bf6f5344fc55bbe49a72fe4f3" ldflags_dirs standard verify_py26
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/2.7
+++ b/plugins/python-build/share/python-build/2.7
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.7" "http://python.org/ftp/python/2.7/Python-2.7.tgz#35f56b092ecf39a6bd59d64f142aae0f" ldflags_dirs standard verify_py27
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/2.7-dev
+++ b/plugins/python-build/share/python-build/2.7-dev
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_hg "Python-2.7-dev" "https://bitbucket.org/mirror/cpython" "2.7" standard verify_py27
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/2.7.1
+++ b/plugins/python-build/share/python-build/2.7.1
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.7.1" "http://python.org/ftp/python/2.7.1/Python-2.7.1.tgz#15ed56733655e3fab785e49a7278d2fb" ldflags_dirs standard verify_py27
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/2.7.2
+++ b/plugins/python-build/share/python-build/2.7.2
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.7.2" "http://python.org/ftp/python/2.7.2/Python-2.7.2.tgz#0ddfe265f1b3d0a8c2459f5bf66894c7" ldflags_dirs standard verify_py27
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/2.7.3
+++ b/plugins/python-build/share/python-build/2.7.3
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.7.3" "http://python.org/ftp/python/2.7.3/Python-2.7.3.tgz#2cf641732ac23b18d139be077bd906cd" ldflags_dirs standard verify_py27
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/2.7.4
+++ b/plugins/python-build/share/python-build/2.7.4
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.7.4" "http://python.org/ftp/python/2.7.4/Python-2.7.4.tgz#592603cfaf4490a980e93ecb92bde44a" ldflags_dirs standard verify_py27
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/2.7.5
+++ b/plugins/python-build/share/python-build/2.7.5
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.7.5" "http://python.org/ftp/python/2.7.5/Python-2.7.5.tgz#b4f01a1d0ba0b46b05c73b2ac909b1df" ldflags_dirs standard verify_py27
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/2.7.6
+++ b/plugins/python-build/share/python-build/2.7.6
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-2.7.6" "http://python.org/ftp/python/2.7.6/Python-2.7.6.tgz#1d8728eb0dfcac72a0fd99c17ec7f386" ldflags_dirs standard verify_py27
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.0.1
+++ b/plugins/python-build/share/python-build/3.0.1
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.0.1" "http://python.org/ftp/python/3.0.1/Python-3.0.1.tgz#220b73f0a1a20c4b1cdf9f9db4cd52fe" ldflags_dirs standard verify_py30
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.1-dev
+++ b/plugins/python-build/share/python-build/3.1-dev
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_hg "Python-3.1-dev" "https://bitbucket.org/mirror/cpython" "3.1" standard verify_py31
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.1.3
+++ b/plugins/python-build/share/python-build/3.1.3
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.1.3" "http://python.org/ftp/python/3.1.3/Python-3.1.3.tgz#d797fa6abe82c21227e328f05a535424" ldflags_dirs standard verify_py31
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.1.4
+++ b/plugins/python-build/share/python-build/3.1.4
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.1.4" "http://python.org/ftp/python/3.1.4/Python-3.1.4.tgz#fa9f8efdc63944c8393870282e8b5c35" ldflags_dirs standard verify_py31
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.1.5
+++ b/plugins/python-build/share/python-build/3.1.5
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.1.5" "http://python.org/ftp/python/3.1.5/Python-3.1.5.tgz#02196d3fc7bc76bdda68aa36b0dd16ab" ldflags_dirs standard verify_py31
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.2
+++ b/plugins/python-build/share/python-build/3.2
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.2" "http://python.org/ftp/python/3.2/Python-3.2.tgz#5efe838a7878b170f6728d7e5d7517af" ldflags_dirs standard verify_py32
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.2-dev
+++ b/plugins/python-build/share/python-build/3.2-dev
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_hg "Python-3.2-dev" "https://bitbucket.org/mirror/cpython" "3.2" standard verify_py32
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.2.1
+++ b/plugins/python-build/share/python-build/3.2.1
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.2.1" "http://python.org/ftp/python/3.2.1/Python-3.2.1.tgz#6c2aa3481cadb7bdf74e625fffc352b2" ldflags_dirs standard verify_py32
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.2.2
+++ b/plugins/python-build/share/python-build/3.2.2
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.2.2" "http://python.org/ftp/python/3.2.2/Python-3.2.2.tgz#3c63a6d97333f4da35976b6a0755eb67" ldflags_dirs standard verify_py32
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.2.3
+++ b/plugins/python-build/share/python-build/3.2.3
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.2.3" "http://python.org/ftp/python/3.2.3/Python-3.2.3.tgz#dcf3a738e7028f1deb41b180bf0e2cbc" ldflags_dirs standard verify_py32
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.2.4
+++ b/plugins/python-build/share/python-build/3.2.4
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.2.4" "http://python.org/ftp/python/3.2.4/Python-3.2.4.tgz#3af05758d0bc2b1a27249e8d622c3e91" ldflags_dirs standard verify_py32
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.2.5
+++ b/plugins/python-build/share/python-build/3.2.5
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.2.5" "http://python.org/ftp/python/3.2.5/Python-3.2.5.tgz#ed8d5529d2aebc36b53f4e0a0c9e6728" ldflags_dirs standard verify_py32
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.3-dev
+++ b/plugins/python-build/share/python-build/3.3-dev
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_hg "Python-3.3-dev" "https://bitbucket.org/mirror/cpython" "3.3" standard verify_py33
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.3.0
+++ b/plugins/python-build/share/python-build/3.3.0
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.3.0" "http://python.org/ftp/python/3.3.0/Python-3.3.0.tgz#198a64f7a04d1d5e95ce2782d5fd8254" ldflags_dirs standard verify_py33
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.3.1
+++ b/plugins/python-build/share/python-build/3.3.1
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.3.1" "http://python.org/ftp/python/3.3.1/Python-3.3.1.tgz#c19bfd6ea252b61779a4f2996fb3b330" ldflags_dirs standard verify_py33
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.3.2
+++ b/plugins/python-build/share/python-build/3.3.2
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.3.2" "http://python.org/ftp/python/3.3.2/Python-3.3.2.tgz#0a2ea57f6184baf45b150aee53c0c8da" ldflags_dirs standard verify_py33
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.3.3
+++ b/plugins/python-build/share/python-build/3.3.3
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.3.3" "http://python.org/ftp/python/3.3.3/Python-3.3.3.tgz#831d59212568dc12c95df222865d3441" ldflags_dirs standard verify_py33
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.3.4
+++ b/plugins/python-build/share/python-build/3.3.4
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.3.4" "http://python.org/ftp/python/3.3.4/Python-3.3.4.tgz#9f7df0dde690132c63b1dd2b640ed3a6" ldflags_dirs standard verify_py33
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.3.5
+++ b/plugins/python-build/share/python-build/3.3.5
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.3.5" "http://python.org/ftp/python/3.3.5/Python-3.3.5.tgz#803a75927f8f241ca78633890c798021" ldflags_dirs standard verify_py33
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/3.4-dev
+++ b/plugins/python-build/share/python-build/3.4-dev
@@ -1,3 +1,3 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_hg "Python-3.4-dev" "https://bitbucket.org/mirror/cpython" "default" standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.0
+++ b/plugins/python-build/share/python-build/3.4.0
@@ -1,3 +1,3 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "Python-3.4.0" "https://www.python.org/ftp/python/3.4.0/Python-3.4.0.tgz#3ca973eb72bb06ed5cadde0e28eaaaca" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7-dev
+++ b/plugins/python-build/share/python-build/stackless-2.7-dev
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_hg "stackless-2.7-dev" "http://hg.python.org/stackless" "2.7-slp" standard verify_py27
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/stackless-2.7.2
+++ b/plugins/python-build/share/python-build/stackless-2.7.2
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "stackless-272-export" "http://www.stackless.com/binaries/stackless-272-export.tar.bz2#79a718db998f2cdd95478d2cb54d56f2" ldflags_dirs standard verify_py27
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/stackless-3.2-dev
+++ b/plugins/python-build/share/python-build/stackless-3.2-dev
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_hg "stackless-3.2-dev" "http://hg.python.org/stackless" "3.2-slp" standard verify_py32
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/stackless-3.2.2
+++ b/plugins/python-build/share/python-build/stackless-3.2.2
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_package "stackless-322-export" "http://www.stackless.com/binaries/stackless-322-export.tar.bz2#3a3edcfb4240bdcc580cec2baea60af4" ldflags_dirs standard verify_py32
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/stackless-3.3-dev
+++ b/plugins/python-build/share/python-build/stackless-3.3-dev
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_hg "stackless-3.3-dev" "http://hg.python.org/stackless" "3.3-slp" standard verify_py33
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python

--- a/plugins/python-build/share/python-build/stackless-dev
+++ b/plugins/python-build/share/python-build/stackless-dev
@@ -1,4 +1,4 @@
-require_cc "gcc" "clang"
+require_cc
 install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
 install_hg "stackless-dev" "http://hg.python.org/stackless" "default" standard verify_py33
 install_package "setuptools-3.3" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.3.tar.gz#87680a0eb0bb6f720d5e2d89ba67debc" python


### PR DESCRIPTION
There is compiler issue on OS X like #148. To avoid choosing older `gcc` (e.g. `gcc-4.2` on OSX, with brew's `apple-gcc42` formula), just use default `cc` as `CC` to build CPython.

Although, there is still a chance to use other `CC`. Just setting `CC` (e.g. `env CC=gcc-4.2 pyenv install -v 2.7.6`) will allow you to build with specified compiler.
