### PR TITLE
Fix #1118: follow only dir-symlinks

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -35,22 +35,18 @@ else
     $READLINK "$1"
   }
 
-  resolve_link_follow() {
-    $READLINK -f "$1"
-  }
-
   abs_dirname() {
     local path="$1"
 
     # Use a subshell to avoid changing the current path
     (
-    while [ -n "$path" ]; do
+    while [[ -n "$path" && $(echo "$path" | grep /) ]]; do
       cd "${path%/*}"
       local name="${path##*/}"
       path="$(resolve_link "$name" || true)"
     done
 
-    resolve_link_follow "$(pwd)"
+    pwd
     )
   }
 fi


### PR DESCRIPTION
This corrects the deffect where pyenv tries to determine an absolute
path of the directory containing a file and follows symlinks
manually. Because of missing check it behaved correctly, but a
misleading error message was shown in the terminal output.
Resolves #1118.

Thanks to @HQJaTu for the initial patch.