### PR TITLE
[WIP/RFC]: use separate shim paths per version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+.python-version
+.vscode/
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Version History
 
+## 1.2.22
+
++ python-build: Add LDFLAGS for zlib on macOS >= 1100 (#1711)
++ python-build: Add the CPython 3.9.1 (#1752)
++ python-build: Change order of LDFLAGS paths (#1754)
++ python-build: Docker config for testing python-build (#1548)
++ python-build: Put prerequisite for installation before install (#1750)
++ python-build: Add GraalPython 20.3 (#1736)
++ python-build: Add CPython 3.8.7
++ python-build: Added anaconda3-2020.11 (#1774)
++ python-build: Added arm64 architecture support in python-build for macOS  (#1775)
+
 ## 1.2.21
 
 * python-build: Add CPython 3.9.0 (#1706)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:18.04
+
+LABEL maintainer="Chris L. Barnes <chrislloydbarnes@gmail.com>"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y \
+    && apt-get install -y \
+        make \
+        build-essential \
+        libssl-dev \
+        zlib1g-dev \
+        libbz2-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        wget \
+        curl \
+        llvm \
+        libncurses5-dev \
+        libncursesw5-dev \
+        xz-utils \
+        tk-dev \
+        libffi-dev \
+        liblzma-dev \
+        python-openssl \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PYENV_ROOT "/pyenv"
+ENV PATH "$PYENV_ROOT/bin:$PATH"
+
+COPY . /pyenv
+
+RUN eval "$(pyenv init -)"
+

--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ We'd recommend to install pyenv-virtualenv as well if you have some plan to play
 
 ## Installation
 
+### Prerequisites:
+
+For pyenv to install python correctly you should [**install the Python build dependencies**](https://github.com/pyenv/pyenv/wiki#suggested-build-environment).
+
 ### Homebrew on macOS
 
    1. Consider installing with [Homebrew](https://brew.sh)

--- a/README.md
+++ b/README.md
@@ -232,12 +232,26 @@ easy to fork and contribute any changes back upstream.
 3. **Add `pyenv init` to your shell** to enable shims and autocompletion.
    Please make sure `eval "$(pyenv init -)"` is placed toward the end of the shell
    configuration file since it manipulates `PATH` during the initialization.
-    ```sh
-    echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
-    ```
-    - **Zsh note**: Modify your `~/.zshrc` file instead of `~/.bash_profile`.
-    - **fish note**: Use `pyenv init - | source` instead of `eval (pyenv init -)`.
-    - **Ubuntu and Fedora note**: Modify your `~/.bashrc` file instead of `~/.bash_profile`.
+
+   - For **bash**:
+     ~~~ bash
+     echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
+     ~~~
+
+   - For **Ubuntu Desktop** and **Fedora**:
+     ~~~ bash
+     echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+     ~~~
+
+   - For **Zsh**:
+     ~~~ zsh
+     echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
+     ~~~
+
+   - For **Fish shell**:
+     ~~~ fish
+     echo -e '\n\n# pyenv init\nif command -v pyenv 1>/dev/null 2>&1\n  pyenv init - | source\nend' >> ~/.config/fish/config.fish
+     ~~~
 
     **General warning**: There are some systems where the `BASH_ENV` variable is configured
     to point to `.bashrc`. On such systems you should almost certainly put the above mentioned line

--- a/libexec/pyenv---version
+++ b/libexec/pyenv---version
@@ -12,7 +12,7 @@
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
-version="1.2.21"
+version="1.2.22"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q pyenv; then

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Summary: Configure the shell environment for pyenv
-# Usage: eval "$(pyenv init - [--no-rehash] [<shell>])"
+# Usage: eval "$(pyenv init - [<shell>])"
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
@@ -8,7 +8,6 @@ set -e
 # Provide pyenv completions
 if [ "$1" = "--complete" ]; then
   echo -
-  echo --no-rehash
   echo bash
   echo fish
   echo ksh
@@ -17,7 +16,6 @@ if [ "$1" = "--complete" ]; then
 fi
 
 print=""
-no_rehash=""
 for args in "$@"
 do
   if [ "$args" = "-" ]; then
@@ -26,7 +24,7 @@ do
   fi
 
   if [ "$args" = "--no-rehash" ]; then
-    no_rehash=1
+    # Ignored, for backward-compatibility.
     shift
   fi
 done
@@ -98,10 +96,6 @@ esac
 completion="${root}/completions/pyenv.${shell}"
 if [ -r "$completion" ]; then
   echo "source '$completion'"
-fi
-
-if [ -z "$no_rehash" ]; then
-  echo 'command pyenv rehash 2>/dev/null'
 fi
 
 commands=(`pyenv-commands --sh`)

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -4,7 +4,9 @@
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
-SHIM_PATH="${PYENV_ROOT}/shims"
+SHIM_PATH=${PYENV_SHIM_PATH:-"${PYENV_ROOT}/shims/$(pyenv-version-name)"}
+# For debugging/feedback.  TODO: remove
+echo "pyenv-rehash: using $SHIM_PATH" >&2
 PROTOTYPE_SHIM_PATH="${SHIM_PATH}/.pyenv-shim"
 
 # Create the shims directory if it doesn't already exist.
@@ -82,6 +84,7 @@ if [[ "\$program" = "python"* ]]; then
 fi
 
 export PYENV_ROOT="$PYENV_ROOT"
+export PYENV_SHIM="\$0"
 exec "$(command -v pyenv)" exec "\$program" "\$@"
 SH
   chmod +x "$PROTOTYPE_SHIM_PATH"
@@ -94,17 +97,25 @@ remove_outdated_shims() {
   local shim
   for shim in "$SHIM_PATH"/*; do
     if ! diff "$PROTOTYPE_SHIM_PATH" "$shim" >/dev/null 2>&1; then
-      rm -f "$SHIM_PATH"/*
+      # NOTE: does not use "rm …/*", since there might be directories now.
+      for file in "$SHIM_PATH"/*; do
+        if [[ -f "$file" ]]; then
+          rm "$file"
+        fi
+      done
     fi
     break
   done
 }
 
-# List basenames of executables for every Python version
+# List basenames of executables for the current Python version(s).
 list_executable_names() {
   local version file
-  pyenv-versions --bare --skip-aliases | \
-  while read -r version; do
+  OLDIFS="$IFS"
+  # shellcheck disable=SC2207
+  IFS=: versions=($(pyenv-version-name))
+  IFS="$OLDIFS"
+  for version in "${versions[@]}"; do
     for file in "${PYENV_ROOT}/versions/${version}/bin/"*; do
       echo "${file##*/}"
     done
@@ -145,8 +156,8 @@ install_registered_shims() {
 remove_stale_shims() {
   local shim
   for shim in "$SHIM_PATH"/*; do
-    if [[ "$registered_shims" != *" ${shim##*/} "* ]]; then
-      rm -f "$shim"
+    if [[ -f "$shim" ]] && [[ "$registered_shims" != *" ${shim##*/} "* ]]; then
+      rm "$shim"
     fi
   done
 }

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -4,7 +4,9 @@
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
-SHIM_PATH=${PYENV_SHIM_PATH:-"${PYENV_ROOT}/shims/$(pyenv-version-name)"}
+version_name="$(pyenv-version-name)"
+# NOTE: replacement also done in updated_path_for_shims
+SHIM_PATH="${PYENV_ROOT}/shims/${version_name//:/_}"
 if [ "$SHIM_PATH" = "${PYENV_ROOT}/shims/system" ]; then
   # Note: this might lead to infinite loops, e.g. with pyenv-which-ext, which
   # uses an old method of removing shims from PATH.

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -5,6 +5,12 @@ set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
 SHIM_PATH=${PYENV_SHIM_PATH:-"${PYENV_ROOT}/shims/$(pyenv-version-name)"}
+if [ "$SHIM_PATH" = "${PYENV_ROOT}/shims/system" ]; then
+  # Note: this might lead to infinite loops, e.g. with pyenv-which-ext, which
+  # uses an old method of removing shims from PATH.
+  echo 'pyenv-rehash: should not be used with "system" version' >&2
+  exit 1
+fi
 # For debugging/feedback.  TODO: remove
 echo "pyenv-rehash: using $SHIM_PATH" >&2
 PROTOTYPE_SHIM_PATH="${SHIM_PATH}/.pyenv-shim"

--- a/libexec/pyenv-sh-shell
+++ b/libexec/pyenv-sh-shell
@@ -52,6 +52,9 @@ updated_path_for_shims() {
     echo "PATH=${result#:}"
     # for debug/feedback.  TODO: remove
     echo "pyenv: updated PATH for $version" >&2
+    if ! [ -d "$new_shims_dir" ]; then
+      PYENV_VERSION="$version" "$PYENV_ROOT/libexec/pyenv-rehash"
+    fi
   fi
 }
 

--- a/libexec/pyenv-sh-shell
+++ b/libexec/pyenv-sh-shell
@@ -29,7 +29,7 @@ if [ "$1" = "--complete" ]; then
   exec pyenv-versions --bare
 fi
 
-update_path_for_shims() {
+updated_path_for_shims() {
   local version="$1"
   # Replace shims dir in PATH.
   shims_base_dir="$PYENV_ROOT/shims"
@@ -43,15 +43,24 @@ update_path_for_shims() {
     result="${result/:${shims_base_dir}*([^:]):/:$new_shims_dir:}"
   done
   result="${result%:}"
-  echo "${result#:}"
 
   if [[ "$result" == "$PATH" ]]; then
     echo "pyenv: warning: PATH was not changed: $shims_base_dir not found" >&2
   else
+    echo "PATH=${result#:}"
     # for debug/feedback.  TODO: remove
     echo "pyenv: updated PATH for $version" >&2
   fi
 }
+
+if [[ "$1" = "--updated-path" ]]; then
+  if [[ -z "$2" ]]; then
+    echo 'pyenv-sh-shell: missing version with --updated-path' >&2
+    exit 1
+  fi
+  updated_path_for_shims "$2"
+  exit
+fi
 
 versions=("$@")
 shell="$(basename "${PYENV_SHELL:-$SHELL}")"
@@ -75,7 +84,7 @@ if [ "$versions" = "--unset" ]; then
   * )
     echo 'PYENV_VERSION_OLD="$PYENV_VERSION"'
     echo "unset PYENV_VERSION"
-    echo "PATH=$(update_path_for_shims "$(PYENV_VERSION='' pyenv-version-name)")"
+    updated_path_for_shims "$(PYENV_VERSION='' pyenv-version-name)"
     ;;
   esac
   exit
@@ -137,7 +146,7 @@ if pyenv-prefix "${versions[@]}" >/dev/null; then
     * )
       echo 'PYENV_VERSION_OLD="$PYENV_VERSION"'
       echo "export PYENV_VERSION=\"${version}\""
-      echo "PATH=$(update_path_for_shims $version)"
+      updated_path_for_shims "$version"
       ;;
     esac
   fi

--- a/libexec/pyenv-sh-shell
+++ b/libexec/pyenv-sh-shell
@@ -33,7 +33,9 @@ updated_path_for_shims() {
   local version="$1"
   # Replace shims dir in PATH.
   shims_base_dir="$PYENV_ROOT/shims"
-  new_shims_dir="$shims_base_dir/$version"
+  # Replace colon (reserved/difficult in PATH).
+  # TODO: more unique?  Could something be used that is invalid in version names? ("+"?)
+  new_shims_dir="$shims_base_dir/${version//:/_}"
 
   # based on remove_from_path
   result=":${PATH//\~/$HOME}:"

--- a/libexec/pyenv-sh-shell
+++ b/libexec/pyenv-sh-shell
@@ -29,6 +29,30 @@ if [ "$1" = "--complete" ]; then
   exec pyenv-versions --bare
 fi
 
+update_path_for_shims() {
+  local version="$1"
+  # Replace shims dir in PATH.
+  shims_base_dir="$PYENV_ROOT/shims"
+  new_shims_dir="$shims_base_dir/$version"
+
+  # based on remove_from_path
+  result=":${PATH//\~/$HOME}:"
+  shopt -s extglob
+  while [ "$path_before" != "$result" ]; do
+    path_before="$result"
+    result="${result/:${shims_base_dir}*([^:]):/:$new_shims_dir:}"
+  done
+  result="${result%:}"
+  echo "${result#:}"
+
+  if [[ "$result" == "$PATH" ]]; then
+    echo "pyenv: warning: PATH was not changed: $shims_base_dir not found" >&2
+  else
+    # for debug/feedback.  TODO: remove
+    echo "pyenv: updated PATH for $version" >&2
+  fi
+}
+
 versions=("$@")
 shell="$(basename "${PYENV_SHELL:-$SHELL}")"
 
@@ -51,6 +75,7 @@ if [ "$versions" = "--unset" ]; then
   * )
     echo 'PYENV_VERSION_OLD="$PYENV_VERSION"'
     echo "unset PYENV_VERSION"
+    echo "PATH=$(update_path_for_shims "$(PYENV_VERSION='' pyenv-version-name)")"
     ;;
   esac
   exit
@@ -112,25 +137,7 @@ if pyenv-prefix "${versions[@]}" >/dev/null; then
     * )
       echo 'PYENV_VERSION_OLD="$PYENV_VERSION"'
       echo "export PYENV_VERSION=\"${version}\""
-
-      # Replace shims dir in PATH.
-      shims_base_dir="$PYENV_ROOT/shims"
-      new_shims_dir="$shims_base_dir/$version"
-
-      # based on remove_from_path
-      result=":${PATH//\~/$HOME}:"
-      shopt -s extglob
-      while [ "$path_before" != "$result" ]; do
-        path_before="$result"
-        result="${result/:${shims_base_dir}*([^:]):/:$new_shims_dir:}"
-      done
-      result="${result%:}"
-      new_path="${result#:}"
-
-      if [[ "$new_path" == "$PATH" ]]; then
-        echo "pyenv: warning: PATH was not changed: $old_shims_dir not found" >&2
-      fi
-      echo "PATH=$new_path"
+      echo "PATH=$(update_path_for_shims $version)"
       ;;
     esac
   fi

--- a/libexec/pyenv-sh-shell
+++ b/libexec/pyenv-sh-shell
@@ -58,12 +58,12 @@ updated_path_for_shims() {
   fi
 }
 
-if [[ "$1" = "--updated-path" ]]; then
+if [[ "$1" = "--update-path" ]]; then
+  version="$2"
   if [[ -z "$2" ]]; then
-    echo 'pyenv-sh-shell: missing version with --updated-path' >&2
-    exit 1
+    version="$(pyenv-version-name)"
   fi
-  updated_path_for_shims "$2"
+  updated_path_for_shims "$version"
   exit
 fi
 

--- a/libexec/pyenv-sh-shell
+++ b/libexec/pyenv-sh-shell
@@ -112,6 +112,25 @@ if pyenv-prefix "${versions[@]}" >/dev/null; then
     * )
       echo 'PYENV_VERSION_OLD="$PYENV_VERSION"'
       echo "export PYENV_VERSION=\"${version}\""
+
+      # Replace shims dir in PATH.
+      shims_base_dir="$PYENV_ROOT/shims"
+      new_shims_dir="$shims_base_dir/$version"
+
+      # based on remove_from_path
+      result=":${PATH//\~/$HOME}:"
+      shopt -s extglob
+      while [ "$path_before" != "$result" ]; do
+        path_before="$result"
+        result="${result/:${shims_base_dir}*([^:]):/:$new_shims_dir:}"
+      done
+      result="${result%:}"
+      new_path="${result#:}"
+
+      if [[ "$new_path" == "$PATH" ]]; then
+        echo "pyenv: warning: PATH was not changed: $old_shims_dir not found" >&2
+      fi
+      echo "PATH=$new_path"
       ;;
     esac
   fi

--- a/libexec/pyenv-which
+++ b/libexec/pyenv-which
@@ -41,7 +41,12 @@ IFS="$OLDIFS"
 
 for version in "${versions[@]}"; do
   if [ "$version" = "system" ]; then
-    PATH="$(remove_from_path "${PYENV_ROOT}/shims")"
+    if [[ -n "$PYENV_SHIM" ]]; then
+      shim_dir=${PYENV_SHIM%/*}
+    else
+      shim_dir="${PYENV_ROOT}/shims"
+    fi
+    PATH="$(remove_from_path "$shim_dir")"
     PYENV_COMMAND_PATH="$(command -v "$PYENV_COMMAND" || true)"
   else
     PYENV_COMMAND_PATH="${PYENV_ROOT}/versions/${version}/bin/${PYENV_COMMAND}"

--- a/libexec/pyenv-which
+++ b/libexec/pyenv-which
@@ -41,13 +41,10 @@ IFS="$OLDIFS"
 
 for version in "${versions[@]}"; do
   if [ "$version" = "system" ]; then
-    if [[ -n "$PYENV_SHIM" ]]; then
-      shim_dir=${PYENV_SHIM%/*}
-    else
-      shim_dir="${PYENV_ROOT}/shims"
-    fi
-    PATH="$(remove_from_path "$shim_dir")"
-    PYENV_COMMAND_PATH="$(command -v "$PYENV_COMMAND" || true)"
+    shopt -s extglob
+    # Remove any shim dir from PATH.
+    path_without_shims="$(remove_from_path "${PYENV_ROOT}/shims*([^:])")"
+    PYENV_COMMAND_PATH="$(PATH="$path_without_shims" command -v "$PYENV_COMMAND" || true)"
   else
     PYENV_COMMAND_PATH="${PYENV_ROOT}/versions/${version}/bin/${PYENV_COMMAND}"
   fi

--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -273,10 +273,7 @@ fi
 # Execute `after_install` hooks.
 for hook in "${after_hooks[@]}"; do eval "$hook"; done
 
-# Run `pyenv-rehash` after a successful installation.
-if [ "$STATUS" == "0" ]; then
-  pyenv-rehash
-else
+if [ "$STATUS" != "0" ]; then
   cleanup
 fi
 

--- a/plugins/python-build/bin/pyenv-uninstall
+++ b/plugins/python-build/bin/pyenv-uninstall
@@ -80,7 +80,6 @@ for hook in "${before_hooks[@]}"; do eval "$hook"; done
 
 if [ -d "$PREFIX" ]; then
   rm -rf "$PREFIX"
-  pyenv-rehash
   echo "pyenv: $VERSION_NAME uninstalled"
 fi
 

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1494,7 +1494,7 @@ use_xcode_sdk_zlib() {
     echo "python-build: use zlib from xcode sdk"
     export CFLAGS="-I${xc_sdk_path}/usr/include ${CFLAGS}"
     if is_mac -ge 1100; then
-      export LDFLAGS="-L${xc_sdk_path}/usr/lib ${LDFLAGS}"
+      export LDFLAGS="${LDFLAGS} -L${xc_sdk_path}/usr/lib"
     fi
   fi
 }

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -995,7 +995,12 @@ build_package_activepython() {
 
 anaconda_architecture() {
   case "$(uname -s)" in
-  "Darwin" ) echo "MacOSX-x86_64" ;;
+  "Darwin" )
+    case "$(uname -m)" in
+    "arm64" ) echo "MacOSX-arm64" ;;
+    * ) echo "MacOSX-x86_64" ;;
+    esac
+    ;;
   "Linux" )
     case "$(uname -m)" in
     "armv7l" ) echo "Linux-armv7l" ;;

--- a/plugins/python-build/pypy3.7-7.3.2
+++ b/plugins/python-build/pypy3.7-7.3.2
@@ -1,0 +1,39 @@
+VERSION='7.3.2'
+PYVER='3.7'
+
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux" )
+  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#34c7e1c7bd06e437ad43cc90a20f9444be1f0a264d0955e32098294c30274784" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux64" )
+  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#a285ddcbc909d68c648585fae4f33b0ba24961bb4e8fafe5874cf725d6e83df6" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux-aarch64" )
+  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#c5c35a37917f759c19e2a6b3df3b4d56298faa2fae83c143469bcbda42ca5dd2" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"osx64" )
+  if require_osx_version "10.13"; then
+    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#337dd4d9e529d2f221e0beb092236c18430e0564ab835c6bba425a1daf7c9958" "pypy" "verify_py${PYVER//./}" ensurepip
+  else
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true), OS X < 10.13."
+      echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+      echo
+    } >&2
+    exit 1
+  fi
+  ;;
+"win32" )
+  install_zip "pypy${PYVER}-v${VERSION}-win32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-win32.zip#e3c589be07760bc3042981c379b7fd1603e832a4db426075f09e090473846a96" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/3.8.7
+++ b/plugins/python-build/share/python-build/3.8.7
@@ -1,0 +1,10 @@
+#require_gcc
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-3.8.7" "https://www.python.org/ftp/python/3.8.7/Python-3.8.7.tar.xz#ddcc1df16bb5b87aa42ec5d20a5b902f2d088caa269b28e01590f97a798ec50a" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+else
+  install_package "Python-3.8.7" "https://www.python.org/ftp/python/3.8.7/Python-3.8.7.tgz#20e5a04262f0af2eb9c19240d7ec368f385788bba2d8dfba7e74b20bab4d2bac" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+fi

--- a/plugins/python-build/share/python-build/3.9.1
+++ b/plugins/python-build/share/python-build/3.9.1
@@ -1,0 +1,11 @@
+#require_gcc
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+    install_package "Python-3.9.1" "https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tar.xz#991c3f8ac97992f3d308fefeb03a64db462574eadbff34ce8bc5bb583d9903ff" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+else
+    install_package "Python-3.9.1" "https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tgz#29cb91ba038346da0bd9ab84a0a55a845d872c341a4da6879f462e94c741f117" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+fi
+

--- a/plugins/python-build/share/python-build/anaconda3-2020.07
+++ b/plugins/python-build/share/python-build/anaconda3-2020.07
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-ppc64le" )
-  install_script "Anaconda3-2020.07-Linux-ppc64le" "https://repo.continuum.io/archive/Anaconda3-2020.07-Linux-ppc64le.sh#0df7c3784973ab46a9ef9848aced01311d08a71d79a18d5ed79dccdae8c8dea7" "anaconda" verify_py37
+  install_script "Anaconda3-2020.07-Linux-ppc64le" "https://repo.continuum.io/archive/Anaconda3-2020.07-Linux-ppc64le.sh#0df7c3784973ab46a9ef9848aced01311d08a71d79a18d5ed79dccdae8c8dea7" "anaconda" verify_py38
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda3-2020.07-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2020.07-Linux-x86_64.sh#38ce717758b95b3bd0b1797cc6ccfb76f29a90c25bdfa50ee45f11e583edfdbf" "anaconda" verify_py37
+  install_script "Anaconda3-2020.07-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2020.07-Linux-x86_64.sh#38ce717758b95b3bd0b1797cc6ccfb76f29a90c25bdfa50ee45f11e583edfdbf" "anaconda" verify_py38
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda3-2020.07-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2020.07-MacOSX-x86_64.sh#3980c2a57fde5de2ccfdf0d7973f95ac1a3fa63351642e6735c50fc3791ef0f1" "anaconda" verify_py37
+  install_script "Anaconda3-2020.07-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2020.07-MacOSX-x86_64.sh#3980c2a57fde5de2ccfdf0d7973f95ac1a3fa63351642e6735c50fc3791ef0f1" "anaconda" verify_py38
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda3-2020.11
+++ b/plugins/python-build/share/python-build/anaconda3-2020.11
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Anaconda3-2020.11-Linux-ppc64le" "https://repo.continuum.io/archive/Anaconda3-2020.11-Linux-ppc64le.sh#870535ada0a8ae75eeda8cd2bf7dde853ac9f4949b20e1b5641f1843a655f3b8" "anaconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda3-2020.11-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2020.11-Linux-x86_64.sh#cf2ff493f11eaad5d09ce2b4feaa5ea90db5174303d5b3fe030e16d29aeef7de" "anaconda" verify_py38
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda3-2020.11-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2020.11-MacOSX-x86_64.sh#ec11e325c792a6f49dbdbe5e641991d0a29788689176d7e54da97def9532c762" "anaconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda3 is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/graalpython-20.1.0
+++ b/plugins/python-build/share/python-build/graalpython-20.1.0
@@ -42,7 +42,7 @@ esac
 if [ -n "${BUILD}" ]; then
   urlprefix="https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/${VERSION}-${BUILD}"
 else
-  urlprefix="https://github.com/graalvm/graalpython/releases/download/vm-${VERSION}"
+  urlprefix="https://github.com/oracle/graalpython/releases/download/vm-${VERSION}"
 fi
 
 install_package "graalpython-${VERSION}${BUILD}" "${urlprefix}/graalpython-${VERSION}-${graalpython_arch}-amd64.tar.gz#${checksum}" "graalpython" ensurepip

--- a/plugins/python-build/share/python-build/graalpython-20.3.0
+++ b/plugins/python-build/share/python-build/graalpython-20.3.0
@@ -17,17 +17,17 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-VERSION='20.2.0'
+VERSION='20.3.0'
 BUILD=''
 
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
   graalpython_arch="linux"
-  checksum="9ba0447523a6cf6f8b74fef2b918672762b7d7f67be9f5be8ab6b479f173cfd7"
+  checksum="121508c64c2f18e9a57294d38a4c090c7a9417087f8549e120d0050906e2c82f"
   ;;
 "osx64" )
   graalpython_arch="macos"
-  checksum="e06f8e6f5766483d5613eca6a4703cec8a93236443c7c6f2866b31307e62bbe6"
+  checksum="1a80bf3fde2dc2d0fdc92605176c281835d912c26847346150b3be82d2a250e0"
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniforge3-4.9.2
+++ b/plugins/python-build/share/python-build/miniforge3-4.9.2
@@ -1,0 +1,22 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.9.2-5-Linux-ppc64le" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-Linux-ppc64le.sh#825b3e5f39f0bdb825323ea23af24ba4" "miniconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.9.2-5-Linux-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-Linux-x86_64.sh#73ea193f82d8f3b558b9c2186a147bcf" "miniconda" verify_py38
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.9.2-5-MacOSX-arm64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-MacOSX-arm64.sh#cf309b725c8a0b4448e4ee922703bf00" "miniconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.9.2-5-MacOSX-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-MacOSX-x86_64.sh#e66d62e8872bc1548af54063cab7b72e" "miniconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/pypy3.7-7.3.2
+++ b/plugins/python-build/share/python-build/pypy3.7-7.3.2
@@ -1,0 +1,39 @@
+VERSION='7.3.2'
+PYVER='3.7'
+
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux" )
+  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#34c7e1c7bd06e437ad43cc90a20f9444be1f0a264d0955e32098294c30274784" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux64" )
+  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#a285ddcbc909d68c648585fae4f33b0ba24961bb4e8fafe5874cf725d6e83df6" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux-aarch64" )
+  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#c5c35a37917f759c19e2a6b3df3b4d56298faa2fae83c143469bcbda42ca5dd2" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"osx64" )
+  if require_osx_version "10.13"; then
+    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#337dd4d9e529d2f221e0beb092236c18430e0564ab835c6bba425a1daf7c9958" "pypy" "verify_py${PYVER//./}" ensurepip
+  else
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true), OS X < 10.13."
+      echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+      echo
+    } >&2
+    exit 1
+  fi
+  ;;
+"win32" )
+  install_zip "pypy${PYVER}-v${VERSION}-win32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-win32.zip#e3c589be07760bc3042981c379b7fd1603e832a4db426075f09e090473846a96" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/pypy3.7-7.3.2-src
+++ b/plugins/python-build/share/python-build/pypy3.7-7.3.2-src
@@ -1,0 +1,4 @@
+#require_gcc
+prefer_openssl11
+install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
+install_package "pypy3.7-v7.3.2-src" "https://downloads.python.org/pypy/pypy3.7-v7.3.2-src.tar.bz2#9274186eb0c28716a8c6134803b1df857bc3f496e25e50e605c4d95201c8817d" "pypy_builder" verify_py37 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.7-7.3.3
+++ b/plugins/python-build/share/python-build/pypy3.7-7.3.3
@@ -1,0 +1,39 @@
+VERSION='7.3.3'
+PYVER='3.7'
+
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux" )
+  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#7d81b8e9fcd07c067cfe2f519ab770ec62928ee8787f952cadf2d2786246efc8" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux64" )
+  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#37e2804c4661c86c857d709d28c7de716b000d31e89766599fdf5a98928b7096" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux-aarch64" )
+  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#ee4aa041558b58de6063dd6df93b3def221c4ca4c900d6a9db5b1b52135703a8" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"osx64" )
+  if require_osx_version "10.13"; then
+    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#d72b27d5bb60813273f14f07378a08822186a66e216c5d1a768ad295b582438d" "pypy" "verify_py${PYVER//./}" ensurepip
+  else
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true), OS X < 10.13."
+      echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+      echo
+    } >&2
+    exit 1
+  fi
+  ;;
+"win32" )
+  install_zip "pypy${PYVER}-v${VERSION}-win32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-win32.zip#a282ce40aa4f853e877a5dbb38f0a586a29e563ae9ba82fd50c7e5dc465fb649" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/pypy3.7-7.3.3-src
+++ b/plugins/python-build/share/python-build/pypy3.7-7.3.3-src
@@ -1,0 +1,4 @@
+#require_gcc
+prefer_openssl11
+install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
+install_package "pypy3.7-v7.3.3-src" "https://downloads.python.org/pypy/pypy3.7-v7.3.3-src.tar.bz2#f6c96401f76331e474cca2d14437eb3b2f68a0f27220a6dcbc537445fe9d5b78" "pypy_builder" verify_py37 ensurepip

--- a/test/init.bats
+++ b/test/init.bats
@@ -11,12 +11,6 @@ load test_helper
   assert [ -d "${PYENV_ROOT}/versions" ]
 }
 
-@test "auto rehash" {
-  run pyenv-init -
-  assert_success
-  assert_line "command pyenv rehash 2>/dev/null"
-}
-
 @test "setup shell completions" {
   root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
   run pyenv-init - bash
@@ -54,12 +48,6 @@ OUT
   run pyenv-init fish
   assert [ "$status" -eq 1 ]
   assert_line 'pyenv init - | source'
-}
-
-@test "option to skip rehash" {
-  run pyenv-init - --no-rehash
-  assert_success
-  refute_line "pyenv rehash 2>/dev/null"
 }
 
 @test "adds shims to PATH" {


### PR DESCRIPTION
Main motivation: `which foo` should not return a pyenv shim in case `foo` is installed in some environment, but not the current.
This is a main issue with pyenv, and this fixes it.

Ref: https://github.com/pyenv/pyenv/issues/1112

Add PYENV_SHIM, and use it with remove_from_path

This is required to avoid infinite recursion with "system" version.

Could also use PYENV_SHIM_PATH, but having PYENV_SHIM is more
flexible/useful.

TODO:

- [x] make pyenv-shell and pyenv-global update $PATH.  Currently it only works for "pyenv-local" via cd hook (using zsh-autoenv).
- [ ] needs to remove any shim files in the root dir probably, otherwise it fails when there is a shim "foo" already, and rehash gets called for a version called "foo"
- [ ] pyenv-virtualenv: Also should run (the new) rehashing when activating a virtualenv directly (not using the chpwd hook).

Uses the following chpwd handler (Zsh), e.g. via
[zsh-autoenv](https://github.com/Tarrasch/zsh-autoenv):

```zsh
  _my_autoenv_pyenv_chpwd() {
    # Experimental: maintain separate shims dir for pyenv.
    local version
    if [[ -z "$PYENV_VERSION" ]]; then
      # version=$(pyenv version-name)

      # Optimized version of pyenv-version-name:
      local -a pyenv_version_file
      setopt localoptions extendedglob
      pyenv_version_file=(./(../)#.python-version(NY1:A))
      if (( $#pyenv_version_file )); then
        version=$(<$pyenv_version_file[1])
      else
        if [[ -f "$PYENV_ROOT/version" ]]; then
          version=$(<$PYENV_ROOT/version)
        else
          version=system
        fi
      fi
    else
      version=$PYENV_VERSION
    fi

    if [[ -z "$_PYENV_AUTO_VERSION" || "$_PYENV_AUTO_VERSION" != "$version" ]]; then
      _PYENV_AUTO_VERSION=$version
      out=$(PATH=$PYENV_ROOT/libexec:$PATH pyenv-sh-shell --updated-path $version | grep '^PATH')
      if [[ -z "$out" ]]; then
        echo "chpwd: pyenv-sh-shell $version failed"
      fi
      eval "$out"
    fi
  }
  add-zsh-hook chpwd _my_autoenv_pyenv_chpwd
```

Drawbacks:

- ~~calls `pyenv version-name` every time you change a directory (if
  `pyenv-shell` was not used).  This could be optimized e.g. by looking for the
  `.python-version` file only.~~

/cc @yyuu @mislav 
