### PR TITLE
Add template for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+Too many issues will kill our team's development velocity, drastically.
+Make sure you have checked all steps below.
+
+### Prerequisite
+* [ ] Make sure your problem is not listed in [the common build problems](https://github.com/pyenv/pyenv/wiki/Common-build-problems)
+* [ ] Make sure duplicated issue has already been reported in [the pyenv issues](https://github.com/pyenv/pyenv/issues). You should look for closed issues too.
+* [ ] Make sure you are not asking us to help solving your specific issue.
+  * GitHub issues is opened mainly for development purpose. If you want to ask someone to help solving your problem, go some community site like [Gitter](https://gitter.im/yyuu/pyenv), [StackOverflow](https://stackoverflow.com/questions/tagged/pyenv), etc.
+* [ ] Make sure your problem is not derived from packaging (e.g. [Homebrew](https://brew.sh))
+  * Please refer the package documentation for the installation issues, etc.
+* [ ] Make sure your problem is not derived from plugins
+  * This repository is maintaining `pyenv` and the default `python-build` plugin only. Please refrain to report the issues of the plugin here.
+
+### Description
+- [ ] Platform information (e.g. Ubuntu Linux 16.04):
+- [ ] OS architecture (e.g. amd64):
+- [ ] pyenv version:
+- [ ] Python version:
+- [ ] C Compiler information (e.g. gcc 7.3): 
+- [ ] Please attach verbose build log as gist
+  * You can turn on verbose debug log like `env PYENV_DEBUG=1 pyenv install -v 3.6.4`

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,14 +2,14 @@ Too many issues will kill our team's development velocity, drastically.
 Make sure you have checked all steps below.
 
 ### Prerequisite
-* [ ] Make sure your problem is not listed in [the common build problems](https://github.com/pyenv/pyenv/wiki/Common-build-problems)
-* [ ] Make sure duplicated issue has already been reported in [the pyenv issues](https://github.com/pyenv/pyenv/issues). You should look for closed issues too.
+* [ ] Make sure your problem is not listed in [the common build problems](https://github.com/pyenv/pyenv/wiki/Common-build-problems).
+* [ ] Make sure no duplicated issue has already been reported in [the pyenv issues](https://github.com/pyenv/pyenv/issues). You should look for closed issues, too.
 * [ ] Make sure you are not asking us to help solving your specific issue.
-  * GitHub issues is opened mainly for development purpose. If you want to ask someone to help solving your problem, go some community site like [Gitter](https://gitter.im/yyuu/pyenv), [StackOverflow](https://stackoverflow.com/questions/tagged/pyenv), etc.
-* [ ] Make sure your problem is not derived from packaging (e.g. [Homebrew](https://brew.sh))
-  * Please refer the package documentation for the installation issues, etc.
-* [ ] Make sure your problem is not derived from plugins
-  * This repository is maintaining `pyenv` and the default `python-build` plugin only. Please refrain to report the issues of the plugin here.
+  * GitHub issues is opened mainly for development purposes. If you want to ask someone to help solving your problem, go to some community site like [Gitter](https://gitter.im/yyuu/pyenv), [StackOverflow](https://stackoverflow.com/questions/tagged/pyenv), etc.
+* [ ] Make sure your problem is not derived from packaging (e.g. [Homebrew](https://brew.sh)).
+  * Please refer to the package documentation for the installation issues, etc.
+* [ ] Make sure your problem is not derived from plugins.
+  * This repository is maintaining `pyenv` and the default `python-build` plugin only. Please refrain from reporting issues of other plugins here.
 
 ### Description
 - [ ] Platform information (e.g. Ubuntu Linux 16.04):
@@ -18,4 +18,4 @@ Make sure you have checked all steps below.
 - [ ] Python version:
 - [ ] C Compiler information (e.g. gcc 7.3): 
 - [ ] Please attach verbose build log as gist
-  * You can turn on verbose debug log like `env PYENV_DEBUG=1 pyenv install -v 3.6.4`
+  * You can turn on verbose debug logging using by setting `PYENV_DEBUG=1`, e.g. `env PYENV_DEBUG=1 pyenv install -v 3.6.4`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 Make sure you have checked all steps below.
 
 ### Prerequisite
-* [ ] Please consider implementing the feature as hook script or plugin at first
-  * pyenv has some powerful support for plugins and hook scripts. Please refer [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement as some plugin if possible.
-* [ ] Please consider contribute similar patch to [rbenv](https://github.com/rbenv/rbenv) since we have borrowed most of lines with the project
-  * We are occasionally importing the changes from the rbenv. In general, you can expect some changes made in rbenv will be imported to pyenv too, eventually.
-  * Generaly speaking, we sometime don't prefer to make some change in the core feature to keep compatibility with rbenv.
+* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
+  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
+* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from this project.
+  * We are occasionally importing the changes from rbenv. In general, you can expect some changes made in rbenv will be imported to pyenv too, eventually.
+  * Generaly speaking, we sometimes don't prefer to make some change in the core to keep compatibility with rbenv.
 * [ ] My PR addresses the following pyenv issue (if any)
   - https://github.com/pyenv/pyenv/issues/XXXX
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+Make sure you have checked all steps below.
+
+### Prerequisite
+* [ ] Please consider implementing the feature as hook script or plugin at first
+  * pyenv has some powerful support for plugins and hook scripts. Please refer [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement as some plugin if possible.
+* [ ] Please consider contribute similar patch to [rbenv](https://github.com/rbenv/rbenv) since we have borrowed most of lines with the project
+  * We are occasionally importing the changes from the rbenv. In general, you can expect some changes made in rbenv will be imported to pyenv too, eventually.
+  * Generaly speaking, we sometime don't prefer to make some change in the core feature to keep compatibility with rbenv.
+* [ ] My PR addresses the following pyenv issue (if any)
+  - https://github.com/pyenv/pyenv/issues/XXXX
+
+### Description
+- [ ] Here are some details about my PR
+
+### Tests
+- [ ] My PR adds the following unit tests (if any)


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as hook script or plugin at first
  * pyenv has some powerful support for plugins and hook scripts. Please refer [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement as some plugin if possible.
* [x] Please consider contribute similar patch to [rbenv](https://github.com/rbenv/rbenv) since we have borrowed most of lines with the project
  * We are occasionally importing the changes from the rbenv. In general, you can expect some changes made in rbenv will be imported to pyenv too, eventually.
  * Generaly speaking, we sometime don't prefer to make some change in the core feature to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1116

### Description
- [x] Here are some details about my PR

This adds the templates for issues and pull requests.

### Tests
- [x] My PR adds the following unit tests (if any)

None. Actually I didn't made any changes to the code itself.