### PR TITLE
[WIP] libexec/pyenv: skip `cd`s

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -71,9 +71,6 @@ if [ -z "${PYENV_DIR}" ]; then
   fi
 else
   [[ $PYENV_DIR == /* ]] || PYENV_DIR="$PWD/$PYENV_DIR"
-  cd "$PYENV_DIR" 2>/dev/null || abort "cannot change working directory to \`$PYENV_DIR'"
-  PYENV_DIR="$PWD"
-  cd "$OLDPWD"
 fi
 
 if [ -z "${PYENV_DIR}" ]; then


### PR DESCRIPTION
This appears to be done to get the resolved name for `$PYENV_DIR`, but
that is not really necessary.

And its existence is checked below.

After doing this I found 19e2b95 (which added no tests?), and that we still have the `cd` in https://github.com/pyenv/pyenv/compare/master...blueyed:no-cd?expand=1#diff-414cbe2ca9ee5fbfdc48e82392f82db7L87 (with an additional subshell).

I think a test for what 19e2b95 fixed should be added, and the extra `PYENV_DIR=$(cd "$PYENV_DIR" && echo "$PWD")` removed then if possible.

/cc @zachriggle 

Upstream: https://github.com/rbenv/rbenv/pull/1085