### PR TITLE
Wait rehash until lock acquisition

### DIFF
--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -34,6 +34,11 @@ release_lock() {
   remove_prototype_shim
 }
 
+if [ ! -w "$SHIM_PATH" ]; then
+  echo "pyenv: cannot rehash: $SHIM_PATH isn't writable"
+  exit 1
+fi
+
 unset acquired
 for _ in $(seq "${PYENV_REHASH_TIMEOUT:-60}"); do
   if acquire_lock 2>/dev/null; then
@@ -46,11 +51,7 @@ for _ in $(seq "${PYENV_REHASH_TIMEOUT:-60}"); do
 done
 
 if [ -z "${acquired}" ]; then
-  if [ -w "$SHIM_PATH" ]; then
-    echo "pyenv: cannot rehash: $PROTOTYPE_SHIM_PATH exists"
-  else
-    echo "pyenv: cannot rehash: $SHIM_PATH isn't writable"
-  fi
+  echo "pyenv: cannot rehash: $PROTOTYPE_SHIM_PATH exists"
   exit 1
 fi
 

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -35,7 +35,7 @@ release_lock() {
 }
 
 unset acquired
-for _ in $(seq "${PYENV_REHASH_LOCK_TIMEOUT:-60}"); do
+for _ in $(seq "${PYENV_REHASH_TIMEOUT:-60}"); do
   if acquire_lock 2>/dev/null; then
     acquired=1
     break

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -10,29 +10,49 @@ PROTOTYPE_SHIM_PATH="${SHIM_PATH}/.pyenv-shim"
 # Create the shims directory if it doesn't already exist.
 mkdir -p "$SHIM_PATH"
 
-# Ensure only one instance of pyenv-rehash is running at a time by
-# setting the shell's `noclobber` option and attempting to write to
-# the prototype shim file. If the file already exists, print a warning
-# to stderr and exit with a non-zero status.
-set -o noclobber
-{ echo > "$PROTOTYPE_SHIM_PATH"
-} 2>| /dev/null ||
-{ if [ -w "$SHIM_PATH" ]; then
+acquire_lock() {
+  # Ensure only one instance of pyenv-rehash is running at a time by
+  # setting the shell's `noclobber` option and attempting to write to
+  # the prototype shim file. If the file already exists, print a warning
+  # to stderr and exit with a non-zero status.
+  local ret
+  set -o noclobber
+  echo > "$PROTOTYPE_SHIM_PATH" 2>| /dev/null || ret=1
+  set +o noclobber
+  [ -z "${ret}" ]
+}
+
+# If we were able to obtain a lock, register a trap to clean up the
+# prototype shim when the process exits.
+trap release_lock EXIT
+
+remove_prototype_shim() {
+  rm -f "$PROTOTYPE_SHIM_PATH"
+}
+
+release_lock() {
+  remove_prototype_shim
+}
+
+unset acquired
+for _ in $(seq "${PYENV_REHASH_LOCK_TIMEOUT:-60}"); do
+  if acquire_lock 2>/dev/null; then
+    acquired=1
+    break
+  else
+    # POSIX sleep(1) doesn't provides time precision of subsecond
+    sleep 1
+  fi
+done
+
+if [ -z "${acquired}" ]; then
+  if [ -w "$SHIM_PATH" ]; then
     echo "pyenv: cannot rehash: $PROTOTYPE_SHIM_PATH exists"
   else
     echo "pyenv: cannot rehash: $SHIM_PATH isn't writable"
   fi
   exit 1
-} >&2
-set +o noclobber
-
-# If we were able to obtain a lock, register a trap to clean up the
-# prototype shim when the process exits.
-trap remove_prototype_shim EXIT
-
-remove_prototype_shim() {
-  rm -f "$PROTOTYPE_SHIM_PATH"
-}
+fi
 
 # The prototype shim file is a script that re-execs itself, passing
 # its filename and any arguments to `pyenv exec`. This file is

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -32,6 +32,15 @@ create_executable() {
   assert_failure "pyenv: cannot rehash: ${PYENV_ROOT}/shims/.pyenv-shim exists"
 }
 
+@test "wait until lock acquisition" {
+  export PYENV_REHASH_TIMEOUT=5
+  mkdir -p "${PYENV_ROOT}/shims"
+  touch "${PYENV_ROOT}/shims/.pyenv-shim"
+  bash -c "sleep 1 && rm -f ${PYENV_ROOT}/shims/.pyenv-shim" &
+  run pyenv-rehash
+  assert_success
+}
+
 @test "creates shims" {
   create_executable "2.7" "python"
   create_executable "2.7" "fab"

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -25,6 +25,7 @@ create_executable() {
 }
 
 @test "rehash in progress" {
+  export PYENV_REHASH_TIMEOUT=1
   mkdir -p "${PYENV_ROOT}/shims"
   touch "${PYENV_ROOT}/shims/.pyenv-shim"
   run pyenv-rehash


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
  * Unfortunately, this cannot be implemented as a hook script since this needs to work prior to invoking hook scripts
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from this project.
  * We are occasionally importing the changes from rbenv. In general, you can expect some changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we sometimes don't prefer to make some change in the core to keep compatibility with rbenv.
  * <del>I'm going to propose this change to rbenv later</del> https://github.com/rbenv/rbenv/pull/1076
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/pull/1092
  - https://github.com/pyenv/pyenv/pull/1137

### Description
- [x] Here are some details about my PR

Improved locking mechanism of rehash to wait until acquisition of the _lock_ instead of fail immediately. For now the code keeps using original pseudo locking mechanism based on `noclobber`.

### Tests
- [x] My PR adds the following unit tests (if any)
  - <del>will implement some</del> implemented basic tests with setting custom `PYENV_REHASH_TIMEOUT`