### PR TITLE
Update links to Portable Pypy 5.8-1 bugfix release

### DIFF
--- a/plugins/python-build/share/python-build/pypy2.7-5.8.0
+++ b/plugins/python-build/share/python-build/pypy2.7-5.8.0
@@ -20,7 +20,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
     install_package "pypy2-v5.8.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.8.0-linux64.tar.bz2#6274292d0e954a2609b15978cde6efa30942ba20aa5d2acbbf1c70c0a54e9b1e" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.8-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.8-linux_x86_64-portable.tar.bz2#337fd7e947a74cb09253f5ff330fb1be471b1d7a64c2d0340ac387920e71bf3c" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.8-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.8-1-linux_x86_64-portable.tar.bz2#52556230af5769c656173ae8a1bdcb2e16aef46e3993ed89f3aec3d220aec862" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2.7-portable-5.8.0
+++ b/plugins/python-build/share/python-build/pypy2.7-portable-5.8.0
@@ -1,6 +1,6 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
-  install_package "pypy-5.8-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.8-linux_x86_64-portable.tar.bz2#337fd7e947a74cb09253f5ff330fb1be471b1d7a64c2d0340ac387920e71bf3c" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.8-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.8-1-linux_x86_64-portable.tar.bz2#52556230af5769c656173ae8a1bdcb2e16aef46e3993ed89f3aec3d220aec862" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3.5-5.8.0
+++ b/plugins/python-build/share/python-build/pypy3.5-5.8.0
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
     install_package "pypy3-v5.8.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.8.0-linux64.tar.bz2#57d871a7f1135719c138cee4e3533c3275d682a76a40ff668e95150c65923035" "pypy" verify_py35 ensurepip
   else
-    install_package "pypy3.5-5.8-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.8-beta-linux_x86_64-portable.tar.bz2#76c2c4b2846e38d2b4846d4b5f9dc0bd9fd7a9b1f04beb92975ae090ad390d75" "pypy" verify_py35 ensurepip
+    install_package "pypy3.5-5.8-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.8-1-beta-linux_x86_64-portable.tar.bz2#cab20a6d315a1bb05aa953ebc37d8deaa34dcbe298cb5938e373c42c05542b99" "pypy" verify_py35 ensurepip
   fi
   ;;
 * )

--- a/plugins/python-build/share/python-build/pypy3.5-portable-5.8.0
+++ b/plugins/python-build/share/python-build/pypy3.5-portable-5.8.0
@@ -1,6 +1,6 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
-  install_package "pypy3.5-5.8-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.8-beta-linux_x86_64-portable.tar.bz2#76c2c4b2846e38d2b4846d4b5f9dc0bd9fd7a9b1f04beb92975ae090ad390d75" "pypy" verify_py35 ensurepip
+  install_package "pypy3.5-5.8-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.8-1-beta-linux_x86_64-portable.tar.bz2#cab20a6d315a1bb05aa953ebc37d8deaa34dcbe298cb5938e373c42c05542b99" "pypy" verify_py35 ensurepip
   ;;
 * )
   { echo


### PR DESCRIPTION
See https://github.com/squeaky-pl/portable-pypy/issues/54

I chose to keep the same filenames, since this would break the current naming convention for PyPy as

**pypy(CPython-version)-(PyPy-releasedversion)**

per issue #931 
let me know what you think. Then I guess we could make another release.