### PR TITLE
Fix dead link in ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,3 +381,11 @@ tracker](https://github.com/pyenv/pyenv/issues).
 
   [pyenv-virtualenv]: https://github.com/pyenv/pyenv-virtualenv#readme
   [hooks]: https://github.com/pyenv/pyenv/wiki/Authoring-plugins#pyenv-hooks
+
+### Version History
+
+See [CHANGELOG.md](CHANGELOG.md).
+
+### License
+
+[The MIT License](LICENSE)


### PR DESCRIPTION
I found dead link inside ToC of this project.

* https://github.com/pyenv/pyenv#version-history
* https://github.com/pyenv/pyenv#license

Both are considered lost when merging with the [rbenv's README](https://github.com/rbenv/rbenv/blob/master/README.md).

I fixed that both were useful information and that I should leave the link.