### PR TITLE
Add PyPy2 5.7.0-src

### DIFF
--- a/plugins/python-build/share/python-build/pypy-5.7.0-src
+++ b/plugins/python-build/share/python-build/pypy-5.7.0-src
@@ -1,0 +1,1 @@
+source "${BASH_SOURCE%/*}/pypy2-5.7.0-src"

--- a/plugins/python-build/share/python-build/pypy2-5.7.0-src
+++ b/plugins/python-build/share/python-build/pypy2-5.7.0-src
@@ -1,0 +1,2 @@
+require_gcc
+install_package "pypy2-v5.7.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-src.tar.bz2#e522ea7ca51b16ee5505f22b86803664b762a263a6d69ba84c359fcf8365ad3e" "pypy_builder" verify_py27 ensurepip


### PR DESCRIPTION
Tested on Ubuntu 16.04 up to the point where it starts translating.