### PR TITLE
python-build: Fix typo in MacOS packages for anaconda2-4.3.0/4.2.0

### DIFF
--- a/plugins/python-build/share/python-build/anaconda2-4.2.0
+++ b/plugins/python-build/share/python-build/anaconda2-4.2.0
@@ -6,7 +6,7 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
   install_script "Anaconda2-4.2.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda2-4.2.0-Linux-x86_64.sh#beee286d24fb37dd6555281bba39b3deb5804baec509a9dc5c69185098cf661a" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda2-4.2.1-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda2-4.2.0-MacOSX-x86_64.sh#a8b3ef86233635d9dcc3499dc384980762a0b42d354a318f8307029c399db452" "anaconda" verify_py27
+  install_script "Anaconda2-4.2.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda2-4.2.0-MacOSX-x86_64.sh#a8b3ef86233635d9dcc3499dc384980762a0b42d354a318f8307029c399db452" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda2-4.3.0
+++ b/plugins/python-build/share/python-build/anaconda2-4.3.0
@@ -6,7 +6,7 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
   install_script "Anaconda2-4.3.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda2-4.3.0-Linux-x86_64.sh#7c52e6e99aabb24a49880130615a48e685da444c3c14eb48d6a65f3313bf745c" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda2-4.2.1-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda2-4.3.0-MacOSX-x86_64.sh#834ac0287062929ab5930661735ee617fd379bdfe79f3e0a20aebd614835b6c5" "anaconda" verify_py27
+  install_script "Anaconda2-4.3.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda2-4.3.0-MacOSX-x86_64.sh#834ac0287062929ab5930661735ee617fd379bdfe79f3e0a20aebd614835b6c5" "anaconda" verify_py27
   ;;
 * )
   { echo


### PR DESCRIPTION
The package names in the python-build files for anaconda2-4.2.0 and
anaconda2-4.3.0 both had 'Anaconda2-4.2.1-MacOSX-x86_64' erroneously
listed as the package name. Anaconda2-4.2.1 is not a version of Anaconda
in existence. The URL arguments were correct, just not the package name
arguments.