### PR TITLE
Fixed a typo in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Make sure you have checked all steps below.
   * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
 * [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from this project.
   * We are occasionally importing the changes from rbenv. In general, you can expect some changes made in rbenv will be imported to pyenv too, eventually.
-  * Generaly speaking, we sometimes don't prefer to make some change in the core to keep compatibility with rbenv.
+  * Generally speaking, we sometimes don't prefer to make some change in the core to keep compatibility with rbenv.
 * [ ] My PR addresses the following pyenv issue (if any)
   - https://github.com/pyenv/pyenv/issues/XXXX
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from this project.
  * We are occasionally importing the changes from rbenv. In general, you can expect some changes made in rbenv will be imported to pyenv too, eventually.
  * Generaly speaking, we sometimes don't prefer to make some change in the core to keep compatibility with rbenv.
  * I'm pretty sure this is pyenv specific!

### Description
- [x] Here are some details about my PR

Fixed typo in PR template.

### Tests
- [x] My PR adds the following unit tests (if any)

I'm pretty sure this won't bother anything in the code itself!