### PR TITLE
Skip passing `--enable-unicode` for CPython 3.3+ (fixes #912)

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1977,7 +1977,15 @@ fi
 # Compile with `--enable-unicode=ucs4` by default (#257)
 if [[ "$PYTHON_CONFIGURE_OPTS" != *"--enable-unicode="* ]]; then
   if ! is_mac; then
-    package_option python configure --enable-unicode=ucs4
+    # Skip specifying `--enable-unicode` for CPython 3.3+ (#912)
+    case "${DEFINITION_PATH##*/}" in
+    "2."* | \
+    "3.0" | "3.0."* | "3.0-"* | \
+    "3.1" | "3.1."* | "3.1-"* | \
+    "3.2" | "3.2."* | "3.2-"* )
+      package_option python configure --enable-unicode=ucs4
+      ;;
+    esac
   fi
 fi
 

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -61,7 +61,7 @@ assert_build_log() {
 
 @test "yaml is installed for python" {
   cached_tarball "yaml-0.1.6"
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   stub brew false
   stub_make_install
@@ -81,8 +81,8 @@ yaml-0.1.6: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
 yaml-0.1.6: --prefix=$INSTALL_ROOT
 make -j 2
 make install
-Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs4
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -90,7 +90,7 @@ OUT
 
 @test "apply python patch before building" {
   cached_tarball "yaml-0.1.6"
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   stub brew false
   stub_make_install
@@ -113,8 +113,8 @@ yaml-0.1.6: --prefix=$INSTALL_ROOT
 make -j 2
 make install
 patch -p0 --force -i $TMP/python-patch.XXX
-Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs4
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -122,7 +122,7 @@ OUT
 
 @test "apply python patch from git diff before building" {
   cached_tarball "yaml-0.1.6"
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   stub brew false
   stub_make_install
@@ -145,15 +145,15 @@ yaml-0.1.6: --prefix=$INSTALL_ROOT
 make -j 2
 make install
 patch -p1 --force -i $TMP/python-patch.XXX
-Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs4
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
 }
 
 @test "yaml is linked from Homebrew" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   brew_libdir="$TMP/homebrew-yaml"
   mkdir -p "$brew_libdir"
@@ -172,15 +172,15 @@ OUT
   unstub make
 
   assert_build_log <<OUT
-Python-3.2.1: CPPFLAGS="-I$brew_libdir/include -I${TMP}/install/include " LDFLAGS="-L$brew_libdir/lib -L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs4
+Python-3.6.2: CPPFLAGS="-I$brew_libdir/include -I${TMP}/install/include " LDFLAGS="-L$brew_libdir/lib -L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
 }
 
 @test "readline is linked from Homebrew" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   readline_libdir="$TMP/homebrew-readline"
   mkdir -p "$readline_libdir"
@@ -193,7 +193,7 @@ OUT
   stub uname '-s : echo Linux'
 
   run_inline_definition <<DEF
-install_package "Python-3.2.1" "http://python.org/ftp/python/3.2.1/Python-3.2.1.tar.gz"
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
 DEF
   assert_success
 
@@ -201,15 +201,15 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.2.1: CPPFLAGS="-I$readline_libdir/include -I${TMP}/install/include " LDFLAGS="-L$readline_libdir/lib -L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs4
+Python-3.6.2: CPPFLAGS="-I$readline_libdir/include -I${TMP}/install/include " LDFLAGS="-L$readline_libdir/lib -L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
 }
 
 @test "readline is not linked from Homebrew when explicitly defined" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   # python-build
   readline_libdir="$TMP/custom"
@@ -225,7 +225,7 @@ OUT
 
   export PYTHON_CONFIGURE_OPTS="CPPFLAGS=-I$readline_libdir/include LDFLAGS=-L$readline_libdir/lib"
   run_inline_definition <<DEF
-install_package "Python-3.2.1" "http://python.org/ftp/python/3.2.1/Python-3.2.1.tar.gz"
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
 DEF
   assert_success
 
@@ -233,15 +233,15 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT CPPFLAGS=-I$readline_libdir/include LDFLAGS=-L$readline_libdir/lib --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs4
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT CPPFLAGS=-I$readline_libdir/include LDFLAGS=-L$readline_libdir/lib --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
 }
 
 @test "number of CPU cores defaults to 2" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   # yyuu/pyenv#222
   stub uname '-s : echo Darwin'
@@ -257,7 +257,7 @@ OUT
 
   export -n MAKE_OPTS
   run_inline_definition <<DEF
-install_package "Python-3.2.1" "http://python.org/ftp/python/3.2.1/Python-3.2.1.tar.gz"
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
 DEF
   assert_success
 
@@ -265,15 +265,15 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
 }
 
 @test "number of CPU cores is detected on Mac" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   # yyuu/pyenv#222
   stub uname '-s : echo Darwin'
@@ -289,7 +289,7 @@ OUT
 
   export -n MAKE_OPTS
   run_inline_definition <<DEF
-install_package "Python-3.2.1" "http://python.org/ftp/python/3.2.1/Python-3.2.1.tar.gz"
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
 DEF
   assert_success
 
@@ -298,15 +298,15 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 4
 make install
 OUT
 }
 
 @test "number of CPU cores is detected on FreeBSD" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   stub uname '-s : echo FreeBSD'
   stub sysctl '-n hw.ncpu : echo 1'
@@ -320,7 +320,7 @@ OUT
 
   export -n MAKE_OPTS
   run_inline_definition <<DEF
-install_package "Python-3.2.1" "http://python.org/ftp/python/3.2.1/Python-3.2.1.tar.gz"
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
 DEF
   assert_success
 
@@ -329,15 +329,15 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs4
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 1
 make install
 OUT
 }
 
 @test "setting PYTHON_MAKE_INSTALL_OPTS to a multi-word string" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   stub_make_install
 
@@ -347,22 +347,22 @@ OUT
 
   export PYTHON_MAKE_INSTALL_OPTS="DOGE=\"such wow\""
   run_inline_definition <<DEF
-install_package "Python-3.2.1" "http://python.org/ftp/python/3.2.1/Python-3.2.1.tar.gz"
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
 DEF
   assert_success
 
   unstub make
 
   assert_build_log <<OUT
-Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs4
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install DOGE="such wow"
 OUT
 }
 
 @test "setting MAKE_INSTALL_OPTS to a multi-word string" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   stub_make_install
 
@@ -372,15 +372,15 @@ OUT
 
   export MAKE_INSTALL_OPTS="DOGE=\"such wow\""
   run_inline_definition <<DEF
-install_package "Python-3.2.1" "http://python.org/ftp/python/3.2.1/Python-3.2.1.tar.gz"
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
 DEF
   assert_success
 
   unstub make
 
   assert_build_log <<OUT
-Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs4
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install DOGE="such wow"
 OUT
@@ -396,7 +396,7 @@ OUT
 }
 
 @test "make on FreeBSD 9 defaults to gmake" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   stub uname "-s : echo FreeBSD" "-r : echo 9.1"
   MAKE=gmake stub_make_install
@@ -415,7 +415,7 @@ OUT
 }
 
 @test "make on FreeBSD 10" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   stub uname "-s : echo FreeBSD" "-r : echo 10.0-RELEASE"
   stub_make_install
@@ -433,7 +433,7 @@ OUT
 }
 
 @test "can use PYTHON_CONFIGURE to apply a patch" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   executable "${TMP}/custom-configure" <<CONF
 #!$BASH
@@ -450,7 +450,7 @@ CONF
 
   export PYTHON_CONFIGURE="${TMP}/custom-configure"
   run_inline_definition <<DEF
-install_package "Python-3.2.1" "http://python.org/ftp/python/3.2.1/Python-3.2.1.tar.gz"
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
 DEF
   assert_success
 
@@ -459,8 +459,8 @@ DEF
 
   assert_build_log <<OUT
 apply -p1 -i /my/patch.diff
-Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs4
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -545,11 +545,11 @@ OUT
 }
 
 @test "initializes LDFLAGS directories" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   export LDFLAGS="-L ${BATS_TEST_DIRNAME}/what/evs"
   run_inline_definition <<DEF
-install_package "Python-3.2.1" "http://python.org/ftp/python/3.2.1/Python-3.2.1.tar.gz" ldflags_dirs
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz" ldflags_dirs
 DEF
   assert_success
 

--- a/plugins/python-build/test/fixtures/definitions/needs-yaml
+++ b/plugins/python-build/test/fixtures/definitions/needs-yaml
@@ -1,2 +1,2 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" --if needs_yaml
-install_package "Python-3.2.1" "http://python.org/ftp/python/3.2.1/Python-3.2.1.tar.gz"
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"

--- a/plugins/python-build/test/fixtures/definitions/vanilla-python
+++ b/plugins/python-build/test/fixtures/definitions/vanilla-python
@@ -1,1 +1,1 @@
-install_package "Python-3.2.1" "http://python.org/ftp/python/3.2.1/Python-3.2.1.tar.gz"
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"

--- a/plugins/python-build/test/hooks.bats
+++ b/plugins/python-build/test/hooks.bats
@@ -16,13 +16,13 @@ OUT
   stub pyenv-hooks "install : echo '$HOOK_PATH'/install.bash"
   stub pyenv-rehash "echo rehashed"
 
-  definition="${TMP}/3.2.1"
+  definition="${TMP}/3.6.2"
   cat > "$definition" <<<"echo python-build"
   run pyenv-install "$definition"
 
   assert_success
   assert_output <<-OUT
-before: ${PYENV_ROOT}/versions/3.2.1
+before: ${PYENV_ROOT}/versions/3.6.2
 python-build
 after: 0
 rehashed
@@ -41,16 +41,16 @@ OUT
   stub pyenv-hooks "uninstall : echo '$HOOK_PATH'/uninstall.bash"
   stub pyenv-rehash "echo rehashed"
 
-  mkdir -p "${PYENV_ROOT}/versions/3.2.1"
-  run pyenv-uninstall -f 3.2.1
+  mkdir -p "${PYENV_ROOT}/versions/3.6.2"
+  run pyenv-uninstall -f 3.6.2
 
   assert_success
   assert_output <<-OUT
-before: ${PYENV_ROOT}/versions/3.2.1
-rm -rf ${PYENV_ROOT}/versions/3.2.1
+before: ${PYENV_ROOT}/versions/3.6.2
+rm -rf ${PYENV_ROOT}/versions/3.6.2
 rehashed
 after.
 OUT
 
-  refute [ -d "${PYENV_ROOT}/versions/3.2.1" ]
+  refute [ -d "${PYENV_ROOT}/versions/3.6.2" ]
 }

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -93,13 +93,13 @@ resolve_link() {
 }
 
 @test "apply built-in python patch before building" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   stub brew false
   stub_make_install
   stub patch ' : echo patch "$@" | sed -E "s/\.[[:alnum:]]+$/.XXX/" >> build.log'
 
-  echo | install_patch definitions/vanilla-python "Python-3.2.1/empty.patch"
+  echo | install_patch definitions/vanilla-python "Python-3.6.2/empty.patch"
 
   # yyuu/pyenv#257
   stub uname '-s : echo Linux'
@@ -110,8 +110,8 @@ resolve_link() {
 
   assert_build_log <<OUT
 patch -p0 --force -i $TMP/python-patch.XXX
-Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs4
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -121,15 +121,15 @@ OUT
 }
 
 @test "apply built-in python patches should be sorted by its name" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   stub brew false
   stub_make_install
   stub patch ' : for arg; do [[ "$arg" == "-"* ]] || sed -e "s/^/patch: /" "$arg"; done >> build.log'
 
-  echo "foo" | install_patch definitions/vanilla-python "Python-3.2.1/foo.patch"
-  echo "bar" | install_patch definitions/vanilla-python "Python-3.2.1/bar.patch"
-  echo "baz" | install_patch definitions/vanilla-python "Python-3.2.1/baz.patch"
+  echo "foo" | install_patch definitions/vanilla-python "Python-3.6.2/foo.patch"
+  echo "bar" | install_patch definitions/vanilla-python "Python-3.6.2/bar.patch"
+  echo "baz" | install_patch definitions/vanilla-python "Python-3.6.2/baz.patch"
 
   # yyuu/pyenv#257
   stub uname '-s : echo Linux'
@@ -142,8 +142,8 @@ OUT
 patch: bar
 patch: baz
 patch: foo
-Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs4
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -153,7 +153,7 @@ OUT
 }
 
 @test "allow custom make install target" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   stub brew false
   stub "$MAKE" \
@@ -168,8 +168,8 @@ OUT
   assert_success
 
   assert_build_log <<OUT
-Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs4
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 2
 make altinstall
 OUT
@@ -280,7 +280,7 @@ EOS
 }
 
 @test "enable custom unicode configuration" {
-  cached_tarball "Python-3.2.1"
+  cached_tarball "Python-3.6.2"
 
   stub brew false
   stub "$MAKE" \
@@ -291,8 +291,8 @@ EOS
   assert_success
 
   assert_build_log <<OUT
-Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --enable-unicode=ucs2 --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --enable-unicode=ucs2 --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT


### PR DESCRIPTION
Prepared some workaround according to a comment to #912

> Since Python 3.3, no options is needed.
> Thanks to Flexible Unicode Representation, no "wide" and "narrow" build.

