### PR TITLE
Fix pyenv install on Solaris / Illumos

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -155,8 +155,11 @@ num_cpu_cores() {
   Darwin | *BSD )
     num="$(sysctl -n hw.ncpu 2>/dev/null || true)"
     ;;
+  SunOS )
+    num="$(getconf NPROCESSORS_ONLN 2>/dev/null)"
+    ;;
   * )
-    num="$({ getconf _NPROCESSORS_ONLN || getconf NPROCESSORS_ONLN ||
+    num="$({ getconf _NPROCESSORS_ONLN ||
              grep -c ^processor /proc/cpuinfo; } 2>/dev/null)"
     num="${num#0}"
     ;;

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -156,7 +156,7 @@ num_cpu_cores() {
     num="$(sysctl -n hw.ncpu 2>/dev/null || true)"
     ;;
   * )
-    num="$({ getconf _NPROCESSORS_ONLN ||
+    num="$({ getconf _NPROCESSORS_ONLN || getconf NPROCESSORS_ONLN ||
              grep -c ^processor /proc/cpuinfo; } 2>/dev/null)"
     num="${num#0}"
     ;;

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -156,7 +156,7 @@ num_cpu_cores() {
     num="$(sysctl -n hw.ncpu 2>/dev/null || true)"
     ;;
   SunOS )
-    num="$(getconf NPROCESSORS_ONLN 2>/dev/null)"
+    num="$(getconf NPROCESSORS_ONLN 2>/dev/null || true)"
     ;;
   * )
     num="$({ getconf _NPROCESSORS_ONLN ||


### PR DESCRIPTION
"pyenv install" crashes on Solaris with an empty log file. Adding support for the proper Solaris getconf call in num_cpu_cores fixed it. Tested and working under OmniOS CE r151024.