### PR TITLE
pyenv-version-file-write: do not use rm, but clobber the file

### DIFF
--- a/libexec/pyenv-version-file-write
+++ b/libexec/pyenv-version-file-write
@@ -17,7 +17,8 @@ fi
 pyenv-prefix "${versions[@]}" >/dev/null
 
 # Write the version out to disk.
-rm -f "$PYENV_VERSION_FILE"
+# Create an empty file. Using "rm" might cause a permission error.
+> "$PYENV_VERSION_FILE"
 for version in "${versions[@]}"; do
   echo "$version" >> "$PYENV_VERSION_FILE"
 done


### PR DESCRIPTION
With e.g. /usr/local/bin/.python-version owned by some user, `pyenv
local foo` would fail, if the user has no permissions for
`/usr/local/bin`, but only the `.python-version` file.
