### PR TITLE
Correct CPython 3.4.8 Checksums

### DIFF
--- a/plugins/python-build/share/python-build/3.4.8
+++ b/plugins/python-build/share/python-build/3.4.8
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.4.8" "https://www.python.org/ftp/python/3.4.8/Python-3.4.8.tar.xz#8b1a1ce043e132082d29a5d09f2841f193c77b631282a82f98895a5dbaba1639" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.8" "https://www.python.org/ftp/python/3.4.8/Python-3.4.8.tar.xz#29a472fa902c7b2add152f5e1e82e0885a8d360645689c1db5d1949a7e8ac3ea" ldflags_dirs standard verify_py34 ensurepip
 else
-  install_package "Python-3.4.8" "https://www.python.org/ftp/python/3.4.8/Python-3.4.8.tgz#29a472fa902c7b2add152f5e1e82e0885a8d360645689c1db5d1949a7e8ac3ea" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.8" "https://www.python.org/ftp/python/3.4.8/Python-3.4.8.tgz#8b1a1ce043e132082d29a5d09f2841f193c77b631282a82f98895a5dbaba1639" ldflags_dirs standard verify_py34 ensurepip
 fi


### PR DESCRIPTION
The current checksums for tar.xz and .tgz files are reversed. This
causes python-build to fail with a checksum mismatch error.

Reversing the checksums to allow the build to succeed.