### PR TITLE
pyenv-exec: do not use `exec -a`, do not mangle PATH for system Python

### DIFF
--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -41,7 +41,8 @@ for script in "${scripts[@]}"; do
 done
 
 shift 1
-# CPython's `sys.executable` requires the `PYENV_BIN_PATH` to be at the top of the `PATH`.
-# https://github.com/pyenv/pyenv/issues/98
-export PATH="${PYENV_BIN_PATH}:${PATH}"
-exec -a "$PYENV_COMMAND" "$PYENV_COMMAND_PATH" "$@"
+if [ "${PYENV_BIN_PATH#${PYENV_ROOT}}" != "${PYENV_BIN_PATH}" ]; then
+  # Only add to $PATH for non-system version.
+  export PATH="${PYENV_BIN_PATH}:${PATH}"
+fi
+exec "$PYENV_COMMAND_PATH" "$@"

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -77,3 +77,39 @@ ${PYENV_ROOT}/versions/3.4/bin/python
   args
 OUT
 }
+
+@test "sys.executable with system version (#98)" {
+  system_python=$(which python)
+
+  PYENV_VERSION="custom"
+  create_executable "python" ""
+  unset PYENV_VERSION
+
+  pyenv-rehash
+  run pyenv-exec python -c 'import sys; print(sys.executable)'
+  assert_success "${system_python}"
+}
+
+@test '$PATH is not modified with system Python' {
+  # Create a wrapper executable that verifies PATH.
+  PYENV_VERSION="custom"
+  create_executable "python" '[[ "$PATH" == "${PYENV_TEST_DIR}/root/versions/custom/bin:"* ]] || { echo "unexpected:$PATH"; exit 2;}'
+  unset PYENV_VERSION
+  pyenv-rehash
+
+  # Path is not modified with system Python.
+  run pyenv-exec python -c 'import os; print(os.getenv("PATH"))'
+  assert_success "$PATH"
+
+  # Path is modified with custom Python.
+  PYENV_VERSION=custom run pyenv-exec python
+  assert_success
+
+  # Path is modified with custom:system Python.
+  PYENV_VERSION=custom:system run pyenv-exec python
+  assert_success
+
+  # Path is not modified with system:custom Python.
+  PYENV_VERSION=system:custom run pyenv-exec python -c 'import os; print(os.getenv("PATH"))'
+  assert_success "$PATH"
+}


### PR DESCRIPTION
Fixes https://github.com/pyenv/pyenv/issues/789.
Ref: #98.