### PR TITLE
Added pypy-portable-5.7.0

### DIFF
--- a/plugins/python-build/share/python-build/pypy-portable-5.7.0
+++ b/plugins/python-build/share/python-build/pypy-portable-5.7.0
@@ -1,0 +1,13 @@
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux64" )
+  install_package "pypy-5.7-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.7-linux_x86_64-portable.tar.bz2#209d2224fe461d85afb201a0c8da18df21219687defadd4550b60420a120bacb" "pypy" verify_py27 ensurepip
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": Portable PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Tested on Ubuntu 16.04 64-bit. Note that there's no longer a 32-bit build available.