### PR TITLE
Do not create `tput` shim when Anaconda is selected

### DIFF
--- a/pyenv.d/rehash/conda.d/default.list
+++ b/pyenv.d/rehash/conda.d/default.list
@@ -27,6 +27,8 @@ xml2-config
 # libxml2-utils
 xmlcatalog
 xmllint
+# ncurses
+tput
 # openssl
 openssl
 # qtchooser


### PR DESCRIPTION
## 0c1edef: Do not create `tput` shim when Anaconda is selected

Add `tput` to the Anaconda's default blacklist in order to prevent pyenv
from creating the shim script for it.

Anaconda 5.0.0 contains some executables which are part of the base system. Many of these executables did not exist in the last major version of Anaconda (`4.4.0`), and the existence of pyenv's shim scripts for these executables in `5.0.0` can cause to conceal those executables in the user's base system; for the details, please see the discussion with @yyuu at #992.

This commit resolves a coloured output error when running a terminal command which uses `tput`. This error occurs when multiple Python versions are installed alongside `anaconda2-5.0.0` or `anaconda3-5.0.0` and neither of those two Anaconda versions is selected by pyenv.

### Many executables have been added in Anaconda 5.0.0

As described above, apart from `tput`, there have been many executables added in **Anaconda 5.0.0**, many of which did not exist in the last major version **Anaconda 4.4.0**; here is the `diff` output of their executable paths:

```sh
# `>` indicates a new executable addded in Anaconda 5.0.0 
$ diff <(ls ~/.pyenv/versions/anaconda3-4.4.0/bin) <(ls ~/.pyenv/versions/anaconda3-5.0.0/bin)
10a11
> autopoint*
15a17
> captoinfo@
18a21
> clear*
19a23,25
> conda-build*
> conda-convert*
> conda-develop*
20a27,30
> conda-index*
> conda-inspect*
> conda-metapackage*
> conda-render*
21a32,33
> conda-skeleton*
> conda-verify*
22a35
> createfontdatachunk.py*
28a42
> dask-mpi*
33a48,56
> dbus-cleanup-sockets*
> dbus-daemon*
> dbus-launch*
> dbus-monitor*
> dbus-run-session*
> dbus-send*
> dbus-test-tool*
> dbus-update-activation-environment*
> dbus-uuidgen*
41c64
< easy_install-3.6@
---
> easy_install-3.6*
42a66,67
> enhancer.py*
> envsubst*
43a69
> explode.py*
44a71,72
> fax2ps*
> fax2tiff*
53a82,83
> gdbus*
> gdbus-codegen*
58a89,91
> gettext*
> gettext.sh*
> gettextize*
59a93,95
> gifmaker.py*
> gio*
> gio-querymodules*
60a97,106
> glib-compile-resources*
> glib-compile-schemas*
> glib-genmarshal*
> glib-gettextize*
> glib-mkenums*
> gobject-query*
> gresource*
> gsettings*
> gtester*
> gtester-report*
63a110
> h5clear*
67a115,116
> h5fc*
> h5format_convert*
77a127
> h5watch*
83a134,135
> infocmp*
> infotocap@
84a137,138
> iptest*
> iptest3*
96a151,153
> jupyter-lab*
> jupyter-labextension*
> jupyter-labhub*
101a159
> jupyter-run*
115a174,184
> lzcat@
> lzcmp@
> lzdiff@
> lzegrep@
> lzfgrep@
> lzgrep@
> lzless@
> lzma@
> lzmadec*
> lzmainfo*
> lzmore@
119a189,202
> msgattrib*
> msgcat*
> msgcmp*
> msgcomm*
> msgconv*
> msgen*
> msgexec*
> msgfilter*
> msgfmt*
> msggrep*
> msginit*
> msgmerge*
> msgunfmt*
> msguniq*
121a205,206
> ncursesw6-config*
> ngettext*
127a213,219
> painter.py*
> pal2rgb*
> pandoc*
> pandoc-citeproc*
> pcre-config*
> pcregrep*
> pcretest*
128a221,225
> pilconvert.py*
> pildriver.py*
> pilfile.py*
> pilfont.py*
> pilprint.py*
131a229,230
> pkginfo*
> player.py*
133a233
> ppm2tiff*
141a242
> pycodestyle*
160c261
< python3.6m*
---
> python3.6m@
184a286
> raw2tiff*
186a289,290
> recode-sr-latin*
> reset@
188a293
> rst2html4.py*
211a317
> sqlite3_analyzer*
213a320
> tabs*
215,216c322,341
< tclsh8.5*
< uconv*
---
> tclsh@
> tclsh8.6*
> thresholder.py*
> tic*
> tiff2bw*
> tiff2pdf*
> tiff2ps*
> tiff2rgba*
> tiffcmp*
> tiffcp*
> tiffcrop*
> tiffdither*
> tiffdump*
> tiffinfo*
> tiffmedian*
> tiffset*
> tiffsplit*
> toe*
> tput*
> tset*
217a343
> unlzma@
219a346
> viewer.py*
223c350,351
< wish8.5*
---
> wish@
> wish8.6*
224a353
> xgettext*
230a360
> xmlwf*
233a364,372
> xzcat@
> xzcmp@
> xzdec*
> xzdiff*
> xzegrep@
> xzfgrep@
> xzgrep*
> xzless*
> xzmore*
```

I am uncertain, apart from `tput`, how many of the other executables newly shipped with Anaconda 5.0.0 can cause to conceal the executables of the user's base system. Further investigations are needed on them, or as @yyuu suggested in #992, the pyenv users can use the [pyenv-which-ext](https://github.com/pyenv/pyenv-which-ext) to deal with the potential `command not found` errors.

### The location of the newly inserted lines in the `pyenv.d/rehash/conda.d/default.list` file

In the blacklist file, the executables seem to be listed in an alphabetical-ish order, and the existing comment lines also seem to be used to group the related executables together. I labelled `tput` as `ncurses` and locate in the order which I thought is appropriate.

---

Please review my commit and if necessary, rectify as appropriate.

Thank you!

sho