### PR TITLE
Homebrew Set openssl PKG_CONFIG_PATH for python 3.7

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1467,6 +1467,7 @@ use_homebrew_openssl() {
   local ssldir="$(brew --prefix openssl 2>/dev/null || true)"
   if [ -d "$ssldir" ]; then
     echo "python-build: use openssl from homebrew"
+    export PKG_CONFIG_PATH="$ssldir/lib/pkgconfig/:${PKG_CONFIG_PATH}"
     export CPPFLAGS="-I$ssldir/include ${CPPFLAGS}"
     export LDFLAGS="-L$ssldir/lib ${LDFLAGS}"
   else


### PR DESCRIPTION
As noted in https://github.com/pyenv/pyenv/issues/993 Python 3.7 changes the way that non default location openssl is added to configure. See https://bugs.python.org/issue32598

This pr aims to make python 3.7b2 build with openssl on High Sierra again by adding openssl to PKG_CONFIG_PATH 
