### PR TITLE
add support for custom alias names for versions

### DIFF
--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -58,6 +58,7 @@ unset KEEP
 unset VERBOSE
 unset HAS_PATCH
 unset DEBUG
+unset USE_ALIAS
 
 parse_options "$@"
 for option in "${OPTIONS[@]}"; do
@@ -87,6 +88,9 @@ for option in "${OPTIONS[@]}"; do
     ;;
   "g" | "debug" )
     DEBUG="-g"
+    ;;
+  "a" | "alias" )
+    USE_ALIAS=true
     ;;
   "version" )
     exec python-build --version
@@ -134,6 +138,13 @@ for script in "${scripts[@]}"; do source "$script"; done
 [ -n "$VERSION_NAME" ] || VERSION_NAME="${DEFINITION##*/}"
 [ -n "$DEBUG" ] && VERSION_NAME="${VERSION_NAME}-debug"
 PREFIX="${PYENV_ROOT}/versions/${VERSION_NAME}"
+
+if [ -n "$USE_ALIAS" ] && [ -n "${ARGUMENTS[1]}" ]; then
+  # The second argument is the alias name.
+  ALIAS_NAME="${ARGUMENTS[1]}"
+  PREFIX="${PYENV_ROOT}/versions/${ALIAS_NAME}"
+  [ -n "$DEBUG" ] && PREFIX="${PREFIX}-debug"
+fi
 
 [ -d "${PREFIX}" ] && PREFIX_EXISTS=1
 


### PR DESCRIPTION
This patch allows you to specify an alias name when installing a python version, by adding a `-a`/`--alias` flag to the `python-install` script. This will allow you to install multiple copies of the same python version.

This is useful if you want to install multiple versions of 2.7.5 with different compile/configure options.

For example:

```
# the following line builds a 2.7.5 python framework with ucs2 on osx:
PYTHON_CONFIGURE_OPTS="--enable-framework --enable-unicode=ucs2" pyenv install -a 2.7.5 2.7.5_framework_ucs2

# and this will give us a framework with ucs4:
PYTHON_CONFIGURE_OPTS="--enable-framework --enable-unicode=ucs4" pyenv install -a 2.7.5 2.7.5_framework_ucs4

# and a regular 'shared' python, no framework:
PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install -a 2.7.5 2.7.5_shared
```

I believe that this minor patch might be useful for people trying to test tools and applications against different instances of the same python version.
