### PR TITLE
Don't attempt to read .python-version directories.

### DIFF
--- a/libexec/pyenv-version-file
+++ b/libexec/pyenv-version-file
@@ -9,7 +9,7 @@ target_dir="$1"
 find_local_version_file() {
   local root="$1"
   while ! [[ "$root" =~ ^//[^/]*$ ]]; do
-    if [ -e "${root}/.python-version" ]; then
+    if [ -f "${root}/.python-version" ]; then
       echo "${root}/.python-version"
       return 0
     fi


### PR DESCRIPTION
My $HOME is located on a share: /company/username. Someone created /company/.python-version directory there and I was getting an error on each pyenv activation:
cut: /company/.python-version: No such file or directory.

That happened because pyenv-version-file wasn't distinguishing regular files and directories, it printed existing matching path and fed it to libexec/pyenv-version-file-read which spilled the error.
