### PR TITLE
Update `pyenv init` line in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ easy to fork and contribute any changes back upstream.
    Please make sure `eval "$(pyenv init -)"` is placed toward the end of the shell
    configuration file since it manipulates `PATH` during the initialization.
     ```sh
-    $ echo '[ -x $PYENV_ROOT/bin/pyenv ] && eval "$(pyenv init -)"' >> ~/.bash_profile
+    $ echo 'eval "$([[ -x $PYENV_ROOT/bin/pyenv ]] && pyenv init -)"' >> ~/.bash_profile
     ```
     **Zsh note**: Modify your `~/.zshenv` file instead of `~/.bash_profile`.  
     **Ubuntu and Fedora note**: Modify your `~/.bashrc` file instead of `~/.bash_profile`.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ easy to fork and contribute any changes back upstream.
    Please make sure `eval "$(pyenv init -)"` is placed toward the end of the shell
    configuration file since it manipulates `PATH` during the initialization.
     ```sh
-    $ echo '[[ -x $PYENV_ROOT/bin/pyenv ]] && eval "$($PYENV_ROOT/bin/pyenv init -)"' >> ~/.bash_profile
+    $ echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
     ```
     **Zsh note**: Modify your `~/.zshenv` file instead of `~/.bash_profile`.  
     **Ubuntu and Fedora note**: Modify your `~/.bashrc` file instead of `~/.bash_profile`.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ easy to fork and contribute any changes back upstream.
    Please make sure `eval "$(pyenv init -)"` is placed toward the end of the shell
    configuration file since it manipulates `PATH` during the initialization.
     ```sh
-    $ echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
+    $ echo '[ -x ~/.pyenv/bin/pyenv ] && eval "$(pyenv init -)"' >> ~/.bash_profile
     ```
     **Zsh note**: Modify your `~/.zshenv` file instead of `~/.bash_profile`.  
     **Ubuntu and Fedora note**: Modify your `~/.bashrc` file instead of `~/.bash_profile`.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ easy to fork and contribute any changes back upstream.
    Please make sure `eval "$(pyenv init -)"` is placed toward the end of the shell
    configuration file since it manipulates `PATH` during the initialization.
     ```sh
-    $ echo 'eval "$([[ -x $PYENV_ROOT/bin/pyenv ]] && pyenv init -)"' >> ~/.bash_profile
+    $ echo '[[ -x $PYENV_ROOT/bin/pyenv ]] && eval "$($PYENV_ROOT/bin/pyenv init -)"' >> ~/.bash_profile
     ```
     **Zsh note**: Modify your `~/.zshenv` file instead of `~/.bash_profile`.  
     **Ubuntu and Fedora note**: Modify your `~/.bashrc` file instead of `~/.bash_profile`.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ easy to fork and contribute any changes back upstream.
    Please make sure `eval "$(pyenv init -)"` is placed toward the end of the shell
    configuration file since it manipulates `PATH` during the initialization.
     ```sh
-    $ echo '[ -x ~/.pyenv/bin/pyenv ] && eval "$(pyenv init -)"' >> ~/.bash_profile
+    $ echo '[ -x $PYENV_ROOT/bin/pyenv ] && eval "$(pyenv init -)"' >> ~/.bash_profile
     ```
     **Zsh note**: Modify your `~/.zshenv` file instead of `~/.bash_profile`.  
     **Ubuntu and Fedora note**: Modify your `~/.bashrc` file instead of `~/.bash_profile`.


### PR DESCRIPTION
I added ```[ -x ~/.pyenv/bin/pyenv ]``` to the front of ```pyenv init```  in case ```pyenv``` is not found.