### PR TITLE
Added jython-2.7.1

### DIFF
--- a/plugins/python-build/share/python-build/jython-2.7.1
+++ b/plugins/python-build/share/python-build/jython-2.7.1
@@ -1,0 +1,14 @@
+require_java
+unrequire_python27
+install_jar "jython-2.7.1" "https://repo1.maven.org/maven2/org/python/jython-installer/2.7.1/jython-installer-2.7.1.jar#6e58dad0b8565b95c6fb14b4bfbf570523d1c5290244cfb33822789fa53b1d25" jython
+
+case "$(pypy_architecture 2>/dev/null || true)" in
+"osx64"|"win32" )
+  # Jython does not seem to work properly on OSX/windows unless JAVA_HOME is set
+  if [ -z "${JAVA_HOME+defined}" ]; then
+    colorize 1 "WARNING: "
+    echo "Please ensure that your JAVA_HOME environment variable is set correctly!"
+    echo "See http://bugs.jython.org/issue2346 for details."
+  fi
+  ;;
+esac


### PR DESCRIPTION
Fixes  #964.

Tested on Fedora Core 26:

```
$ python
Jython 2.7.1 (default:0df7adb1b397, Jun 30 2017, 19:02:43) 
[OpenJDK 64-Bit Server VM (Oracle Corporation)] on java1.8.0_141
Type "help", "copyright", "credits" or "license" for more information.
>>>
```

