### PR TITLE
Check wget version iff wget is going to be used (again)

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -339,6 +339,11 @@ http() {
     elif type curl &>/dev/null; then
       http_client="http_${method}_curl"
     elif type wget &>/dev/null; then
+      # SSL Certificate error with older wget that does not support Server Name Indication (#60)
+      if [[ "$(wget --version 2>/dev/null || true)" = "GNU Wget 1.1"[0-3]* ]]; then
+        echo "python-build: wget (< 1.14) doesn't support Server Name Indication. Please install curl (>= 7.18.1) and try again" >&2
+        return 1
+      fi
       http_client="http_${method}_wget"
     else
       echo "error: please install \`aria2c\`, \`curl\` or \`wget\` and try again" >&2
@@ -2039,14 +2044,6 @@ fi
 ARIA2_OPTS="${PYTHON_BUILD_ARIA2_OPTS} ${IPV4+--disable-ipv6=true} ${IPV6+--disable-ipv6=false}"
 CURL_OPTS="${PYTHON_BUILD_CURL_OPTS} ${IPV4+--ipv4} ${IPV6+--ipv6}"
 WGET_OPTS="${PYTHON_BUILD_WGET_OPTS} ${IPV4+--inet4-only} ${IPV6+--inet6-only}"
-
-if [ -z "${PYTHON_BUILD_HTTP_CLIENT}" ] && ! type aria2c &>/dev/null && ! type curl &>/dev/null; then
-  # SSL Certificate error with older wget that does not support Server Name Indication (#60)
-  if [[ "$(wget --version 2>/dev/null || true)" = "GNU Wget 1.1"[0-3]* ]]; then
-    echo "python-build: wget (< 1.14) doesn't support Server Name Indication. Please install curl (>= 7.18.1) and try again" >&2
-    return 1
-  fi
-fi
 
 # Add an option to build a debug version of Python (#11)
 if [ -n "$DEBUG" ]; then


### PR DESCRIPTION
This modification is reapplying #1051 4ebba7cd5f33386e1ddbffe9e020be20f229c509 , which is (accidently?) reverted by #1146 fc90785f75461b8eb67b0a9c3d74f1e4932c9c6f

We need this on supercomputer's computing node which is offline but has only old wget