### PR TITLE
Option to disable implicit whence command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ easy to fork and contribute any changes back upstream.
     $ echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
     $ echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
     ```
-    **Zsh note**: Modify your `~/.zshenv` file instead of `~/.bash_profile`.  
-    **Ubuntu and Fedora note**: Modify your `~/.bashrc` file instead of `~/.bash_profile`.  
+    **Zsh note**: Modify your `~/.zshenv` file instead of `~/.bash_profile`.
+    **Ubuntu and Fedora note**: Modify your `~/.bashrc` file instead of `~/.bash_profile`.
     **Proxy note**: If you use a proxy, export `http_proxy` and `HTTPS_PROXY` too.
 
 3. **Add `pyenv init` to your shell** to enable shims and autocompletion.
@@ -205,7 +205,7 @@ easy to fork and contribute any changes back upstream.
     ```sh
     $ echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
     ```
-    **Zsh note**: Modify your `~/.zshenv` file instead of `~/.bash_profile`.  
+    **Zsh note**: Modify your `~/.zshenv` file instead of `~/.bash_profile`.
     **Ubuntu and Fedora note**: Modify your `~/.bashrc` file instead of `~/.bash_profile`.
 
     **General warning**: There are some systems where the `BASH_ENV` variable is configured
@@ -361,7 +361,7 @@ name | default | description
 `PYENV_HOOK_PATH` | [_see wiki_][hooks] | Colon-separated list of paths searched for pyenv hooks.
 `PYENV_DIR` | `$PWD` | Directory to start searching for `.python-version` files.
 `PYTHON_BUILD_ARIA2_OPTS` | | Used to pass additional parameters to [`aria2`](https://aria2.github.io/).<br>if `aria2c` binary is available on PATH, pyenv use `aria2c` instead of `curl` or `wget` to download the Python Source code. If you have an unstable internet connection, you can use this variable to instruct `aria2` to accelerate the download.<br>In most cases, you will only need to use `-x 10 -k 1M` as value to `PYTHON_BUILD_ARIA2_OPTS` environment variable
-
+`PYENV_NO_IMPLICIT_WHENCE` | false | Inscructs `pyenv` not to implicitly execute a `pyenv whence` upon not finding a command.
 
 
 ## Development

--- a/libexec/pyenv-which
+++ b/libexec/pyenv-which
@@ -76,15 +76,17 @@ else
 
   echo "pyenv: $PYENV_COMMAND: command not found" >&2
 
-  if [ -z $PYENV_NO_IMPLICIT_WHENCE ]; then
-    versions="$(pyenv-whence "$PYENV_COMMAND" || true)"
-    if [ -n "$versions" ]; then
-      { echo
-        echo "The \`$1' command exists in these Python versions:"
-        echo "$versions" | sed 's/^/  /g'
-        echo
-      } >&2
-    fi
+  if [ -n $PYENV_NO_IMPLICIT_WHENCE ]; then
+    exit 127
+  fi
+
+  versions="$(pyenv-whence "$PYENV_COMMAND" || true)"
+  if [ -n "$versions" ]; then
+    { echo
+      echo "The \`$1' command exists in these Python versions:"
+      echo "$versions" | sed 's/^/  /g'
+      echo
+    } >&2
   fi
 
   exit 127

--- a/libexec/pyenv-which
+++ b/libexec/pyenv-which
@@ -76,13 +76,15 @@ else
 
   echo "pyenv: $PYENV_COMMAND: command not found" >&2
 
-  versions="$(pyenv-whence "$PYENV_COMMAND" || true)"
-  if [ -n "$versions" ]; then
-    { echo
-      echo "The \`$1' command exists in these Python versions:"
-      echo "$versions" | sed 's/^/  /g'
-      echo
-    } >&2
+  if [ -z $PYENV_NO_IMPLICIT_WHENCE ]; then
+    versions="$(pyenv-whence "$PYENV_COMMAND" || true)"
+    if [ -n "$versions" ]; then
+      { echo
+        echo "The \`$1' command exists in these Python versions:"
+        echo "$versions" | sed 's/^/  /g'
+        echo
+      } >&2
+    fi
   fi
 
   exit 127


### PR DESCRIPTION
Hey,

there is a shell prompt builder that I write I Go which also has a python plugin https://github.com/bullettrain-sh/bullettrain-go-python.

The problem I am facing is that whenever I am testing e.g. `python3 --version`  in a virtualenv or setup that has no python3, the whence command kicks in a search if it can help the user. In many cases it's great and helps a lot.

In my case, it is merely a performance bottleneck and useless in my scenario. Therefore I kindly ask if I can share this little option (which be also beneficial for other shell themes out there) to disable the implicit search.
