### PR TITLE
Turn off auto-update for conda builds.

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1058,7 +1058,7 @@ build_package_anaconda() {
 
 build_package_miniconda() {
   build_package_anaconda "$@"
-  "${PREFIX_PATH}/bin/conda" install --yes "pip"
+  CONDA_AUTO_UPDATE=False "${PREFIX_PATH}/bin/conda" install --yes "pip"
 }
 
 build_package_copy() {


### PR DESCRIPTION
Unless specified otherwise, conda will auto-update to the latest version, resulting in a conda install that differs from what was requested. This commit makes the necessary change for the user, but I could also imagine that we might want the user to specify this environment variable themselves (or through a .condarc file).