### PR TITLE
Stackless updates

### DIFF
--- a/plugins/python-build/share/python-build/stackless-2.7.14
+++ b/plugins/python-build/share/python-build/stackless-2.7.14
@@ -1,0 +1,4 @@
+#require_gcc
+install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "stackless-2.7.14-slp" "https://github.com/stackless-dev/stackless/archive/v2.7.14-slp.tar.gz#e67f60984d034bfd80fef58d26df9d5a1cdecb429c55ac7bc8d932cff6f88ab8" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.3.7
+++ b/plugins/python-build/share/python-build/stackless-3.3.7
@@ -1,0 +1,4 @@
+#require_gcc
+install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "stackless-3.3.7-slp" "https://github.com/stackless-dev/stackless/archive/v3.3.7-slp.tar.gz#f05b8ff8a0e318aa5880dc995518ab4453894d068a26a171b89e21b98da5a5c1" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.4.7
+++ b/plugins/python-build/share/python-build/stackless-3.4.7
@@ -1,0 +1,4 @@
+#require_gcc
+install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "stackless-3.4.7-slp" "https://github.com/stackless-dev/stackless/archive/v3.4.7-slp.tar.gz#e41959afcfc9381cbc9ac14c12110e3e748e65ceeec4fe61fb1c34cabcb9e6bf" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.5.4
+++ b/plugins/python-build/share/python-build/stackless-3.5.4
@@ -1,0 +1,4 @@
+#require_gcc
+install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "stackless-3.5.4-slp" "https://github.com/stackless-dev/stackless/archive/v3.5.4-slp.tar.gz#ddb65a8118c754f66875f65c4d5d2a4937d67858ec8c361a6c5b386f5e4d9fce" ldflags_dirs standard verify_py35 ensurepip


### PR DESCRIPTION
Tested on Fedora 26. I had to use the workaround posted on https://github.com/pyenv/pyenv/issues/950#issuecomment-334316289

> Uninstall:
$ dnf remove openssl-devel

> Install:
$ dnf install compat-openssl10-devel

to be able to build 3.3.7 and 3.4.7. Stackless 3.5.4 seems to build fine under both OpenSSL 1.0.2 and 1.1, but I haven't done any serious testing besides trying to import _ssl:

```python
$ python
Python 3.5.4 Stackless 3.1b3 060516 (default, Oct 22 2017, 15:25:02) 
[GCC 7.2.1 20170915 (Red Hat 7.2.1-2)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import _ssl
>>> _ssl.OPENSSL_VERSION
'OpenSSL 1.1.0f-fips  25 May 2017'
```