### PR TITLE
Add support for 2.1.3, 2.2.3, 2.3.7

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1308,6 +1308,39 @@ verify_python_module() {
   fi
 }
 
+# Post-install check for Python 2.1.x
+build_package_verify_py21() {
+  verify_python "${2:-python2.1}"
+  try_python_module "readline" "GNU readline lib"
+  verify_python_module "binascii" "binascii"
+  # fixme: zlib doesn't link correctly on 64-bit Linux, due to being in
+  # /usr/x86_64-linux-gnu instead of /usr/lib
+  try_python_module "zlib" "zlib"
+  try_python_module "bz2" "bzip2 lib"
+}
+
+# Post-install check for Python 2.2.x
+build_package_verify_py22() {
+  verify_python "${2:-python2.2}"
+  try_python_module "readline" "GNU readline lib"
+  verify_python_module "binascii" "binascii"
+  # fixme: zlib doesn't link correctly on 64-bit Linux, due to being in
+  # /usr/x86_64-linux-gnu instead of /usr/lib
+  try_python_module "zlib" "zlib"
+  try_python_module "bz2" "bzip2 lib"
+}
+
+# Post-install check for Python 2.3.x
+build_package_verify_py23() {
+  verify_python "${2:-python2.3}"
+  try_python_module "readline" "GNU readline lib"
+  verify_python_module "binascii" "binascii"
+  # fixme: zlib doesn't link correctly on 64-bit Linux, due to being in
+  # /usr/x86_64-linux-gnu instead of /usr/lib
+  try_python_module "zlib" "zlib"
+  try_python_module "bz2" "bzip2 lib"
+}
+
 # Post-install check for Python 2.4.x
 build_package_verify_py24() {
   verify_python "${2:-2.4}"

--- a/plugins/python-build/share/python-build/2.1.3
+++ b/plugins/python-build/share/python-build/2.1.3
@@ -1,0 +1,5 @@
+require_cc
+install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
+install_package "Python-2.1.3" "http://www.python.org/ftp/python/2.1.3/Python-2.1.3.tgz#1bcb5bb587948bc38f36db60e15c376009c56c66570e563a08a82bf7f227afb9" ldflags_dirs standard verify_py21
+#install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python
+#install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#62a9f08dd5dc69d76734568a6c040508" python

--- a/plugins/python-build/share/python-build/2.2.3
+++ b/plugins/python-build/share/python-build/2.2.3
@@ -1,0 +1,5 @@
+require_cc
+install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
+install_package "Python-2.2.3" "http://www.python.org/ftp/python/2.2.3/Python-2.2.3.tgz#a8f92e6b89d47359fff0d1fbfe47f104afc77fd1cd5143e7332758b7bc100188" ldflags_dirs standard verify_py22
+#install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python
+#install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#62a9f08dd5dc69d76734568a6c040508" python

--- a/plugins/python-build/share/python-build/2.3.7
+++ b/plugins/python-build/share/python-build/2.3.7
@@ -1,0 +1,5 @@
+require_cc
+install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#67948acb2ca081f23359d0256e9a271c" standard --if has_broken_mac_readline
+install_package "Python-2.3.7" "http://python.org/ftp/python/2.3.7/Python-2.3.7.tgz#969a9891dce9f50b13e54f9890acaf2be66715a5895bf9b11111f320c205b90e" ldflags_dirs standard verify_py23
+#install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#13951be6711438073fbe50843e7f141f" python
+#install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#62a9f08dd5dc69d76734568a6c040508" python

--- a/plugins/python-build/share/python-build/patches/2.1.3/Python-2.1.3/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/2.1.3/Python-2.1.3/000_patch-setup.py.diff
@@ -1,0 +1,58 @@
+--- setup.py.orig	2014-06-22 01:56:56.614802000 -0700
++++ setup.py	2014-06-22 01:55:54.555149273 -0700
+@@ -12,10 +12,18 @@
+ from distutils.errors import *
+ from distutils.core import Extension, setup
+ from distutils.command.build_ext import build_ext
++from distutils.spawn import find_executable
+ 
+ # This global variable is used to hold the list of modules to be disabled.
+ disabled_module_list = []
+ 
++def add_dir_to_list(dirlist, dir):
++    """Add the directory 'dir' to the list 'dirlist' (at the front) if
++    1) 'dir' is not already in 'dirlist'
++    2) 'dir' actually exists, and is a directory."""
++    if dir is not None and os.path.isdir(dir) and dir not in dirlist:
++        dirlist.insert(0, dir)
++
+ def find_file(filename, std_dirs, paths):
+     """Searches for the directory where a given file is located,
+     and returns a possibly-empty list of additional directories, or None
+@@ -144,12 +152,36 @@
+ 
+         return platform
+ 
++    def add_multiarch_paths(self):
++        # Debian/Ubuntu multiarch support.
++        # https://wiki.ubuntu.com/MultiarchSpec
++        if not find_executable('dpkg-architecture'):
++            return
++        tmpfile = os.path.join(self.build_temp, 'multiarch')
++        if not os.path.exists(self.build_temp):
++            os.makedirs(self.build_temp)
++        ret = os.system(
++            'dpkg-architecture -qDEB_HOST_MULTIARCH > %s 2> /dev/null' %
++            tmpfile)
++        try:
++            if ret >> 8 == 0:
++                fp = open(tmpfile)
++                multiarch_path_component = fp.readline().strip()
++                fp.close()
++                add_dir_to_list(self.compiler.library_dirs,
++                                '/usr/lib/' + multiarch_path_component)
++                add_dir_to_list(self.compiler.include_dirs,
++                                '/usr/include/' + multiarch_path_component)
++        finally:
++            os.unlink(tmpfile)
++
+     def detect_modules(self):
+         # Ensure that /usr/local is always used
+         if '/usr/local/lib' not in self.compiler.library_dirs:
+             self.compiler.library_dirs.insert(0, '/usr/local/lib')
+         if '/usr/local/include' not in self.compiler.include_dirs:
+             self.compiler.include_dirs.insert(0, '/usr/local/include' )
++        self.add_multiarch_paths()
+ 
+         # lib_dirs and inc_dirs are used to search for files;
+         # if a file is found in one of those directories, it can

--- a/plugins/python-build/share/python-build/patches/2.2.3/Python-2.2.3/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/2.2.3/Python-2.2.3/000_patch-setup.py.diff
@@ -1,0 +1,58 @@
+--- setup.py.orig	2014-06-22 01:49:02.521459238 -0700
++++ setup.py	2014-06-22 01:53:59.607792944 -0700
+@@ -10,10 +10,18 @@
+ from distutils.core import Extension, setup
+ from distutils.command.build_ext import build_ext
+ from distutils.command.install import install
++from distutils.spawn import find_executable
+ 
+ # This global variable is used to hold the list of modules to be disabled.
+ disabled_module_list = []
+ 
++def add_dir_to_list(dirlist, dir):
++    """Add the directory 'dir' to the list 'dirlist' (at the front) if
++    1) 'dir' is not already in 'dirlist'
++    2) 'dir' actually exists, and is a directory."""
++    if dir is not None and os.path.isdir(dir) and dir not in dirlist:
++        dirlist.insert(0, dir)
++
+ def find_file(filename, std_dirs, paths):
+     """Searches for the directory where a given file is located,
+     and returns a possibly-empty list of additional directories, or None
+@@ -209,12 +217,36 @@
+ 
+         return platform
+ 
++    def add_multiarch_paths(self):
++        # Debian/Ubuntu multiarch support.
++        # https://wiki.ubuntu.com/MultiarchSpec
++        if not find_executable('dpkg-architecture'):
++            return
++        tmpfile = os.path.join(self.build_temp, 'multiarch')
++        if not os.path.exists(self.build_temp):
++            os.makedirs(self.build_temp)
++        ret = os.system(
++            'dpkg-architecture -qDEB_HOST_MULTIARCH > %s 2> /dev/null' %
++            tmpfile)
++        try:
++            if ret >> 8 == 0:
++                fp = open(tmpfile)
++                multiarch_path_component = fp.readline().strip()
++                fp.close()
++                add_dir_to_list(self.compiler.library_dirs,
++                                '/usr/lib/' + multiarch_path_component)
++                add_dir_to_list(self.compiler.include_dirs,
++                                '/usr/include/' + multiarch_path_component)
++        finally:
++            os.unlink(tmpfile)
++
+     def detect_modules(self):
+         # Ensure that /usr/local is always used
+         if '/usr/local/lib' not in self.compiler.library_dirs:
+             self.compiler.library_dirs.insert(0, '/usr/local/lib')
+         if '/usr/local/include' not in self.compiler.include_dirs:
+             self.compiler.include_dirs.insert(0, '/usr/local/include' )
++        self.add_multiarch_paths()
+ 
+         try:
+             have_unicode = unicode

--- a/plugins/python-build/share/python-build/patches/2.3.7/Python-2.3.7/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/2.3.7/Python-2.3.7/000_patch-setup.py.diff
@@ -1,0 +1,45 @@
+--- setup.py.orig	2005-01-17 13:07:52.000000000 -0800
++++ setup.py	2014-06-22 02:03:46.888499800 -0700
+@@ -13,6 +13,7 @@
+ from distutils.command.build_ext import build_ext
+ from distutils.command.install import install
+ from distutils.command.install_lib import install_lib
++from distutils.spawn import find_executable
+ 
+ # This global variable is used to hold the list of modules to be disabled.
+ disabled_module_list = []
+@@ -239,10 +240,34 @@
+                 return platform
+         return sys.platform
+ 
++    def add_multiarch_paths(self):
++        # Debian/Ubuntu multiarch support.
++        # https://wiki.ubuntu.com/MultiarchSpec
++        if not find_executable('dpkg-architecture'):
++            return
++        tmpfile = os.path.join(self.build_temp, 'multiarch')
++        if not os.path.exists(self.build_temp):
++            os.makedirs(self.build_temp)
++        ret = os.system(
++            'dpkg-architecture -qDEB_HOST_MULTIARCH > %s 2> /dev/null' %
++            tmpfile)
++        try:
++            if ret >> 8 == 0:
++                fp = open(tmpfile)
++                multiarch_path_component = fp.readline().strip()
++                fp.close()
++                add_dir_to_list(self.compiler.library_dirs,
++                                '/usr/lib/' + multiarch_path_component)
++                add_dir_to_list(self.compiler.include_dirs,
++                                '/usr/include/' + multiarch_path_component)
++        finally:
++            os.unlink(tmpfile)
++
+     def detect_modules(self):
+         # Ensure that /usr/local is always used
+         add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+         add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
++        self.add_multiarch_paths()
+ 
+         # fink installs lots of goodies in /sw/... - make sure we
+         # check there

--- a/plugins/python-build/share/python-build/patches/2.3.7/Python-2.3.7/001_fortify_crash_workaround.diff
+++ b/plugins/python-build/share/python-build/patches/2.3.7/Python-2.3.7/001_fortify_crash_workaround.diff
@@ -1,0 +1,51 @@
+Author: Dwayne Litzenberger <dlitz@dlitz.net>
+Date:   Sun Jun 22 01:15:05 2014 -0700
+
+    Patch configure to handle Ubuntu Bug#286334
+    
+    Fixes this crash:
+    
+        *** buffer overflow detected ***: ./python terminated
+        ======= Backtrace: =========
+        /lib/x86_64-linux-gnu/libc.so.6(__fortify_fail+0x37)[0x2b08765c9007]
+
+diff --git configure configure
+index 4838393..654de3f 100755
+--- configure
++++ configure
+@@ -20798,6 +20798,15 @@ done
+ echo "$as_me:$LINENO: result: done" >&5
+ echo "${ECHO_T}done" >&6
+ 
++case $ac_sys_system in
++Linux*)
++# Workaround for bug in Ubuntu 10.10 amd64 gcc-4.4
++# See http://orip.org/2008/10/building-python-235-on-ubuntu-intrepid.html
++# and Ubuntu Bug #286334
++BASECFLAGS="$BASECFLAGS -U_FORTIFY_SOURCE"
++;;
++esac
++
+ # generate output files
+                     ac_config_files="$ac_config_files Makefile.pre Modules/Setup.config"
+ 
+diff --git configure.in configure.in
+index ba7a011..060a73f 100644
+--- configure.in
++++ configure.in
+@@ -3072,6 +3072,15 @@ for dir in $SRCDIRS; do
+ done
+ AC_MSG_RESULT(done)
+ 
++case $ac_sys_system in
++Linux*)
++# Workaround for bug in Ubuntu 10.10 amd64 gcc-4.4
++# See http://orip.org/2008/10/building-python-235-on-ubuntu-intrepid.html
++# and Ubuntu Bug #286334
++BASECFLAGS="$BASECFLAGS -U_FORTIFY_SOURCE"
++;;
++esac
++
+ # generate output files
+ AC_CONFIG_FILES(Makefile.pre Modules/Setup.config)
+ AC_OUTPUT


### PR DESCRIPTION
This provides just enough to support PyCrypto's test suite, which goes all the way back to Python 2.1.
