### PR TITLE
micropython-dev: Set better sys.path

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -946,9 +946,10 @@ build_package_micropython() {
   fi
   { cd unix
     "$MAKE" $MAKE_OPTS axtls
-    "$MAKE" $MAKE_OPTS
+    "$MAKE" $MAKE_OPTS CFLAGS_EXTRA="-DMICROPY_PY_SYS_PATH_DEFAULT='\"${PREFIX_PATH}/lib/micropython\"'"
     "$MAKE" install $MAKE_INSTALL_OPTS PREFIX="${PREFIX_PATH}"
-    ( cd "${PREFIX_PATH}/bin" && ln -fs micropython python )
+    ln -fs micropython "${PREFIX_PATH}/bin/python"
+    mkdir -p "${PREFIX_PATH}/lib/micropython"
   }>&4 2>&1
 }
 


### PR DESCRIPTION
The default was `~/.micropython:/usr/lib/micropython`