### PR TITLE
Remove shebang lines from scripts for performance

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -e
 
 if [ "$1" = "--debug" ]; then

--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 set -e
 
 if [ "$1" = "--debug" ]; then

--- a/libexec/pyenv---version
+++ b/libexec/pyenv---version
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Summary: Display the version of pyenv
 #
 # Displays the version number of this pyenv release, including the

--- a/libexec/pyenv-commands
+++ b/libexec/pyenv-commands
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Summary: List all available pyenv commands
 # Usage: pyenv commands [--sh|--no-sh]
 

--- a/libexec/pyenv-completions
+++ b/libexec/pyenv-completions
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Usage: pyenv completions <command> [arg1 arg2...]
 
 set -e

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: Run an executable with the selected Python version
 #
 # Usage: pyenv exec <command> [arg1 arg2...]

--- a/libexec/pyenv-global
+++ b/libexec/pyenv-global
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: Set or show the global Python version
 #
 # Usage: pyenv global <version>

--- a/libexec/pyenv-help
+++ b/libexec/pyenv-help
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: Display help for a command
 #
 # Usage: pyenv help [--usage] COMMAND

--- a/libexec/pyenv-hooks
+++ b/libexec/pyenv-hooks
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Summary: List hook scripts for a given pyenv command
 # Usage: pyenv hooks <command>
 

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Summary: Configure the shell environment for pyenv
 # Usage: eval "$(pyenv init - [--no-rehash] [<shell>])"
 

--- a/libexec/pyenv-local
+++ b/libexec/pyenv-local
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: Set or show the local application-specific Python version
 #
 # Usage: pyenv local <version>

--- a/libexec/pyenv-prefix
+++ b/libexec/pyenv-prefix
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Summary: Display prefix for a Python version
 # Usage: pyenv prefix [<version>]
 #

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Summary: Rehash pyenv shims (run this after installing executables)
 
 set -e
@@ -62,7 +61,6 @@ fi
 # serves as a locking mechanism.
 create_prototype_shim() {
   cat > "$PROTOTYPE_SHIM_PATH" <<SH
-#!/usr/bin/env bash
 set -e
 [ -n "\$PYENV_DEBUG" ] && set -x
 

--- a/libexec/pyenv-root
+++ b/libexec/pyenv-root
@@ -1,3 +1,2 @@
-#!/usr/bin/env bash
 # Summary: Display the root directory where versions and shims are kept
 echo "$PYENV_ROOT"

--- a/libexec/pyenv-sh-rehash
+++ b/libexec/pyenv-sh-rehash
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 

--- a/libexec/pyenv-sh-shell
+++ b/libexec/pyenv-sh-shell
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: Set or show the shell-specific Python version
 #
 # Usage: pyenv shell <version>...

--- a/libexec/pyenv-shims
+++ b/libexec/pyenv-shims
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Summary: List existing pyenv shims
 # Usage: pyenv shims [--short]
 

--- a/libexec/pyenv-version
+++ b/libexec/pyenv-version
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Summary: Show the current Python version and its origin
 #
 # Shows the currently selected Python version and how it was

--- a/libexec/pyenv-version-file
+++ b/libexec/pyenv-version-file
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Usage: pyenv version-file [<dir>]
 # Summary: Detect the file that sets the current pyenv version
 set -e

--- a/libexec/pyenv-version-file-read
+++ b/libexec/pyenv-version-file-read
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Usage: pyenv version-file-read <file>
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x

--- a/libexec/pyenv-version-file-write
+++ b/libexec/pyenv-version-file-write
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Usage: pyenv version-file-write <file> <version>
 
 set -e

--- a/libexec/pyenv-version-name
+++ b/libexec/pyenv-version-name
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Summary: Show the current Python version
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x

--- a/libexec/pyenv-version-origin
+++ b/libexec/pyenv-version-origin
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Summary: Explain how the current Python version is set
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x

--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Summary: List all Python versions available to pyenv
 # Usage: pyenv versions [--bare] [--skip-aliases]
 #

--- a/libexec/pyenv-whence
+++ b/libexec/pyenv-whence
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Summary: List all Python versions that contain the given executable
 # Usage: pyenv whence [--path] <command>
 

--- a/libexec/pyenv-which
+++ b/libexec/pyenv-which
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: Display the full path to an executable
 #
 # Usage: pyenv which <command>

--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: Install a Python version using python-build
 #
 # Usage: pyenv install [-f] [-kvp] <version>

--- a/plugins/python-build/bin/pyenv-uninstall
+++ b/plugins/python-build/bin/pyenv-uninstall
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Summary: Uninstall a specific Python version
 #
 # Usage: pyenv uninstall [-f|--force] <version>

--- a/plugins/python-build/test/stubs/stub
+++ b/plugins/python-build/test/stubs/stub
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 set -e
 
 status=0

--- a/pyenv.d/exec/pip-rehash/conda
+++ b/pyenv.d/exec/pip-rehash/conda
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 

--- a/pyenv.d/exec/pip-rehash/easy_install
+++ b/pyenv.d/exec/pip-rehash/easy_install
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 

--- a/pyenv.d/exec/pip-rehash/pip
+++ b/pyenv.d/exec/pip-rehash/pip
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 

--- a/test/init.bats
+++ b/test/init.bats
@@ -35,7 +35,7 @@ load test_helper
   cd "$PYENV_TEST_DIR"
   cat > myscript.sh <<OUT
 #!/bin/sh
-eval "\$(pyenv-init -)"
+eval "\$(pyenv init -)"
 echo \$PYENV_SHELL
 OUT
   chmod +x myscript.sh

--- a/test/libexec/pyenv-echo
+++ b/test/libexec/pyenv-echo
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Usage: pyenv echo [-F<char>] VAR
 
 if [[ $1 == -F* ]]; then


### PR DESCRIPTION
All scripts in libexec/ (excluding pyenv) are called through pyenv,
therefore the shebang lines are not necessary. On some systems this
provides a measurable increase in performance of the shell prompt.

Related to pyenv/pyenv-virtualenv#259

On my system this removes 1050ms of runtime from `pyenv sh-activate --quiet`.
