### PR TITLE
Fix pyenv-init command in fish shell

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -86,8 +86,8 @@ mkdir -p "${PYENV_ROOT}/"{shims,versions}
 
 case "$shell" in
 fish )
-  echo "setenv PATH '${PYENV_ROOT}/shims' \$PATH"
-  echo "setenv PYENV_SHELL $shell"
+  echo "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
+  echo "set -gx PYENV_SHELL $shell"
 ;;
 * )
   echo 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'

--- a/test/init.bats
+++ b/test/init.bats
@@ -73,7 +73,7 @@ OUT
   export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
   run pyenv-init - fish
   assert_success
-  assert_line 0 "setenv PATH '${PYENV_ROOT}/shims' \$PATH"
+  assert_line 0 "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
 }
 
 @test "can add shims to PATH more than once" {
@@ -87,7 +87,7 @@ OUT
   export PATH="${PYENV_ROOT}/shims:$PATH"
   run pyenv-init - fish
   assert_success
-  assert_line 0 "setenv PATH '${PYENV_ROOT}/shims' \$PATH"
+  assert_line 0 "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
 }
 
 @test "outputs sh-compatible syntax" {


### PR DESCRIPTION
In fish shell version 2.6.0, it show the error ``setenv: Too many arguments`` when executing ``. (pyenv init - | psub)``.
It is because ``setenv`` accepts only two arguments in this version.
```
$ type setenv
# Defined in /usr/share/fish/functions/setenv.fish @ line 1
function setenv --description 'Set an env var for csh compatibility.'
    # No arguments should cause the current env vars to be displayed.
    if not set -q argv[1]
        env
        return
    end

    # A single argument should set the named var to nothing.
    if not set -q argv[2]
        set -gx $argv[1] ''
        return
    end

    # `setenv` accepts only two arguments: the var name and the value. If there are more than two
    # args it is an error. The error message is verbatim from csh.
    if set -q argv[3]
        printf (_ '%s: Too many arguments\n') setenv >&2
        return 1
    end

    # We have exactly two arguments as required by the csh `setenv` command.
    set -l var $argv[1]
    set -l val $argv[2]

    # Validate the variable name.
    if not string match -qr '^\w+$' -- $var
        # This message is verbatim from csh. We don't really need to do this but if we don't fish
        # will display a different error message which might confuse someone expecting the csh
        # message.
        printf (_ '%s: Variable name must contain alphanumeric characters\n') setenv >&2
        return 1
    end

    # We need to special case some vars to be compatible with fish. In particular how they are
    # treated as arrays split on colon characters. All other var values are treated literally.
    if contains -- $var PATH CDPATH MANPATH
        set -gx $var (string split -- ':' $val)
    else
        set -gx $var $val
    end
end
```