### PR TITLE
Fixes pip-rehash to rehash if pip was called with a flag

### DIFF
--- a/pyenv.d/exec/pip-rehash/pip
+++ b/pyenv.d/exec/pip-rehash/pip
@@ -21,9 +21,15 @@ STATUS=0
 
 # Run `pyenv-rehash` after a successful installation.
 if [ "$STATUS" == "0" ]; then
-  case "$1" in
-  "install" | "uninstall" ) pyenv-rehash;;
-  esac
+  for piparg in "$@"; do
+    case ${piparg} in
+    "install" | "uninstall" ) REHASH=0;;
+    esac
+  done
+fi
+
+if [ "$REHASH" == "0" ]; then
+ pyenv-rehash
 fi
 
 exit "$STATUS"

--- a/pyenv.d/exec/pip-rehash/pip
+++ b/pyenv.d/exec/pip-rehash/pip
@@ -23,13 +23,9 @@ STATUS=0
 if [ "$STATUS" == "0" ]; then
   for piparg in "$@"; do
     case ${piparg} in
-    "install" | "uninstall" ) REHASH=0;;
+    "install" | "uninstall" ) pyenv-rehash ; break;;
     esac
   done
 fi
 
-if [ "$REHASH" == "0" ]; then
- pyenv-rehash
-fi
-
-exit "$STATUS"
+exit "$STATUS";

--- a/pyenv.d/exec/pip-rehash/pip
+++ b/pyenv.d/exec/pip-rehash/pip
@@ -28,4 +28,4 @@ if [ "$STATUS" == "0" ]; then
   done
 fi
 
-exit "$STATUS";
+exit "$STATUS"


### PR DESCRIPTION
`pip -v install foobar` or `pip -q install foobar` did not trigger a rehash before. Now it should have the same behaviour as `pip install foobar`.