### PR TITLE
Address #273 via a patch from python#21811

### DIFF
--- a/plugins/python-build/share/python-build/patches/2.7.6/Python-2.7.6/012_fix_bundle_loader_for_new_osx.patch
+++ b/plugins/python-build/share/python-build/patches/2.7.6/Python-2.7.6/012_fix_bundle_loader_for_new_osx.patch
@@ -1,0 +1,58 @@
+diff -ur ../Python-2.7.6/configure ./configure
+--- ../Python-2.7.6/configure 2014-06-19 14:35:59.000000000 -0400
++++ ./configure	2018-04-24 12:44:24.143179222 -0400
+@@ -6045,8 +6045,14 @@
+ 
+ 	    # Calculate the right deployment target for this build.
+ 	    #
+-	    cur_target=`sw_vers -productVersion | sed 's/\(10\.[0-9]*\).*/\1/'`
+-	    if test ${cur_target} '>' 10.2; then
++		cur_target_major=`sw_vers -productVersion | \
++				sed 's/\([0-9]*\)\.\([0-9]*\).*/\1/'`
++		cur_target_minor=`sw_vers -productVersion | \
++				sed 's/\([0-9]*\)\.\([0-9]*\).*/\2/'`
++		cur_target="${cur_target_major}.${cur_target_minor}"
++		if test ${cur_target_major} -eq 10 && \
++		   test ${cur_target_minor} -ge 3
++		then
+ 		    cur_target=10.3
+ 		    if test ${enable_universalsdk}; then
+ 			    if test "${UNIVERSAL_ARCHS}" = "all"; then
+@@ -8230,15 +8236,14 @@
+ 		# Use -undefined dynamic_lookup whenever possible (10.3 and later).
+ 		# This allows an extension to be used in any Python
+ 
+-		if test ${MACOSX_DEPLOYMENT_TARGET} '>' 10.2
++		dep_target_major=`echo ${MACOSX_DEPLOYMENT_TARGET} | \
++				sed 's/\([0-9]*\)\.\([0-9]*\).*/\1/'`
++		dep_target_minor=`echo ${MACOSX_DEPLOYMENT_TARGET} | \
++				sed 's/\([0-9]*\)\.\([0-9]*\).*/\2/'`
++		if test ${dep_target_major} -eq 10 && \
++		   test ${dep_target_minor} -le 2
+ 		then
+-			if test "${enable_universalsdk}"; then
+-				LDFLAGS="${UNIVERSAL_ARCH_FLAGS} -isysroot ${UNIVERSALSDK} ${LDFLAGS}"
+-			fi
+-			LDSHARED='$(CC) -bundle -undefined dynamic_lookup'
+-			LDCXXSHARED='$(CXX) -bundle -undefined dynamic_lookup'
+-			BLDSHARED="$LDSHARED"
+-		else
++			# building for OS X 10.0 through 10.2
+ 			LDSHARED='$(CC) -bundle'
+ 			LDCXXSHARED='$(CXX) -bundle'
+ 			if test "$enable_framework" ; then
+@@ -8252,6 +8257,14 @@
+ 				LDSHARED="$LDSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
+ 				LDCXXSHARED="$LDCXXSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
+ 			fi
++		else
++			# building for OS X 10.3 and later
++			if test "${enable_universalsdk}"; then
++				LDFLAGS="${UNIVERSAL_ARCH_FLAGS} -isysroot ${UNIVERSALSDK} ${LDFLAGS}"
++			fi
++			LDSHARED='$(CC) -bundle -undefined dynamic_lookup'
++			LDCXXSHARED='$(CXX) -bundle -undefined dynamic_lookup'
++			BLDSHARED="$LDSHARED"
+ 		fi
+ 		;;
+ 	Linux*|GNU*|QNX*)


### PR DESCRIPTION
### Prerequisite
* [NA] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [NA] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from this project.
  * We are occasionally importing the changes from rbenv. In general, you can expect some changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we sometimes don't prefer to make some change in the core to keep compatibility with rbenv.
* [X] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/273

### Description

#273 was closed since it was a defect in old python, not pyenv. However, pyenv's patching system allows us to work around that defect so that extension bundles can be built on newer OSX distributions. This PR adds support for that; I hope the issue can be reopened and resolved via this PR.

**There is a lot of code in the patch file, but I didn't hand-write any of it.** In the #273 discussion thread, the python issue that causes this behavior is linked: https://bugs.python.org/issue21811; in order to implement this PR, I did the following:

- Downloaded the 2.7.6 sources used by pyenv.
- Applied the patch to the `configure.ac` file from that issue: https://bugs.python.org/file35698/issue_21811_yosemite_support_configure_27.patch
- Ran `autoreconf` on those sources (Homebrew-installed GNU autoconf 2.69).
- Took a diff of the resulting `configure` file and turned it into this patch.

Other Pythons may also benefit from this change. I've been cautious and just applied it to 2.7.6, since that is the platform on which I am developing and testing. I can confirm that I have experienced no issues with extension modules built with this patch in my development.

If pyenv maintainers want me to do the above patch process for other versions I am happy to do that.

### Tests
I have tested the various install issues in the #273 discussion thread. None of them reoccur with this PR's changes, and the post-install `sed` statements suggested are no longer necessary.

`bats test` has 2 failures for me on a clean master checkout. The failures are no different with this branch's changes.