### PR TITLE
Fix zsh completion with multiple words

### DIFF
--- a/completions/pyenv.zsh
+++ b/completions/pyenv.zsh
@@ -11,7 +11,7 @@ _pyenv() {
   if [ "${#words}" -eq 2 ]; then
     completions="$(pyenv commands)"
   else
-    completions="$(pyenv completions "${words[2,-2]}")"
+    completions="$(pyenv completions ${words[2,-2]})"
   fi
 
   reply=("${(ps:\n:)completions}")


### PR DESCRIPTION
`${words[2,-2]}` must not be quoted, otherwise completion for multiple
words (e.g. `shell 3.4.1`) fails.
