### PR TITLE
prevent duplicate path entries for fish shell

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -86,8 +86,12 @@ mkdir -p "${PYENV_ROOT}/"{shims,versions}
 
 case "$shell" in
 fish )
-  echo "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
-  echo "set -gx PYENV_SHELL $shell"
+  # add check to prevent duplicate `$PYENV_ROOT/shims` directories in `$PATH`
+  echo "if not contains '${PYENV_ROOT}/shims' \$PATH"
+  echo "and test -d '${PYENV_ROOT}/shims'"
+    echo "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
+    echo "set -gx PYENV_SHELL $shell"
+  echo "end"
 ;;
 * )
   echo 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'


### PR DESCRIPTION
add simple check for fish shell to prevent reading the `\$PYENV_ROOT/shims` directory to the `\$PATH` when launching `tmux` or reinitializing the shell via `exec fish`. 

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from this project.
  * We are occasionally importing the changes from rbenv. In general, you can expect some changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we sometimes don't prefer to make some change in the core to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Prevent duplicate path entries for `$PYENV_ROOT/shims` in the `$PATH` using fish shell.

### Tests
- [ ] My PR adds the following unit tests (if any)
