### PR TITLE
Allow overriding HTTP client type based on environment variable

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -328,21 +328,22 @@ http() {
   local file="$3"
   [ -n "$url" ] || return 1
 
-  if type aria2c &>/dev/null; then
-    "http_${method}_aria2c" "$url" "$file"
-  elif type curl &>/dev/null; then
-    "http_${method}_curl" "$url" "$file"
-  elif type wget &>/dev/null; then
-    # SSL Certificate error with older wget that does not support Server Name Indication (#60)
-    if [[ "$(wget --version 2>/dev/null || true)" = "GNU Wget 1.1"[0-3]* ]]; then
-      echo "python-build: wget (< 1.14) doesn't support Server Name Indication. Please install curl (>= 7.18.1) and try again" >&2
-      return 1
-    fi
-    "http_${method}_wget" "$url" "$file"
+  local http_client
+  if [ -n "${PYTHON_BUILD_HTTP_CLIENT}" ]; then
+    http_client="http_${method}_${PYTHON_BUILD_HTTP_CLIENT}"
   else
-    echo "error: please install \`aria2c\`, \`curl\` or \`wget\` and try again" >&2
-    exit 1
+    if type aria2c &>/dev/null; then
+      http_client="http_${method}_aria2c"
+    elif type curl &>/dev/null; then
+      http_client="http_${method}_curl"
+    elif type wget &>/dev/null; then
+      http_client="http_${method}_wget"
+    else
+      echo "error: please install \`aria2c\`, \`curl\` or \`wget\` and try again" >&2
+      exit 1
+    fi
   fi
+  "${http_client}" "$url" "$file"
 }
 
 http_head_aria2c() {
@@ -2030,6 +2031,14 @@ fi
 ARIA2_OPTS="${PYTHON_BUILD_ARIA2_OPTS} ${IPV4+--disable-ipv6=true} ${IPV6+--disable-ipv6=false}"
 CURL_OPTS="${PYTHON_BUILD_CURL_OPTS} ${IPV4+--ipv4} ${IPV6+--ipv6}"
 WGET_OPTS="${PYTHON_BUILD_WGET_OPTS} ${IPV4+--inet4-only} ${IPV6+--inet6-only}"
+
+if [ -z "${PYTHON_BUILD_HTTP_CLIENT}" ] && ! type aria2c &>/dev/null && ! type curl &>/dev/null; then
+  # SSL Certificate error with older wget that does not support Server Name Indication (#60)
+  if [[ "$(wget --version 2>/dev/null || true)" = "GNU Wget 1.1"[0-3]* ]]; then
+    echo "python-build: wget (< 1.14) doesn't support Server Name Indication. Please install curl (>= 7.18.1) and try again" >&2
+    return 1
+  fi
+fi
 
 # Add an option to build a debug version of Python (#11)
 if [ -n "$DEBUG" ]; then

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -6,7 +6,6 @@ export MAKE=make
 export MAKE_OPTS="-j 2"
 export CC=cc
 export -n PYTHON_CONFIGURE_OPTS
-export PYTHON_BUILD_HTTP_CLIENT="curl"
 
 setup() {
   mkdir -p "$INSTALL_ROOT"

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -6,9 +6,9 @@ export MAKE=make
 export MAKE_OPTS="-j 2"
 export CC=cc
 export -n PYTHON_CONFIGURE_OPTS
+export PYTHON_BUILD_HTTP_CLIENT="curl"
 
 setup() {
-  ensure_not_found_in_path aria2c
   mkdir -p "$INSTALL_ROOT"
   stub md5 false
   stub curl false

--- a/plugins/python-build/test/cache.bats
+++ b/plugins/python-build/test/cache.bats
@@ -4,9 +4,9 @@ load test_helper
 export PYTHON_BUILD_SKIP_MIRROR=1
 export PYTHON_BUILD_CACHE_PATH="$TMP/cache"
 export PYTHON_BUILD_CURL_OPTS=
+export PYTHON_BUILD_HTTP_CLIENT="curl"
 
 setup() {
-  ensure_not_found_in_path aria2c
   mkdir "$PYTHON_BUILD_CACHE_PATH"
 }
 

--- a/plugins/python-build/test/cache.bats
+++ b/plugins/python-build/test/cache.bats
@@ -3,8 +3,6 @@
 load test_helper
 export PYTHON_BUILD_SKIP_MIRROR=1
 export PYTHON_BUILD_CACHE_PATH="$TMP/cache"
-export PYTHON_BUILD_CURL_OPTS=
-export PYTHON_BUILD_HTTP_CLIENT="curl"
 
 setup() {
   mkdir "$PYTHON_BUILD_CACHE_PATH"

--- a/plugins/python-build/test/checksum.bats
+++ b/plugins/python-build/test/checksum.bats
@@ -3,8 +3,6 @@
 load test_helper
 export PYTHON_BUILD_SKIP_MIRROR=1
 export PYTHON_BUILD_CACHE_PATH=
-export PYTHON_BUILD_CURL_OPTS=
-export PYTHON_BUILD_HTTP_CLIENT="curl"
 
 
 @test "package URL without checksum" {

--- a/plugins/python-build/test/checksum.bats
+++ b/plugins/python-build/test/checksum.bats
@@ -4,10 +4,7 @@ load test_helper
 export PYTHON_BUILD_SKIP_MIRROR=1
 export PYTHON_BUILD_CACHE_PATH=
 export PYTHON_BUILD_CURL_OPTS=
-
-setup() {
-  ensure_not_found_in_path aria2c
-}
+export PYTHON_BUILD_HTTP_CLIENT="curl"
 
 
 @test "package URL without checksum" {

--- a/plugins/python-build/test/fetch.bats
+++ b/plugins/python-build/test/fetch.bats
@@ -3,8 +3,6 @@
 load test_helper
 export PYTHON_BUILD_SKIP_MIRROR=1
 export PYTHON_BUILD_CACHE_PATH=
-export PYTHON_BUILD_ARIA2_OPTS=
-export PYTHON_BUILD_HTTP_CLIENT="curl"
 
 setup() {
   export PYTHON_BUILD_BUILD_PATH="${TMP}/source"
@@ -21,6 +19,7 @@ setup() {
 }
 
 @test "using aria2c if available" {
+  export PYTHON_BUILD_ARIA2_OPTS=
   export PYTHON_BUILD_HTTP_CLIENT="aria2c"
   stub aria2c "--allow-overwrite=true --no-conf=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$4"
 

--- a/plugins/python-build/test/fetch.bats
+++ b/plugins/python-build/test/fetch.bats
@@ -4,9 +4,9 @@ load test_helper
 export PYTHON_BUILD_SKIP_MIRROR=1
 export PYTHON_BUILD_CACHE_PATH=
 export PYTHON_BUILD_ARIA2_OPTS=
+export PYTHON_BUILD_HTTP_CLIENT="curl"
 
 setup() {
-  ensure_not_found_in_path aria2c
   export PYTHON_BUILD_BUILD_PATH="${TMP}/source"
   mkdir -p "${PYTHON_BUILD_BUILD_PATH}"
 }
@@ -21,6 +21,7 @@ setup() {
 }
 
 @test "using aria2c if available" {
+  export PYTHON_BUILD_HTTP_CLIENT="aria2c"
   stub aria2c "--allow-overwrite=true --no-conf=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$4"
 
   install_fixture definitions/without-checksum

--- a/plugins/python-build/test/mirror.bats
+++ b/plugins/python-build/test/mirror.bats
@@ -5,10 +5,7 @@ export PYTHON_BUILD_SKIP_MIRROR=
 export PYTHON_BUILD_CACHE_PATH=
 export PYTHON_BUILD_MIRROR_URL=http://mirror.example.com
 export PYTHON_BUILD_CURL_OPTS=
-
-setup() {
-  ensure_not_found_in_path aria2c
-}
+export PYTHON_BUILD_HTTP_CLIENT="curl"
 
 
 @test "package URL without checksum bypasses mirror" {

--- a/plugins/python-build/test/mirror.bats
+++ b/plugins/python-build/test/mirror.bats
@@ -4,8 +4,6 @@ load test_helper
 export PYTHON_BUILD_SKIP_MIRROR=
 export PYTHON_BUILD_CACHE_PATH=
 export PYTHON_BUILD_MIRROR_URL=http://mirror.example.com
-export PYTHON_BUILD_CURL_OPTS=
-export PYTHON_BUILD_HTTP_CLIENT="curl"
 
 
 @test "package URL without checksum bypasses mirror" {

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -5,11 +5,11 @@ export PYTHON_BUILD_CACHE_PATH="$TMP/cache"
 export MAKE=make
 export MAKE_OPTS="-j 2"
 export CC=cc
+export PYTHON_BUILD_HTTP_CLIENT="curl"
 
 export TMP_FIXTURES="$TMP/fixtures"
 
 setup() {
-  ensure_not_found_in_path aria2c
   mkdir -p "$INSTALL_ROOT"
   stub md5 false
   stub curl false

--- a/plugins/python-build/test/test_helper.bash
+++ b/plugins/python-build/test/test_helper.bash
@@ -1,4 +1,6 @@
 export TMP="$BATS_TEST_DIRNAME/tmp"
+export RUBY_BUILD_CURL_OPTS=
+export RUBY_BUILD_HTTP_CLIENT="curl"
 
 if [ "$FIXTURE_ROOT" != "$BATS_TEST_DIRNAME/fixtures" ]; then
   export FIXTURE_ROOT="$BATS_TEST_DIRNAME/fixtures"

--- a/plugins/python-build/test/test_helper.bash
+++ b/plugins/python-build/test/test_helper.bash
@@ -9,35 +9,6 @@ if [ "$FIXTURE_ROOT" != "$BATS_TEST_DIRNAME/fixtures" ]; then
   export PATH
 fi
 
-remove_command_from_path() {
-  OLDIFS="${IFS}"
-  local cmd="$1"
-  local path
-  local paths=()
-  IFS=:
-  for path in ${PATH}; do
-    if [ -e "${path}/${cmd}" ]; then
-      local tmp_path="$(mktemp -d "${TMP}/path.XXXXX")"
-      ln -fs "${path}"/* "${tmp_path}"
-      rm -f "${tmp_path}/${cmd}"
-      paths["${#paths[@]}"]="${tmp_path}"
-    else
-      paths["${#paths[@]}"]="${path}"
-    fi
-  done
-  export PATH="${paths[*]}"
-  IFS="${OLDIFS}"
-}
-
-ensure_not_found_in_path() {
-  local cmd
-  for cmd; do
-    if command -v "${cmd}" 1>/dev/null 2>&1; then
-      remove_command_from_path "${cmd}"
-    fi
-  done
-}
-
 teardown() {
   rm -fr "${TMP:?}"/*
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,5 +1,6 @@
 unset PYENV_VERSION
 unset PYENV_DIR
+unset PYTHON_BUILD_HTTP_CLIENT
 
 # guard against executing this block twice due to bats internals
 if [ -z "$PYENV_TEST_DIR" ]; then

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,6 +1,5 @@
 unset PYENV_VERSION
 unset PYENV_DIR
-unset PYTHON_BUILD_HTTP_CLIENT
 
 # guard against executing this block twice due to bats internals
 if [ -z "$PYENV_TEST_DIR" ]; then


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
  * This is core functionality of python-build plugin and needs to be implemented in its plugin code
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from this project.
  * We are occasionally importing the changes from rbenv. In general, you can expect some changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we sometimes don't prefer to make some change in the core to keep compatibility with rbenv.
  * https://github.com/rbenv/ruby-build/pull/1198
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1126

### Description
- [x] Here are some details about my PR

Let python-build to pick up HTTP client without relying on the commands in `$PATH`. Since pyenv is using shim script architecture, checking availability of some command based on the presence doesn't make sense.

This effectively allows user to use custom arbitrary HTTP client without relying on python-build's code. It might be better to do some extra refactoring the code around there.

### Tests
- [x] My PR adds the following unit tests (if any)
  * <del>will do</del> rewritten some tests with using `PYTHON_BUILD_HTTP_CLIENT`