### PR TITLE
Ignore LibreSSL bundled with macOS 10.13

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1385,8 +1385,9 @@ use_homebrew_readline() {
 }
 
 has_broken_mac_openssl() {
-  is_mac &&
-  [[ "$(/usr/bin/openssl version 2>/dev/null || true)" = "OpenSSL 0.9.8"?* ]] &&
+  is_mac || return 1
+  local openssl_version="$(/usr/bin/openssl version 2>/dev/null || true)"
+  [[ $openssl_version = "OpenSSL 0.9.8"?* || $openssl_version = "LibreSSL"* ]] &&
   ! use_homebrew_openssl
 }
 


### PR DESCRIPTION
I've encountered the same error about a missing OpenSSL lib that has affected other users on macOS 10.13 (See #950 and #993). I've also seen the workaround to this problem (See [Common-build-problems](https://github.com/pyenv/pyenv/wiki/Common-build-problems#error-the-python-ssl-extension-was-not-compiled-missing-the-openssl-lib)).

I haven't encountered this issue with `rbenv`, so I went searching and they've handled the issue inside `ruby-build`.

It seems that High Sierra now bundles LibreSSL, and it's this check that is causing `python-build` to not locate the openssl package.

I've added in the same check that `ruby-build` does, and it works on my local machine. I've not done any tests on this as I have no idea where to start.

See rbenv/ruby-build#1095 and rbenv/ruby-build#1104.