### PR TITLE
Fix broken link for setuptools-4.0.1

### DIFF
--- a/plugins/python-build/share/python-build/2.7.7
+++ b/plugins/python-build/share/python-build/2.7.7
@@ -1,5 +1,5 @@
 require_cc
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-2.7.7" "https://www.python.org/ftp/python/2.7.7/Python-2.7.7.tgz#7f49c0a6705ad89d925181e27d0aaa025ee4731ce0de64776c722216c3e66c42" ldflags_dirs standard verify_py27
-install_package "setuptools-3.8.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.8.1.tar.gz#md5=f2219937a17d4311499a52e82cba681e" python
+install_package "setuptools-3.8.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-3.8.1.tar.gz#736395f1e095fa7491ecba6590d288ea6aa532bf17a3abcf777a191aa205d386" python
 install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python


### PR DESCRIPTION
Setuptools re-release of 3.8.1 to signal that it supersedes 4.x
