### PR TITLE
Added a check for PATH if already set

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -2,6 +2,18 @@
 set -e
 unset CDPATH
 
+# Safely adds new paths to the PATH variable.
+path_add_front() {
+  if ! echo ${PATH} | egrep -q "(^|:)$1($|:)" ; then
+    PATH=${1}:${PATH}
+  fi
+}
+path_add_back() {
+  if ! echo ${PATH} | egrep -q "(^|:)$1($|:)" ; then
+    PATH=${PATH}:${1}
+  fi
+}
+
 if [ "$1" = "--debug" ]; then
   export PYENV_DEBUG=1
   shift
@@ -87,9 +99,10 @@ shopt -s nullglob
 
 bin_path="$(abs_dirname "$0")"
 for plugin_bin in "${PYENV_ROOT}/plugins/"*/bin; do
-  PATH="${plugin_bin}:${PATH}"
+  path_add_front "${plugin_bin}"
 done
-export PATH="${bin_path}:${PATH}"
+path_add_front "${bin_path}"
+export PATH
 
 PYENV_HOOK_PATH="${PYENV_HOOK_PATH}:${PYENV_ROOT}/pyenv.d"
 if [ "${bin_path%/*}" != "$PYENV_ROOT" ]; then


### PR DESCRIPTION
There is a minor problem when stack-running shell -- the PATH variable keeps on appending the `.../.pyenv/shims:...`. You can reproduce it by running

```
bash
bash
bash
bash
echo ${PATH}
# On my machine prints
# /home/zafar/.pyenv/shims:/home/zafar/.pyenv/bin:/home/zafar/.pyenv/shims:/home/zafar/.pyenv/bin:/home/zafar/.pyenv/shims:/home/zafar/.pyenv/bin:/home/zafar/.pyenv/shims:/home/zafar/.pyenv/bin:/home/zafar/.pyenv/shims:/home/zafar/.pyenv/bin:/home/zafar/.pyenv/shims:/home/zafar/.pyenv/bin:...
```

This PR adds a safety check if the appended path already exists in the `${PATH}`. Note that the check is if the appended path is between `(^|:)` and `($|:)` -- just in case there is a need to add sub-paths (i.e.: it is fine to add `/some/long/path` and `/some/long/` after it).