### PR TITLE
python-build: add anaconda[23]-5.0.0

### DIFF
--- a/plugins/python-build/share/python-build/anaconda2-5.0.0
+++ b/plugins/python-build/share/python-build/anaconda2-5.0.0
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Anaconda2-5.0.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda2-5.0.0-Linux-x86.sh#a3ed8769d20d55a41c04cf7c04e81c95974ea8eb614afab7bbc0c06fa6a52437" "anaconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda2-5.0.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda2-5.0.0-Linux-x86_64.sh#58a7117f89c40275114bf7e824a613a963da2b0fe63f2ec3c1175fea785b468e" "anaconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda2-5.0.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda2-5.0.0-MacOSX-x86_64.sh#d85198c63657924fae11b6ea5961f50d81d09a1185d6f0a9a9d5bc69eb788ccc" "anaconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda2 is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/anaconda3-5.0.0
+++ b/plugins/python-build/share/python-build/anaconda3-5.0.0
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Anaconda3-5.0.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda3-5.0.0-Linux-x86.sh#634d2dfa97d19f2cc15e941cb4d059bc83a31facedfb9d02a980c4fa74f2776a" "anaconda" verify_py36
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda3-5.0.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-5.0.0-Linux-x86_64.sh#67f5c20232a3e493ea3f19a8e273e0618ab678fa14b03b59b1783613062143e9" "anaconda" verify_py36
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda3-5.0.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-5.0.0-MacOSX-x86_64.sh#23df1e3a38a6b4aaa0ab559d0c1e51be76eca5d75cb595d473d223c8d17e762d" "anaconda" verify_py36
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda3 is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
This PR consists of a single commit adding two new files, which allow the user to install both **Anaconda2 5.0.0** and **Anaconda3 5.0.0**.

The tests have been done only on macOS, but it should also work on Linux; please check if it is buildable on Linux.

The SHA-256 checksum for each Anaconda shell file is copied from the following pages:

- https://docs.anaconda.com/anaconda/install/hashes/Anaconda2-5.0.0-Linux-x86.sh-hash
- https://docs.anaconda.com/anaconda/install/hashes/Anaconda2-5.0.0-Linux-x86_64.sh-hash
- https://docs.anaconda.com/anaconda/install/hashes/Anaconda2-5.0.0-MacOSX-x86_64.sh-hash
- https://docs.anaconda.com/anaconda/install/hashes/Anaconda3-5.0.0-Linux-x86.sh-hash
- https://docs.anaconda.com/anaconda/install/hashes/Anaconda3-5.0.0-Linux-x86_64.sh-hash
- https://docs.anaconda.com/anaconda/install/hashes/Anaconda3-5.0.0-MacOSX-x86_64.sh-hash