### PR TITLE
Add the environment variable PYENV_NOREHASH to disable automatic rehashing

### DIFF
--- a/pyenv.d/exec/pip-rehash/pip
+++ b/pyenv.d/exec/pip-rehash/pip
@@ -19,8 +19,9 @@ export PATH="${PYENV_BIN_PATH}:${PATH}"
 STATUS=0
 "$PYENV_COMMAND_PATH" "$@" || STATUS="$?"
 
-# Run `pyenv-rehash` after a successful installation.
-if [ "$STATUS" == "0" ]; then
+# Run `pyenv-rehash` after a successful installation,
+# unless rehash is explicitly disabled.
+if [ "$STATUS" == "0" -a -z "$PYENV_NOREHASH" ]; then
   case "$1" in
   "install" | "uninstall" ) pyenv-rehash;;
   esac


### PR DESCRIPTION
There are times when we do not want this to happen, such as when we are using 'fpm' to package python modules.

In my case, I am using "pyenv" alongside "rbenv" (and "plenv" and "renv"). In my ruby environment, I'm using "fpm" (https://github.com/jordansissel/fpm). Let's say I have python 2.7.9 in pyenv, and I want to package "pyramid" into a .deb.

```
fpm --debug -f 
    --python-pypi https://pypi.python.org/simple \
    --python-install-lib /opt/pyenv/.pyenv/versions/2.7.9/lib/python2.7/site-packages \
    --python-bin /opt/pyenv/.pyenv/shims/python \
    --python-pip /opt/pyenv/.pyenv/shims/pip -s python -t deb pyramid
```

This will fail because I'm not root and it will fail the auto rehash. With this patch, I can now do this:

```
PYENV_NOREHASH=1 fpm --debug -f 
    --python-pypi https://pypi.python.org/simple \
    --python-install-lib /opt/pyenv/.pyenv/versions/2.7.9/lib/python2.7/site-packages \
    --python-bin /opt/pyenv/.pyenv/shims/python \
    --python-pip /opt/pyenv/.pyenv/shims/pip -s python -t deb pyramid
```
