### PR TITLE
Run rehash command in the background

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -101,7 +101,7 @@ if [ -r "$completion" ]; then
 fi
 
 if [ -z "$no_rehash" ]; then
-  echo 'command pyenv rehash 2>/dev/null'
+  echo '(command pyenv rehash 2>/dev/null &)'
 fi
 
 commands=(`pyenv-commands --sh`)

--- a/test/init.bats
+++ b/test/init.bats
@@ -14,7 +14,7 @@ load test_helper
 @test "auto rehash" {
   run pyenv-init -
   assert_success
-  assert_line "command pyenv rehash 2>/dev/null"
+  assert_line "(command pyenv rehash 2>/dev/null &)"
 }
 
 @test "setup shell completions" {


### PR DESCRIPTION
The rehash command doesn't take too long to run, but can add up when
several *env projects (rbenv, pyenv, nodenv, etc) are installed at the
same time. This makes it run in the background so that you don't have
to skip it altogether (using the `--no-rehash` flag) but also don't
have to wait a lot during shell initialization.

The `()` around the command prevent it from displaying the job number
or the "job done" message once it finishes.

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from this project.
  * We are occasionally importing the changes from rbenv. In general, you can expect some changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we sometimes don't prefer to make some change in the core to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
