### PR TITLE
Add micropython-dev

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -938,6 +938,20 @@ build_package_ironpython_builder() {
   ( cd "Stage/Release/IronPython-"* && build_package_ironpython )
 }
 
+build_package_micropython() {
+  if [ "${MAKEOPTS+defined}" ]; then
+    MAKE_OPTS="$MAKEOPTS"
+  elif [ -z "${MAKE_OPTS+defined}" ]; then
+    MAKE_OPTS="-j $(num_cpu_cores)"
+  fi
+  { cd unix
+    "$MAKE" $MAKE_OPTS axtls
+    "$MAKE" $MAKE_OPTS
+    "$MAKE" install $MAKE_INSTALL_OPTS PREFIX="${PREFIX_PATH}"
+    ( cd "${PREFIX_PATH}/bin" && ln -fs micropython python )
+  }>&4 2>&1
+}
+
 pypy_architecture() {
   case "$(uname -s)" in
   "Darwin" ) echo "osx64" ;;

--- a/plugins/python-build/share/python-build/micropython-dev
+++ b/plugins/python-build/share/python-build/micropython-dev
@@ -1,0 +1,2 @@
+#require_gcc
+install_git micropython-dev https://github.com/micropython/micropython master micropython


### PR DESCRIPTION
Not sure if this is quite complete yet as of pyenv standards. Works for me on Fedora 25, if I install the libffi-devel package before trying to install.