### PR TITLE
Do not create `clear` shim when Anaconda is installed

### DIFF
--- a/pyenv.d/rehash/conda.d/default.list
+++ b/pyenv.d/rehash/conda.d/default.list
@@ -1,4 +1,5 @@
 bunzip2
+clear
 # curl
 curl
 curl-config


### PR DESCRIPTION
## b64c445: Do not create `clear` shim when Anaconda is installed

Add `clear` to the Anaconda's default blacklist in order to prevent pyenv from creating the shim script for it.

The `clear` command executable began included from Anaconda 5.0.0 onwards, and this executable now conceals that of the user's base system - this hinders the user from running the `clear` command with the `command not found` error output if a user installs and selects one or more Python versions other than Anaconda 5.x.x.

Adding this one-liner to the blacklist allows the user to use the `clear` command even when Anaconda 5.x.x is not selected by pyenv.

---

### Message from the collaborator

I added this one-liner fix as I have a few Python versions installed together with Anaconda. I was wondering if adding this `clear` executable to the blacklist (and possibly adding more to it if any interferes with my base system in the future) could potentially cause the Anaconda installation to malfunction or not 🤔

I am guessing blacklisting the `clear` command in this fix shouldn't be a problem and hoping that other people will also gain the small benefit out of it 🤞 

Please review my commit and if necessary, rectify as appropriate 🙇

Thank you 🙏 

sho