### PR TITLE
Added pypy3-portable-5.7.0

### DIFF
--- a/plugins/python-build/share/python-build/pypy3-portable-5.7.0
+++ b/plugins/python-build/share/python-build/pypy3-portable-5.7.0
@@ -1,0 +1,13 @@
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux64" )
+  install_package "pypy3.5-5.7-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.7-beta-linux_x86_64-portable.tar.bz2#d289ff7c32fd4263c3889994c8191c626891513e8ab60a65ba41a58b331db92c" "pypy" verify_py35 ensurepip
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": Portable PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Tested on Ubuntu 16.04 64-bit. No 32-bit build as well.