### PR TITLE
Added pypy3.5-5.7-beta-src

### DIFF
--- a/plugins/python-build/share/python-build/pypy3.5-5.7-beta-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.7-beta-src
@@ -1,0 +1,2 @@
+require_gcc
+install_package "pypy3-v5.7.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.7.0-src.tar.bz2#f0f563b74f8b82ec33b022393219b93cc0d81e9f9500614fe8417b67a52e9569" "pypy_builder" verify_py35 ensurepip


### PR DESCRIPTION
Tested on Ubuntu 16.04 up to the point where it starts translating. Not sure about the naming convention though (IMHO it's getting complicated).