### PR TITLE
Fix $PWD changes when executing Python

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -36,9 +36,10 @@ else
   }
 
   abs_dirname() {
-    local cwd="$PWD"
     local path="$1"
 
+    # Use a subshell to avoid changing the current path
+    (
     while [ -n "$path" ]; do
       cd "${path%/*}"
       local name="${path##*/}"
@@ -46,7 +47,7 @@ else
     done
 
     pwd
-    cd "$cwd"
+    )
   }
 fi
 
@@ -72,11 +73,13 @@ fi
 
 if [ -z "${PYENV_DIR}" ]; then
   PYENV_DIR="$PWD"
-else
-  cd "$PYENV_DIR" 2>/dev/null || abort "cannot change working directory to \`$PYENV_DIR'"
-  PYENV_DIR="$PWD"
-  cd "$OLDPWD"
 fi
+
+if [ ! -d "$PYENV_DIR" ] || [ ! -e "$PYENV_DIR" ]; then
+  abort "cannot change working directory to \`$PYENV_DIR'"
+fi
+
+PYENV_DIR=$(cd "$PYENV_DIR" && echo "$PWD")
 export PYENV_DIR
 
 

--- a/libexec/pyenv-hooks
+++ b/libexec/pyenv-hooks
@@ -37,10 +37,10 @@ resolve_link() {
 }
 
 realpath() {
-  local cwd="$PWD"
   local path="$1"
   local name
-
+  # Use a subshell to avoid changing the current path
+  (
   while [ -n "$path" ]; do
     name="${path##*/}"
     [ "$name" = "$path" ] || cd "${path%/*}"
@@ -48,7 +48,7 @@ realpath() {
   done
 
   echo "${PWD}/$name"
-  cd "$cwd"
+  )
 }
 fi
 

--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -44,10 +44,11 @@ if ! enable -f "${BASH_SOURCE%/*}"/pyenv-realpath.dylib realpath 2>/dev/null; th
   }
 
   realpath() {
-    local cwd="$PWD"
     local path="$1"
     local name
 
+    # Use a subshell to avoid changing the current path
+    (
     while [ -n "$path" ]; do
       name="${path##*/}"
       [ "$name" = "$path" ] || cd "${path%/*}"
@@ -55,7 +56,7 @@ if ! enable -f "${BASH_SOURCE%/*}"/pyenv-realpath.dylib realpath 2>/dev/null; th
     done
 
     echo "${PWD}/$name"
-    cd "$cwd"
+    )
   }
 fi
 

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -60,9 +60,10 @@ resolve_link() {
 }
 
 abs_dirname() {
-  local cwd="$(pwd)"
   local path="$1"
 
+  # Use a subshell to avoid modifying the current path
+  (
   while [ -n "$path" ]; do
     cd "${path%/*}"
     local name="${path##*/}"
@@ -70,7 +71,7 @@ abs_dirname() {
   done
 
   pwd
-  cd "$cwd"
+  )
 }
 
 capitalize() {


### PR DESCRIPTION
Currently, pyenv uses `cd` in some spots to determine real paths, by abusing `$PWD`.

This works in the general case, but fails when `PWD=/proc/self/cwd`.  When `pyenv` attempts to change directories back to the "old" directory, it fails to do so.

This Pull Request wraps a few of these cases in sub-shells, and changes the code in one instance that uses `$OLDPWD`.

Specifically, this issue becomes apparent because it breaks the build for Android Open Source Project when `pyenv` is on `$PATH`, even when `pyenv global system` is in use.  This is because Clang upstream compilers now use `#!/usr/bin/env python` instead of `#!/usr/bin/python` in their shebang for the Python wrapper scripts.