### PR TITLE
python-build: add anaconda[23]-4.4.0

### DIFF
--- a/plugins/python-build/share/python-build/anaconda2-4.4.0
+++ b/plugins/python-build/share/python-build/anaconda2-4.4.0
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Anaconda2-4.4.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda2-4.4.0-Linux-x86.sh#452aa91ac83d3b6a68b79cea3042170ec591d468d6966307ff9af18fdbce9fbf" "anaconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda2-4.4.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda2-4.4.0-Linux-x86_64.sh#2d30b91ed4d215b6b4a15162a3389e9057b15445a0c02da71bd7bd272e7b824e" "anaconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda2-4.4.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda2-4.4.0-MacOSX-x86_64.sh#ab95aef1110c2a385fd39a17e5f11dfbaabce25c1a5944598de164d7a2772969" "anaconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda2 is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/anaconda3-4.4.0
+++ b/plugins/python-build/share/python-build/anaconda3-4.4.0
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Anaconda3-4.4.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda3-4.4.0-Linux-x86.sh#b0e492206d43067314b25963bc7d1f012096ca0323b7629f4ebcd071b03905b5" "anaconda" verify_py36
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda3-4.4.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-4.4.0-Linux-x86_64.sh#3301b37e402f3ff3df216fe0458f1e6a4ccbb7e67b4d626eae9651de5ea3ab63" "anaconda" verify_py36
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda3-4.4.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-4.4.0-MacOSX-x86_64.sh#10fe58f09ae524df2548d17b8bb1e75db17da597a6ec10d695ce01387a2d7422" "anaconda" verify_py36
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda3 is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
This PR includes two new files, which allow the user to install both **Anaconda2 4.4.0** and **Anaconda3 4.4.0**.

The test was done only on macOS, but it should also work on Linux; please check if it is buildable on Linux.

SHA-256 checksums are from the following pages:

- https://docs.continuum.io/anaconda/hashes/Anaconda2-4.4.0-Linux-x86.sh-hash
- https://docs.continuum.io/anaconda/hashes/Anaconda2-4.4.0-Linux-x86_64.sh-hash
- https://docs.continuum.io/anaconda/hashes/Anaconda2-4.4.0-MacOSX-x86_64.sh-hash
- https://docs.continuum.io/anaconda/hashes/Anaconda3-4.4.0-Linux-x86.sh-hash
- https://docs.continuum.io/anaconda/hashes/Anaconda3-4.4.0-Linux-x86_64.sh-hash
- https://docs.continuum.io/anaconda/hashes/Anaconda3-4.4.0-MacOSX-x86_64.sh-hash

This should be able to close #923.