### PR TITLE
Create releases on GitHub automatically from tags (fixes #1038)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,10 @@ env:
 notifications:
   email:
     on_success: never
+deploy:
+  provider: releases
+  api_key:
+    secure: FLWevL09KYp7V1SjJUNEdWzuomuocXwNvPr1DSAFH7mmrjKTtjzwrjINAthSqzjlDrs5B//P47l1VLyHp5byEzy673W+bOmEg8swmqc7E9FrHLRyEByd/yca3DzkZgXEXgGdY/cl7tHhM4V2fYKEgAIWbFV+takmTFMK4WkEtNg=
+  on:
+    repo: pyenv/pyenv
+    tags: true


### PR DESCRIPTION
Configured based on https://docs.travis-ci.com/user/deployment/releases/. There's @yyuu's OAuth token is embedded in encrypted form.

With configuring automation for the release, I believe we don't need to create releases manually anymore.

cc: @joshfriend @blueyed @Samureus 
