### PR TITLE
Remove prototype shim if rehash is interrupted

### DIFF
--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -27,8 +27,9 @@ set -o noclobber
 set +o noclobber
 
 # If we were able to obtain a lock, register a trap to clean up the
-# prototype shim when the process exits.
-trap remove_prototype_shim EXIT
+# prototype shim when the process is interrupted, terminated, 
+# has an error or exits.
+trap remove_prototype_shim SIGINT SIGTERM ERR EXIT
 
 remove_prototype_shim() {
   rm -f "$PROTOTYPE_SHIM_PATH"


### PR DESCRIPTION
We use pyenv in our CI and the CI system can kill a job at any point in time (force push, new commit). I think we had a situation where the job was killed while pyenv was rehashing and the file was not removed. 

All subsequent builds failed with `pyenv: cannot rehash: [...].pyenv/shims/.pyenv-shim exists`