### PR TITLE
Documenting the main thing pyenv does!

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This project was forked from [rbenv](https://github.com/rbenv/rbenv) and
 ## Table of Contents
 
 * **[How It Works](#how-it-works)**
+  * [How to switch python versions](#switch-python-versions)
   * [Understanding PATH](#understanding-path)
   * [Understanding Shims](#understanding-shims)
   * [Choosing the Python Version](#choosing-the-python-version)
@@ -59,6 +60,19 @@ This project was forked from [rbenv](https://github.com/rbenv/rbenv) and
 
 ----
 
+## How to Switch Python Versions
+
+To list available python versions:
+
+    pyenv versions
+
+To set the Python version for the local directory only:
+
+    pyenv local VERSION
+
+To set the Python version for all sessions (overwritten by pyenv local):
+
+    pyenv global VERSION
 
 ## How It Works
 


### PR DESCRIPTION
Trying to figure out how to actually switch is surprisingly difficult.
Consider that [rvm](https://rvm.io/rvm/basics), [nvm](https://github.com/creationix/nvm#usage), [chruby](https://github.com/postmodern/chruby#examples), etc all have a clear, explicit documentation line for switching versions. This repository has a long readme with the way to switch buried in some obscurity. I think it should be surfaced front and center!
