### PR TITLE
python-build: add anaconda[23]-5.1.0

### DIFF
--- a/plugins/python-build/share/python-build/anaconda2-5.1.0
+++ b/plugins/python-build/share/python-build/anaconda2-5.1.0
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Anaconda2-5.1.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda2-5.1.0-Linux-x86.sh#5af0c7a09a5f3aaf3666c0b362246d342d80e782128ef043998c9ead5ad41df7" "anaconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda2-5.1.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda2-5.1.0-Linux-x86_64.sh#5f26ee92860d1dffdcd20910ff2cf75572c39d2892d365f4e867a611cca2af5b" "anaconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda2-5.1.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda2-5.1.0-MacOSX-x86_64.sh#b686e01aeadb33526d9c154a0ac6f691dfad135080df96fb44d3ae1e4b128521" "anaconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda2 is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/anaconda3-5.1.0
+++ b/plugins/python-build/share/python-build/anaconda3-5.1.0
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Anaconda3-5.1.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda3-5.1.0-Linux-x86.sh#0e940272517d8f8a6f26316a19e4be2bdaea8477a3a32cc2ecee7b48fd0fae84" "anaconda" verify_py36
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda3-5.1.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-5.1.0-Linux-x86_64.sh#7e6785caad25e33930bc03fac4994a434a21bc8401817b7efa28f53619fa9c29" "anaconda" verify_py36
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda3-5.1.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-5.1.0-MacOSX-x86_64.sh#be705b3c3a0ca29ee32ce7658890bb5edb32a9eadedc09dec3d7e3cfbfd23cb7" "anaconda" verify_py36
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda3 is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
This PR consists of a single commit adding two new files, which allow the user to install both Anaconda2 5.1.0 and Anaconda3 5.1.0.

The tests have been done only on macOS, but it should also work on Linux; please check if it is buildable on Linux.

The SHA-256 checksum for each Anaconda shell file is copied from the following pages:

- https://docs.anaconda.com/anaconda/install/hashes/Anaconda2-5.1.0-Linux-x86.sh-hash
- https://docs.anaconda.com/anaconda/install/hashes/Anaconda2-5.1.0-Linux-x86_64.sh-hash
- https://docs.anaconda.com/anaconda/install/hashes/Anaconda2-5.1.0-MacOSX-x86_64.sh-hash
- https://docs.anaconda.com/anaconda/install/hashes/Anaconda3-5.1.0-Linux-x86.sh-hash
- https://docs.anaconda.com/anaconda/install/hashes/Anaconda3-5.1.0-Linux-x86_64.sh-hash
- https://docs.anaconda.com/anaconda/install/hashes/Anaconda3-5.1.0-MacOSX-x86_64.sh-hash