### PR TITLE
add patches to stop '/Library/Python/X.X/site-packages' from being added to sys.path

### DIFF
--- a/plugins/python-build/share/python-build/patches/2.7.2/Python-2.7.2/003_system_library_path_in_sys_path.patch
+++ b/plugins/python-build/share/python-build/patches/2.7.2/Python-2.7.2/003_system_library_path_in_sys_path.patch
@@ -1,0 +1,13 @@
+Only in .: 003_system_library_path_in_sys_path.patch
+diff -ur ../Python-2.7.2/Lib/site.py ./Lib/site.py
+--- ../Python-2.7.2/Lib/site.py	2014-12-12 10:59:47.000000000 +0200
++++ ./Lib/site.py	2014-12-12 11:24:28.000000000 +0200
+@@ -312,7 +312,7 @@
+             # locations.
+             from sysconfig import get_config_var
+             framework = get_config_var("PYTHONFRAMEWORK")
+-            if framework and "/%s.framework/"%(framework,) in prefix:
++            if False and framework and "/%s.framework/"%(framework,) in prefix:
+                 sitepackages.append(
+                         os.path.join("/Library", framework,
+                             sys.version[:3], "site-packages"))

--- a/plugins/python-build/share/python-build/patches/2.7.3/Python-2.7.3/003_system_library_path_in_sys_path.patch
+++ b/plugins/python-build/share/python-build/patches/2.7.3/Python-2.7.3/003_system_library_path_in_sys_path.patch
@@ -1,0 +1,13 @@
+Only in .: 003_system_library_path_in_sys_path.patch
+diff -ur ../Python-2.7.3/Lib/site.py ./Lib/site.py
+--- ../Python-2.7.3/Lib/site.py	2012-04-10 02:07:31.000000000 +0300
++++ ./Lib/site.py	2014-12-12 11:35:33.000000000 +0200
+@@ -312,7 +312,7 @@
+             # locations.
+             from sysconfig import get_config_var
+             framework = get_config_var("PYTHONFRAMEWORK")
+-            if framework:
++            if False and framework:
+                 sitepackages.append(
+                         os.path.join("/Library", framework,
+                             sys.version[:3], "site-packages"))

--- a/plugins/python-build/share/python-build/patches/2.7.4/Python-2.7.4/003_system_library_path_in_sys_path.patch
+++ b/plugins/python-build/share/python-build/patches/2.7.4/Python-2.7.4/003_system_library_path_in_sys_path.patch
@@ -1,0 +1,13 @@
+Only in .: 003_system_library_path_in_sys_path.patch
+diff -ur ../Python-2.7.3/Lib/site.py ./Lib/site.py
+--- ../Python-2.7.3/Lib/site.py	2012-04-10 02:07:31.000000000 +0300
++++ ./Lib/site.py	2014-12-12 11:35:33.000000000 +0200
+@@ -312,7 +312,7 @@
+             # locations.
+             from sysconfig import get_config_var
+             framework = get_config_var("PYTHONFRAMEWORK")
+-            if framework:
++            if False and framework:
+                 sitepackages.append(
+                         os.path.join("/Library", framework,
+                             sys.version[:3], "site-packages"))

--- a/plugins/python-build/share/python-build/patches/2.7.5/Python-2.7.5/003_system_library_path_in_sys_path.patch
+++ b/plugins/python-build/share/python-build/patches/2.7.5/Python-2.7.5/003_system_library_path_in_sys_path.patch
@@ -1,0 +1,13 @@
+Only in .: 003_system_library_path_in_sys_path.patch
+diff -ur ../Python-2.7.5/Lib/site.py ./Lib/site.py
+--- ../Python-2.7.5/Lib/site.py	2013-05-12 06:32:44.000000000 +0300
++++ ./Lib/site.py	2014-12-12 11:29:29.000000000 +0200
+@@ -300,7 +300,7 @@
+             # locations.
+             from sysconfig import get_config_var
+             framework = get_config_var("PYTHONFRAMEWORK")
+-            if framework:
++            if False and framework:
+                 sitepackages.append(
+                         os.path.join("/Library", framework,
+                             sys.version[:3], "site-packages"))

--- a/plugins/python-build/share/python-build/patches/2.7.6/Python-2.7.6/003_system_library_path_in_sys_path.patch
+++ b/plugins/python-build/share/python-build/patches/2.7.6/Python-2.7.6/003_system_library_path_in_sys_path.patch
@@ -1,0 +1,13 @@
+Only in .: 003_system_library_path_in_sys_path.patch
+diff -ur ../Python-2.7.5/Lib/site.py ./Lib/site.py
+--- ../Python-2.7.5/Lib/site.py	2013-05-12 06:32:44.000000000 +0300
++++ ./Lib/site.py	2014-12-12 11:29:29.000000000 +0200
+@@ -300,7 +300,7 @@
+             # locations.
+             from sysconfig import get_config_var
+             framework = get_config_var("PYTHONFRAMEWORK")
+-            if framework:
++            if False and framework:
+                 sitepackages.append(
+                         os.path.join("/Library", framework,
+                             sys.version[:3], "site-packages"))

--- a/plugins/python-build/share/python-build/patches/2.7.7/Python-2.7.7/003_system_library_path_in_sys_path.patch
+++ b/plugins/python-build/share/python-build/patches/2.7.7/Python-2.7.7/003_system_library_path_in_sys_path.patch
@@ -1,0 +1,13 @@
+Only in .: 003_system_library_path_in_sys_path.patch
+diff -ur ../Python-2.7.5/Lib/site.py ./Lib/site.py
+--- ../Python-2.7.5/Lib/site.py	2013-05-12 06:32:44.000000000 +0300
++++ ./Lib/site.py	2014-12-12 11:29:29.000000000 +0200
+@@ -300,7 +300,7 @@
+             # locations.
+             from sysconfig import get_config_var
+             framework = get_config_var("PYTHONFRAMEWORK")
+-            if framework:
++            if False and framework:
+                 sitepackages.append(
+                         os.path.join("/Library", framework,
+                             sys.version[:3], "site-packages"))

--- a/plugins/python-build/share/python-build/patches/2.7.8/Python-2.7.8/003_system_library_path_in_sys_path.patch
+++ b/plugins/python-build/share/python-build/patches/2.7.8/Python-2.7.8/003_system_library_path_in_sys_path.patch
@@ -1,0 +1,13 @@
+Only in .: 003_system_library_path_in_sys_path.patch
+diff -ur ../Python-2.7.8/Lib/site.py ./Lib/site.py
+--- ../Python-2.7.8/Lib/site.py	2014-06-30 05:05:30.000000000 +0300
++++ ./Lib/site.py	2014-12-12 11:42:33.000000000 +0200
+@@ -300,7 +300,7 @@
+             # locations.
+             from sysconfig import get_config_var
+             framework = get_config_var("PYTHONFRAMEWORK")
+-            if framework:
++            if False and framework:
+                 sitepackages.append(
+                         os.path.join("/Library", framework,
+                             sys.version[:3], "site-packages"))


### PR DESCRIPTION
See issue #282.

This allows pip to install and function correctly in pyenv python instances.
