### PR TITLE
Workaround for CI failures with versions with multiple digits

### DIFF
--- a/test/--version.bats
+++ b/test/--version.bats
@@ -19,7 +19,7 @@ git_commit() {
   assert [ ! -e "$PYENV_ROOT" ]
   run pyenv---version
   assert_success
-  [[ $output == "pyenv "?.?.? ]]
+  [[ $output == "pyenv "?.?.* ]]
 }
 
 @test "doesn't read version from non-pyenv repo" {
@@ -30,7 +30,7 @@ git_commit() {
 
   run pyenv---version
   assert_success
-  [[ $output == "pyenv "?.?.? ]]
+  [[ $output == "pyenv "?.?.* ]]
 }
 
 @test "reads version from git repo" {
@@ -51,5 +51,5 @@ git_commit() {
   git_commit
 
   run pyenv---version
-  [[ $output == "pyenv "?.?.? ]]
+  [[ $output == "pyenv "?.?.* ]]
 }


### PR DESCRIPTION
I realized that there was CI failure after tagging a new version 😞 

https://travis-ci.org/pyenv/pyenv/jobs/215777826