### PR TITLE
Allow binary installs of PyPy on Xenial

### DIFF
--- a/plugins/python-build/share/python-build/pypy2.7-5.10.0
+++ b/plugins/python-build/share/python-build/pypy2.7-5.10.0
@@ -5,9 +5,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "linux64" )
-  if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.10.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-linux64.tar.bz2#da85af9240220179493ad66c857934dc7ea91aef8f168cd293a2d99af8346ee2" "pypy" verify_py27 ensurepip
-  elif require_distro "Ubuntu 16.04" 1>/dev/null 2>&1; then
+  if require_distro "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
     install_package "pypy2-v5.10.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-linux64.tar.bz2#da85af9240220179493ad66c857934dc7ea91aef8f168cd293a2d99af8346ee2" "pypy" verify_py27 ensurepip
   else
     { echo

--- a/plugins/python-build/share/python-build/pypy2.7-5.10.0
+++ b/plugins/python-build/share/python-build/pypy2.7-5.10.0
@@ -7,6 +7,8 @@ case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
     install_package "pypy2-v5.10.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-linux64.tar.bz2#da85af9240220179493ad66c857934dc7ea91aef8f168cd293a2d99af8346ee2" "pypy" verify_py27 ensurepip
+  elif require_distro "Ubuntu 16.04" 1>/dev/null 2>&1; then
+    install_package "pypy2-v5.10.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-linux64.tar.bz2#da85af9240220179493ad66c857934dc7ea91aef8f168cd293a2d99af8346ee2" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.0
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.0
@@ -7,6 +7,8 @@ case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
     install_package "pypy3-v5.10.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-linux64.tar.bz2#aa4fb52fb858d973dd838dcf8d74f30705e5afdf1150acb8e056eb99353dfe77" "pypy" verify_py27 ensurepip
+  elif require_distro "Ubuntu 16.04" 1>/dev/null 2>&1; then
+    install_package "pypy3-v5.10.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-linux64.tar.bz2#aa4fb52fb858d973dd838dcf8d74f30705e5afdf1150acb8e056eb99353dfe77" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.0
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.0
@@ -5,9 +5,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "linux64" )
-  if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-v5.10.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-linux64.tar.bz2#aa4fb52fb858d973dd838dcf8d74f30705e5afdf1150acb8e056eb99353dfe77" "pypy" verify_py27 ensurepip
-  elif require_distro "Ubuntu 16.04" 1>/dev/null 2>&1; then
+  if require_distro "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
     install_package "pypy3-v5.10.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-linux64.tar.bz2#aa4fb52fb858d973dd838dcf8d74f30705e5afdf1150acb8e056eb99353dfe77" "pypy" verify_py27 ensurepip
   else
     { echo


### PR DESCRIPTION
Ideally, the `require_distro` function is a little more intelligent to allow Xenial to be detected, but this should be good enough for now.