### PR TITLE
python-build: fix/improve is_mac function

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -101,9 +101,12 @@ os_information() {
   fi
 }
 
+# Is this MacOS?
+# This can be called with arguments for test/[[ optionally, in which case it is
+# tested against the version from osx_version.
 is_mac() {
-  [ "$(uname -s)" = "Darwin" ] || return 1
-  [ $# -eq 0 ] || [ "$(osx_version)" "$@" ]
+  [[ "$(uname -s)" == 'Darwin' ]] || return 1
+  (( $# == 0 )) || eval "[[ '$(osx_version)' $* ]]"
 }
 
 #  9.1  -> 901


### PR DESCRIPTION
shellcheck was not able to parse it before.

There are no tests, but I've checked it using:

    uname_s() {
      echo "Darwin"
    }
    osx_version() {
      echo 1000
    }
    is_mac() {
      [ "$(uname_s)" = "Darwin" ] || return 1
      (( $# == 0 )) || eval "[ '$(osx_version)' $* ]"
    }

    is_mac; echo $?
    is_mac -gt 1000; echo $?
    is_mac -lt 1000; echo $?
    is_mac -gt 999; echo $?