### PR TITLE
prevent changing PATH in pyenv shims

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -86,6 +86,7 @@ bin_path="$(abs_dirname "$0")"
 for plugin_bin in "${PYENV_ROOT}/plugins/"*/bin; do
   PATH="${plugin_bin}:${PATH}"
 done
+export PYENV_ORIGINAL_PATH="$PATH"
 export PATH="${bin_path}:${PATH}"
 
 PYENV_HOOK_PATH="${PYENV_HOOK_PATH}:${PYENV_ROOT}/pyenv.d"

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -44,7 +44,12 @@ shift 1
 
 # reset path to original path
 # https://github.com/pyenv/pyenv/issues/985
-export PATH="$PYENV_ORIGINAL_PATH"
+# if installing package via pip/conda/easy_install, do not reset path as pyenv-which will be needed for auto rehash
+if [[ "$PYENV_COMMAND" != "pip" && "$PYENV_COMMAND" != "conda" && "$PYENV_COMMAND" != "easy_install" ]]; then
+  if [ -z "$PYENV_ORIGINAL_PATH" ]; then
+  	export PATH="$PYENV_ORIGINAL_PATH"
+  fi
+fi
 
 if [ "$PYENV_COMMAND" = "virtualenv" ]; then
   # CPython's `sys.executable` requires the `PYENV_BIN_PATH` to be at the top of the `PATH`.

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -41,7 +41,15 @@ for script in "${scripts[@]}"; do
 done
 
 shift 1
-# CPython's `sys.executable` requires the `PYENV_BIN_PATH` to be at the top of the `PATH`.
-# https://github.com/pyenv/pyenv/issues/98
-export PATH="${PYENV_BIN_PATH}:${PATH}"
+
+# reset path to original path
+# https://github.com/pyenv/pyenv/issues/985
+export PATH="$PYENV_ORIGINAL_PATH"
+
+if [ "$PYENV_COMMAND" = "virtualenv" ]; then
+  # CPython's `sys.executable` requires the `PYENV_BIN_PATH` to be at the top of the `PATH`.
+  # https://github.com/pyenv/pyenv/issues/98
+  export PATH="${PYENV_BIN_PATH}:${PATH}"
+fi
+
 exec -a "$PYENV_COMMAND" "$PYENV_COMMAND_PATH" "$@"


### PR DESCRIPTION
fixes #985. this introduces two changes:

- remove `libexec` from PATH
- remove actual python binary location from PATH

cc @blueyed cc @yyuu for review

also do either of you remember some more details regarding #98? was this specific to virtualenv? I don't see any documentation saying `sys.executable` **needs** to point to the python binary:

https://docs.python.org/3/library/sys.html#sys.executable
>A string giving the absolute path of the executable binary for the Python interpreter, on systems where this makes sense. If Python is unable to retrieve the real path to its executable, sys.executable will be an empty string or None.

reading through some of the virtualenv sourcecode, the issue seemed to be specific to virtualenv

to elaborate, this is the quintessential bug from changing of the path: https://github.com/jezdez/envdir/issues/62 (tl;dr: programs that create subshells end up with a different PATH)