### PR TITLE
Do not quote completions in $reply

### DIFF
--- a/completions/pyenv.zsh
+++ b/completions/pyenv.zsh
@@ -14,5 +14,5 @@ _pyenv() {
     completions="$(pyenv completions ${words[2,-2]})"
   fi
 
-  reply=("${(ps:\n:)completions}")
+  reply=(${(ps:\n:)completions})
 }


### PR DESCRIPTION
With an empty list of completions, zsh would complete a space / advance
the cursor by a space when completing.
