### PR TITLE
Hide error message when walking abs_dirname paths

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -40,7 +40,7 @@ else
     local path="$1"
 
     while [ -n "$path" ]; do
-      cd "${path%/*}"
+      cd "${path%/*}" 2>/dev/null
       local name="${path##*/}"
       path="$(resolve_link "$name" || true)"
     done


### PR DESCRIPTION
I've just started using pyenv, and I've noticed an annoying error message every time I use ansible:

```
/home/mcclurmc/.pyenv/libexec/pyenv: line 43: cd: ansible: Not a directory
```

I run ansible from source, so the python program `ansible-playbook` is somewhere "nonstandard" on my path. I've added `set -x` to my pyenv and here are the relevant verbose lines:

```
+ unset CDPATH
+ '[' exec = --debug ']'
+ '[' -n '' ']'
+ enable -f /home/mcclurmc/.pyenv/libexec/../libexec/pyenv-realpath.dylib realpath
+ '[' -z '' ']'
++ type -p greadlink readlink
++ head -1
+ READLINK=/bin/readlink
+ '[' -n /bin/readlink ']'
+ '[' -z /home/mcclurmc/.pyenv ']'
+ PYENV_ROOT=/home/mcclurmc/.pyenv
+ export PYENV_ROOT
+ '[' -z '' ']'
+ '[' -n /home/mcclurmc/Work/external/ansible/bin/ansible-playbook ']'
+ '[' -L /home/mcclurmc/Work/external/ansible/bin/ansible-playbook ']'
++ abs_dirname /home/mcclurmc/Work/external/ansible/bin/ansible-playbook
++ local cwd=/home/mcclurmc/Work/code/infra/ansible
++ local path=/home/mcclurmc/Work/external/ansible/bin/ansible-playbook
++ '[' -n /home/mcclurmc/Work/external/ansible/bin/ansible-playbook ']'
++ cd /home/mcclurmc/Work/external/ansible/bin
++ local name=ansible-playbook
+++ resolve_link ansible-playbook
+++ /bin/readlink ansible-playbook
++ path=ansible
++ '[' -n ansible ']'
++ cd ansible
/home/mcclurmc/.pyenv/libexec/pyenv: line 43: cd: ansible: Not a directory
```

I think that all we need to do is pipe the output of the `cd $path` statement to `/dev/null`, so that's what I've done. Please let me know if there are any bash conventions I should follow, or if there are any tests I should write/modify.