### PR TITLE
Add ability to build using readline and openssl from pkgsrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Version History
 
+# Unreleased
+
+* python-build: Add PyPy[23] 5.10
+
 ## 1.2.0
 
 * python-build: Import changes from ruby-build v20171031 (#1026)

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1361,6 +1361,17 @@ require_distro() {
   return 1
 }
 
+require_osx_version() {
+  function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+
+  local required_version="$@"
+  local osx_version="$(sw_vers -productVersion)"
+  if [[ $(version $osx_version) -ge $(version $required_version) ]]; then
+    return 0
+  fi
+  return 1
+}
+
 configured_with_package_dir() {
   local package_var_name="$(capitalize "$1")"
   shift 1

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1429,7 +1429,8 @@ has_broken_mac_readline() {
   # https://github.com/pyenv/pyenv/issues/23
   is_mac &&
   ! configured_with_package_dir "python" "readline/rlconf.h" &&
-  ! use_homebrew_readline
+  ! use_homebrew_readline &&
+  ! use_pkgsrc_readline
 }
 
 use_homebrew_readline() {
@@ -1445,17 +1446,46 @@ use_homebrew_readline() {
   fi
 }
 
+use_pkgsrc_readline() {
+  if ! configured_with_package_dir "python" "readline/rlconf.h"; then
+    local libdir="$(pkg_info -p readline 2>/dev/null |
+                   awk '/CWD/ {print $NF}' |
+                   sort -u || true)"
+    if [ -d "$libdir" ]; then
+      echo "python-build: use readline from pkgsrc"
+      export CPPFLAGS="-I$libdir/include ${CPPFLAGS}"
+      export LDFLAGS="-L$libdir/lib ${LDFLAGS}"
+    else
+      return 1
+    fi
+  fi
+}
+
 has_broken_mac_openssl() {
   is_mac || return 1
   local openssl_version="$(/usr/bin/openssl version 2>/dev/null || true)"
   [[ $openssl_version = "OpenSSL 0.9.8"?* || $openssl_version = "LibreSSL"* ]] &&
-  ! use_homebrew_openssl
+  ! use_homebrew_openssl &&
+  ! use_pkgsrc_openssl
 }
 
 use_homebrew_openssl() {
   local ssldir="$(brew --prefix openssl 2>/dev/null || true)"
   if [ -d "$ssldir" ]; then
     echo "python-build: use openssl from homebrew"
+    export CPPFLAGS="-I$ssldir/include ${CPPFLAGS}"
+    export LDFLAGS="-L$ssldir/lib ${LDFLAGS}"
+  else
+    return 1
+  fi
+}
+
+use_pkgsrc_openssl() {
+  local ssldir="$(pkg_info -p openssl 2>/dev/null |
+                 awk '/CWD/ {print $NF}' |
+                 sort -u || true)"
+  if [ -d "$ssldir" ]; then
+    echo "python-build: use openssl from pkgsrc"
     export CPPFLAGS="-I$ssldir/include ${CPPFLAGS}"
     export LDFLAGS="-L$ssldir/lib ${LDFLAGS}"
   else

--- a/plugins/python-build/share/python-build/pypy2.7-5.10
+++ b/plugins/python-build/share/python-build/pypy2.7-5.10
@@ -1,0 +1,53 @@
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux" )
+  if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
+    install_package "pypy2-v5.10.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-linux32.tar.bz2#ee1980467ac8cc9fa9d609f7da93c5282503e59a548781248fe1914a7199d540" "pypy" verify_py27 ensurepip
+  fi
+  ;;
+"linux64" )
+  if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
+    install_package "pypy2-v5.10.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-linux64.tar.bz2#da85af9240220179493ad66c857934dc7ea91aef8f168cd293a2d99af8346ee2" "pypy" verify_py27 ensurepip
+  else
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+      echo "try 'pypy2.7-5.10.0-src' to build from source."
+      echo
+    } >&2
+    exit 1
+  fi
+  ;;
+"linux-armel" )
+  require_distro "Ubuntu 12.04" || true
+  install_package "pypy2-v5.10.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-linux-armel.tar.bz2#6fdd55dd8f674efd06f76edb60a09a03b9b04a5fbc56741f416a94a0b9d2ff91" "pypy" verify_py27 ensurepip
+  ;;
+"linux-armhf" )
+  if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
+    install_package "pypy2-v5.10.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-linux-armhf-raspbian.tar.bz2#5ec3617bb9a07a0a0b2f3c8fbe69912345da4696cdb0a2aca7889b6f1e74435c" "pypy" verify_py27 ensurepip
+  else
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+      echo "try 'pypy2.7-5.10.0-src' to build from source."
+      echo
+    } >&2
+    exit 1
+  fi
+  ;;
+"osx64" )
+  install_package "pypy2-v5.10.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-osx64.tar.bz2#7e4120f0a83529a6851cbae0ec107dc7085ba8a4aeff4e7bd9da9aadb1ef37a4" "pypy" verify_py27 ensurepip
+  ;;
+"win32" )
+  # FIXME: never tested on Windows
+  install_zip "pypy2-v5.10.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-win32.zip#350914f9b70404781674f2f188f84d440d9d25da46ed9733b3f98269a510e033" "pypy" verify_py27 ensurepip
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo "try 'pypy2.7-5.10.0-src' to build from source."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/pypy2.7-5.10-src
+++ b/plugins/python-build/share/python-build/pypy2.7-5.10-src
@@ -1,0 +1,3 @@
+#require_gcc
+install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "pypy2-v5.10.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-src.tar.bz2#1209f2db718e6afda17528baa5138177a14a0938588a7d3e1b7c722c483079a8" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.10
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10
@@ -1,0 +1,57 @@
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux" )
+  if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
+    install_package "pypy3-v5.10.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-linux32.tar.bz2#529bc3b11edbdcdd676d90c805b8f607f6eedd5f0ec457a31bbe09c03f5bebfe" "pypy" verify_py27 ensurepip
+  fi
+  ;;
+"linux64" )
+  if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
+    install_package "pypy3-v5.10.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-linux64.tar.bz2#aa4fb52fb858d973dd838dcf8d74f30705e5afdf1150acb8e056eb99353dfe77" "pypy" verify_py27 ensurepip
+  else
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+      echo "try 'pypy3.5-5.10.0-src' to build from source."
+      echo
+    } >&2
+    exit 1
+  fi
+  ;;
+"linux-armel" )
+  require_distro "Ubuntu 12.04" || true
+  install_package "pypy3-v5.10.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-linux-armel.tar.bz2#c2cc529befb3e1f2ef8bd4e96af4a823c52ef2d180b0b3bd87511c5b47d59210" "pypy" verify_py27 ensurepip
+  ;;
+"linux-armhf" )
+  if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
+    install_package "pypy3-v5.10.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-linux-armhf-raspbian.tar.bz2#4e902e0e79f62f2a9049c1c71310ff4fc801011bec4d25082edb5c537d3f15c9" "pypy" verify_py27 ensurepip
+  else
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+      echo "try 'pypy3.5-5.10.0-src' to build from source."
+      echo
+    } >&2
+    exit 1
+  fi
+  ;;
+"osx64" )
+  if require_osx_version "10.13"; then
+    install_package "pypy3-v5.10.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-osx64.tar.bz2#7e389a103f560de1eead1271ec3a2df9424c6ccffe7cbae8e95e6e81ae811a16" "pypy" verify_py27 ensurepip
+  else
+    install_package "pypy3-v5.10.0-osx64-2" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-osx64-2.tar.bz2#f5ced20934fff78e55c72aa82a4703954349a5a8099b94e77d74b96a94326a2c" "pypy" verify_py27 ensurepip
+  fi
+  ;;
+"win32" )
+  # FIXME: never tested on Windows
+  install_zip "pypy3-v5.10.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-win32.zip#2d93bf2bd7b1d031b96331d3fde6cacdda95673ce6875d6d1669c4c0ea2a52bc" "pypy" verify_py27 ensurepip
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo "try 'pypy3.5-5.10.0-src' to build from source."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/pypy3.5-5.10-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10-src
@@ -1,0 +1,3 @@
+#require_gcc
+install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "pypy3-v5.10.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-src.tar.bz2#a6e4cffde71e3f08b6e1befa5c0352a9bcc5f4e9f5cbf395001e0763a1a0d9e3" "pypy_builder" verify_py35 ensurepip


### PR DESCRIPTION
This is a simple change to pyenv's python-build plugin allowing it to use "pkgsrc" instead of "homebrew" for the source of "readline" and "openssl" when building python.

The assumption is that a user will either be using "homebrew" or "pkgsrc" but not both.
