### PR TITLE
Use custom get-pip URL based on the target version

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2122,7 +2122,21 @@ if [ -z "${GET_PIP_URL}" ]; then
     # Unset `PIP_VERSION` from environment before invoking `get-pip.py` to deal with "ValueError: invalid truth value" (pypa/pip#4528)
     unset PIP_VERSION
   else
-    GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"
+    # Use custom get-pip URL based on the target version (#1127)
+    case "${DEFINITION_PATH##*/}" in
+    2.6 | 2.6.* )
+      GET_PIP_URL="https://bootstrap.pypa.io/2.6/get-pip.py"
+      ;;
+    3.2 | 3.2.* )
+      GET_PIP_URL="https://bootstrap.pypa.io/3.2/get-pip.py"
+      ;;
+    3.3 | 3.3.* )
+      GET_PIP_URL="https://bootstrap.pypa.io/3.3/get-pip.py"
+      ;;
+    * )
+      GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"
+      ;;
+    esac
   fi
 fi
 

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2119,7 +2119,7 @@ fi
 if [ -z "${GET_PIP_URL}" ]; then
   if [ -n "${PIP_VERSION}" ]; then
     { colorize 1 "WARNING"
-      echo ": pip is going to abandon the support for the custom version installation via custom get-pip URL. The use of PIP_VERSION=${PIP_VERSION} may not work anymore."
+      echo ": Setting PIP_VERSION=${PIP_VERSION} is no longer supported and may cause failures during the install process."
     } 1>&2
     GET_PIP_URL="https://raw.githubusercontent.com/pypa/pip/${PIP_VERSION}/contrib/get-pip.py"
     # Unset `PIP_VERSION` from environment before invoking `get-pip.py` to deal with "ValueError: invalid truth value" (pypa/pip#4528)

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2118,6 +2118,9 @@ if [ -z "${EZ_SETUP_URL}" ]; then
 fi
 if [ -z "${GET_PIP_URL}" ]; then
   if [ -n "${PIP_VERSION}" ]; then
+    { colorize 1 "WARNING"
+      echo ": pip is going to abandon the support for the custom version installation via custom get-pip URL. The use of PIP_VERSION=${PIP_VERSION} may not work anymore."
+    } 1>&2
     GET_PIP_URL="https://raw.githubusercontent.com/pypa/pip/${PIP_VERSION}/contrib/get-pip.py"
     # Unset `PIP_VERSION` from environment before invoking `get-pip.py` to deal with "ValueError: invalid truth value" (pypa/pip#4528)
     unset PIP_VERSION

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -92,6 +92,19 @@ resolve_link() {
   $(type -p greadlink readlink | head -1) "$1"
 }
 
+run_inline_definition_with_name() {
+  local definition_name="build-definition"
+  case "$1" in
+  "--name="* )
+    local definition_name="${1#--name=}"
+    shift 1
+    ;;
+  esac
+  local definition="${TMP}/${definition_name}"
+  cat > "$definition"
+  run python-build "$definition" "${1:-$INSTALL_ROOT}"
+}
+
 @test "apply built-in python patch before building" {
   cached_tarball "Python-3.6.2"
 
@@ -325,4 +338,44 @@ echo "\${MACOSX_DEPLOYMENT_TARGET}"
 OUT
   assert_success
   assert_output "10.4"
+}
+
+@test "use the default EZ_SETUP_URL by default" {
+  run_inline_definition <<OUT
+echo "\${EZ_SETUP_URL}"
+OUT
+  assert_output "https://bootstrap.pypa.io/ez_setup.py"
+  assert_success
+}
+
+@test "use the default GET_PIP_URL by default" {
+  run_inline_definition <<OUT
+echo "\${GET_PIP_URL}"
+OUT
+  assert_output "https://bootstrap.pypa.io/get-pip.py"
+  assert_success
+}
+
+@test "use the custom GET_PIP_URL for 2.6 versions" {
+  run_inline_definition_with_name --name=2.6 <<OUT
+echo "\${GET_PIP_URL}"
+OUT
+  assert_output "https://bootstrap.pypa.io/2.6/get-pip.py"
+  assert_success
+}
+
+@test "use the custom GET_PIP_URL for 3.2 versions" {
+  run_inline_definition_with_name --name=3.2 <<OUT
+echo "\${GET_PIP_URL}"
+OUT
+  assert_output "https://bootstrap.pypa.io/3.2/get-pip.py"
+  assert_success
+}
+
+@test "use the custom GET_PIP_URL for 3.3 versions" {
+  run_inline_definition_with_name --name=3.3 <<OUT
+echo "\${GET_PIP_URL}"
+OUT
+  assert_output "https://bootstrap.pypa.io/3.3/get-pip.py"
+  assert_success
 }


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from this project.
  * We are occasionally importing the changes from rbenv. In general, you can expect some changes made in rbenv will be imported to pyenv too, eventually.
  * Generaly speaking, we sometimes don't prefer to make some change in the core to keep compatibility with rbenv.
  * This change is pretty much Python specific.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1127

### Description
- [x] Here are some details about my PR

Let python-build to use custom URL for `get-pip.py` some specific versions of CPython as a tentative workaround for backward compatibility issue of pip.

### Tests
- [x] My PR adds the following unit tests (if any)

Added some tests of `GET_PIP_URL` value for 2.6, 3.2, 3.3 and other versions.