### PR TITLE
python-build: add miniconda[23]-4.3.30

### DIFF
--- a/plugins/python-build/share/python-build/miniconda2-4.3.30
+++ b/plugins/python-build/share/python-build/miniconda2-4.3.30
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda2-4.3.30-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda2-4.3.30-Linux-x86.sh#3727dcc1561be246c052d6be210b5fd748bf32407cb7e06d0322fe4f79c77482" "miniconda" verify_py35
+  install_script "Miniconda2-4.3.30-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda2-4.3.30-Linux-x86.sh#3727dcc1561be246c052d6be210b5fd748bf32407cb7e06d0322fe4f79c77482" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda2-4.3.30-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-4.3.30-Linux-x86_64.sh#0891000ca28359e63aa77e613c01f7a88855dedfc0ddc8be31829f3139318cf3" "miniconda" verify_py35
+  install_script "Miniconda2-4.3.30-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-4.3.30-Linux-x86_64.sh#0891000ca28359e63aa77e613c01f7a88855dedfc0ddc8be31829f3139318cf3" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda2-4.3.30-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-4.3.30-MacOSX-x86_64.sh#1fa6f0ae3b65fc09ba5156c43a3901c4aad0510735c31f58d1be2a71009416f9" "miniconda" verify_py35
+  install_script "Miniconda2-4.3.30.1-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-4.3.30.1-MacOSX-x86_64.sh#1d4eb025ce58e6f0d5e19b39191ca17dee1fe3b2fd7d425a7418d99fe01fd65e" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda2-4.3.30
+++ b/plugins/python-build/share/python-build/miniconda2-4.3.30
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Miniconda2-4.3.30-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda2-4.3.30-Linux-x86.sh#3727dcc1561be246c052d6be210b5fd748bf32407cb7e06d0322fe4f79c77482" "miniconda" verify_py35
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda2-4.3.30-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-4.3.30-Linux-x86_64.sh#0891000ca28359e63aa77e613c01f7a88855dedfc0ddc8be31829f3139318cf3" "miniconda" verify_py35
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda2-4.3.30-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-4.3.30-MacOSX-x86_64.sh#1fa6f0ae3b65fc09ba5156c43a3901c4aad0510735c31f58d1be2a71009416f9" "miniconda" verify_py35
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-4.3.30
+++ b/plugins/python-build/share/python-build/miniconda3-4.3.30
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda3-4.3.30-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-4.3.30-Linux-x86.sh#5d0c59c3d93b56dea90af1be96a9f36aa7f35605d9f821e8b86c1aa31d3b4e4b" "miniconda" verify_py35
+  install_script "Miniconda3-4.3.30-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-4.3.30-Linux-x86.sh#5d0c59c3d93b56dea90af1be96a9f36aa7f35605d9f821e8b86c1aa31d3b4e4b" "miniconda" verify_py36
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-4.3.30-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-4.3.30-Linux-x86_64.sh#66c822dfe76636b4cc2ae5604816e0e723aa01620f50087f06410ecf5bfdf38c" "miniconda" verify_py35
+  install_script "Miniconda3-4.3.30-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-4.3.30-Linux-x86_64.sh#66c822dfe76636b4cc2ae5604816e0e723aa01620f50087f06410ecf5bfdf38c" "miniconda" verify_py36
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-4.3.30-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-4.3.30-MacOSX-x86_64.sh#f8b09aa53b7f66ed62d6dd0fec66fa0aead203d5def28f9f125df93af8dbd78a" "miniconda" verify_py35
+  install_script "Miniconda3-4.3.30.1-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-4.3.30.1-MacOSX-x86_64.sh#43d05d914139e6249498fe24cf97390a16eb95b56fc05b7f39470ff8b176d1af" "miniconda" verify_py36
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-4.3.30
+++ b/plugins/python-build/share/python-build/miniconda3-4.3.30
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Miniconda3-4.3.30-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-4.3.30-Linux-x86.sh#5d0c59c3d93b56dea90af1be96a9f36aa7f35605d9f821e8b86c1aa31d3b4e4b" "miniconda" verify_py35
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-4.3.30-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-4.3.30-Linux-x86_64.sh#66c822dfe76636b4cc2ae5604816e0e723aa01620f50087f06410ecf5bfdf38c" "miniconda" verify_py35
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-4.3.30-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-4.3.30-MacOSX-x86_64.sh#f8b09aa53b7f66ed62d6dd0fec66fa0aead203d5def28f9f125df93af8dbd78a" "miniconda" verify_py35
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
This PR consists of a single commit adding two new files, which allow the user to install both **Miniconda2 4.3.30** and **Miniconda3 4.3.30**.

The tests have been done only on macOS, but it should also work on Linux; please check if it is installable on Linux.

The SHA-256 checksums for [each Miniconda shell file](https://repo.continuum.io/miniconda/) have been checked by the following shell command:

```sh
# checksums for Miniconda2-4.3.30
$ shasum -a 256 Miniconda2-4.3.30-MacOSX-x86_64.sh Miniconda2-4.3.30-Linux-x86_64.sh Miniconda2-4.3.30-Linux-x86.sh
1fa6f0ae3b65fc09ba5156c43a3901c4aad0510735c31f58d1be2a71009416f9  Miniconda2-4.3.30-MacOSX-x86_64.sh
0891000ca28359e63aa77e613c01f7a88855dedfc0ddc8be31829f3139318cf3  Miniconda2-4.3.30-Linux-x86_64.sh
3727dcc1561be246c052d6be210b5fd748bf32407cb7e06d0322fe4f79c77482  Miniconda2-4.3.30-Linux-x86.sh

# checksums for Miniconda3-4.3.30
$ shasum -a 256 Miniconda3-4.3.30-MacOSX-x86_64.sh Miniconda3-4.3.30-Linux-x86_64.sh Miniconda3-4.3.30-Linux-x86.sh
f8b09aa53b7f66ed62d6dd0fec66fa0aead203d5def28f9f125df93af8dbd78a  Miniconda3-4.3.30-MacOSX-x86_64.sh
66c822dfe76636b4cc2ae5604816e0e723aa01620f50087f06410ecf5bfdf38c  Miniconda3-4.3.30-Linux-x86_64.sh
5d0c59c3d93b56dea90af1be96a9f36aa7f35605d9f821e8b86c1aa31d3b4e4b  Miniconda3-4.3.30-Linux-x86.sh
```

---

### Message from the collaborator

Please review my commit and if necessary, rectify as appropriate.

Thank you!

sho