### PR TITLE
compute_md5() doesn't fail on NetBSD

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -186,7 +186,12 @@ make_package() {
 
 compute_md5() {
   if type md5 &>/dev/null; then
-    md5 -q
+    if echo test | md5 -q &>/dev/null; then
+        md5 -q
+    else
+        # NetBSD does not have "md5 -q"
+        md5 | cut -d '=' -f 2 | tr -d ' '
+    fi
   elif type openssl &>/dev/null; then
     local output="$(openssl md5)"
     echo "${output##* }"


### PR DESCRIPTION
NetBSD's mds5 command (6.1.3 at least) does not have a -q/--quiet
switch. Work around that.
