### PR TITLE
python-build: add anaconda[23]-5.2.0

### DIFF
--- a/plugins/python-build/share/python-build/anaconda2-5.2.0
+++ b/plugins/python-build/share/python-build/anaconda2-5.2.0
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Anaconda2-5.2.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda2-5.2.0-Linux-x86.sh#402758c24767e9eb3b77312c388725a058f76e03316464797c3ca404e6eebc2c" "anaconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda2-5.2.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda2-5.2.0-Linux-x86_64.sh#cb0d7a08b0e2cec4372033d3269979b4e72e2353ffd1444f57cb38bc9621219f" "anaconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda2-5.2.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda2-5.2.0-MacOSX-x86_64.sh#d7d46e566306da5979cd5632079497fe6103b980e3a089ccf27a9f30cbee84dc" "anaconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda2 is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/anaconda3-5.2.0
+++ b/plugins/python-build/share/python-build/anaconda3-5.2.0
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Anaconda3-5.2.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda3-5.2.0-Linux-x86.sh#f3527d085d06f35b6aeb96be2a9253ff9ec9ced3dc913c8e27e086329f3db588" "anaconda" verify_py36
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda3-5.2.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-5.2.0-Linux-x86_64.sh#09f53738b0cd3bb96f5b1bac488e5528df9906be2480fe61df40e0e0d19e3d48" "anaconda" verify_py36
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda3-5.2.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-5.2.0-MacOSX-x86_64.sh#c8089121dc89ffe8f9a0c01205bab75a112821a13d413152d6690f5eef094afa" "anaconda" verify_py36
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda3 is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from this project.
  * We are occasionally importing the changes from rbenv. In general, you can expect some changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we sometimes don't prefer to make some change in the core to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)

### Description
- [x] Here are some details about my PR

This PR consists of a single commit adding two new files, which allow the user to install both **Anaconda2 5.2.0** and **Anaconda3 5.2.0** for macOS (64 bit) and Linux (both 32 and 64 bit).

The only one of the six Anaconda installation scripts (**Anaconda3 5.2.0**) has been tested only on macOS to see if it is installable, but every other script should also work properly on each OS platform; please check if they are installable with the other possible scripts and OSs combinations.

The SHA-256 checksum for each Anaconda shell file is copied from the following pages:

- https://docs.anaconda.com/anaconda/install/hashes/Anaconda2-5.2.0-Linux-x86.sh-hash
- https://docs.anaconda.com/anaconda/install/hashes/Anaconda2-5.2.0-Linux-x86_64.sh-hash
- https://docs.anaconda.com/anaconda/install/hashes/Anaconda2-5.2.0-MacOSX-x86_64.sh-hash
- https://docs.anaconda.com/anaconda/install/hashes/Anaconda3-5.2.0-Linux-x86.sh-hash
- https://docs.anaconda.com/anaconda/install/hashes/Anaconda3-5.2.0-Linux-x86_64.sh-hash
- https://docs.anaconda.com/anaconda/install/hashes/Anaconda3-5.2.0-MacOSX-x86_64.sh-hash

### Tests
- [x] My PR adds the following unit tests (if any)

As mentioned in the section above, I have only checked one of the six Anaconda installation scripts, which is **Anaconda3 5.2.0** on macOS (10.12.6). But I believe five of the other scripts should work on each OS platform.

Just to mention that I did quadruple-check to make sure the SHA-256 checksum for each Anaconda shell file is properly copied and pasted from the pages listed above to the newly added `anaconda2-5.2.0` and `anaconda3-5.2.0` files (they are the renamed duplicates of its predecessor files, i.e. `anaconda2-5.1.0` and `anaconda3-5.1.0`). For this reason, I believe they all should work fine (unless copy-and-pasting was wrongly done by me, even after the quadruple-checks).

---

### Message from the contributor

Please review my commit(s) and if necessary, rectify as appropriate.

Thank you!

sho