### PR TITLE
Link Python against local OpenSSL

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1504,6 +1504,9 @@ use_homebrew_openssl() {
 }
 
 build_package_mac_openssl() {
+  OPENSSL_VERSION_LTS='1.0.*'
+  OPENSSL_VERSION_STABLE='1.1.*'
+
   # Install to a subdirectory since we don't want shims for bin/openssl.
   OPENSSL_PREFIX_PATH="${PREFIX_PATH}/openssl"
 
@@ -1520,12 +1523,22 @@ build_package_mac_openssl() {
   # Hint OpenSSL that we prefer a 64-bit build.
   export KERNEL_BITS="64"
   OPENSSL_CONFIGURE="${OPENSSL_CONFIGURE:-./config}"
+  OPENSSL_OPTIONS="zlib-dynamic shared no-ssl3"
 
   local nokerberos
-  [[ "$1" != openssl-1.0.* ]] || nokerberos=1
+  [[ "$1" != openssl-${OPENSSL_VERSION_LTS} ]] || nokerberos=1
+
+  local openssl_stable
+  [[ "$1" == openssl-${OPENSSL_VERSION_STABLE} ]] && openssl_stable=1
+
+  # Set additional flags based on LTS versus Stable
+  if [[ ! $openssl_stable ]]; then
+    OPENSSL_OPTIONS="${OPENSSL_OPTIONS} no-ssl2"
+    [[ $nokerberos ]] && OPENSSL_OPTIONS="${OPENSSL_OPTIONS} no-krb5"
+  fi
 
   # Compile a shared lib with zlib dynamically linked, no kerberos.
-  package_option openssl configure --openssldir="$OPENSSLDIR" zlib-dynamic no-ssl2 no-ssl3 no-krb5 shared
+  package_option openssl configure --openssldir="$OPENSSLDIR" ${OPENSSL_OPTIONS}
 
   # Default MAKE_OPTS are -j 2 which can confuse the build. Thankfully, make
   # gives precedence to the last -j option, so we can override that.

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2053,6 +2053,11 @@ fi
 # python-build: Specify `--libdir` on configure to fix build on openSUSE (#36)
 package_option python configure --libdir="${PREFIX_PATH}/lib"
 
+# python-build: Use just-compiled OpenSSL installation (#1184)
+if [ -d "${PREFIX_PATH}/openssl" ]; then
+  package_option python configure --with-openssl="${PREFIX_PATH}/openssl"
+fi
+
 # python-build: Set `RPATH` if `--enable-shared` was given (#65, #66, #82)
 if [[ "$CONFIGURE_OPTS" == *"--enable-shared"* ]] || [[ "$PYTHON_CONFIGURE_OPTS" == *"--enable-shared"* ]]; then
   # The ld on Darwin embeds the full paths to each dylib by default

--- a/plugins/python-build/share/python-build/2.6.6
+++ b/plugins/python-build/share/python-build/2.6.6
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-2.6.6" "https://www.python.org/ftp/python/2.6.6/Python-2.6.6.tgz#372f66db46d773214e4619df1794a26449158f626138d4d2141a64c2f017fae1" ldflags_dirs standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.7
+++ b/plugins/python-build/share/python-build/2.6.7
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-2.6.7" "https://www.python.org/ftp/python/2.6.7/Python-2.6.7.tgz#a8093eace4cfd3e06b05f0deb5d765e3c6cec65908048640a8cadd7a948b3826" ldflags_dirs standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.8
+++ b/plugins/python-build/share/python-build/2.6.8
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-2.6.8" "https://www.python.org/ftp/python/2.6.8/Python-2.6.8.tgz#5bf02a75ffa2fcaa5a3cabb8201998519b045541975622316888ea468d9512f7" ldflags_dirs standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.9
+++ b/plugins/python-build/share/python-build/2.6.9
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-2.6.9" "https://www.python.org/ftp/python/2.6.9/Python-2.6.9.tgz#7277b1285d8a82f374ef6ebaac85b003266f7939b3f2a24a3af52f9523ac94db" ldflags_dirs standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.7
+++ b/plugins/python-build/share/python-build/2.7
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-2.7" "https://www.python.org/ftp/python/2.7/Python-2.7.tgz#5670dd6c0c93b0b529781d070852f7b51ce6855615b16afcd318341af2910fb5" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7-dev
+++ b/plugins/python-build/share/python-build/2.7-dev
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-2.7-dev" "https://github.com/python/cpython" "2.7" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.1
+++ b/plugins/python-build/share/python-build/2.7.1
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-2.7.1" "https://www.python.org/ftp/python/2.7.1/Python-2.7.1.tgz#ca13e7b1860821494f70de017202283ad73b1fb7bd88586401c54ef958226ec8" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.10
+++ b/plugins/python-build/share/python-build/2.7.10
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.10" "https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tar.xz#1cd3730781b91caf0fa1c4d472dc29274186480161a150294c42ce9b5c5effc0" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.11
+++ b/plugins/python-build/share/python-build/2.7.11
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.11" "https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tar.xz#962b4c45af50124ea61f11a30deb4342fc0bc21126790fa1d7f6c79809413f46" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.12
+++ b/plugins/python-build/share/python-build/2.7.12
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.12" "https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tar.xz#d7837121dd5652a05fef807c361909d255d173280c4e1a4ded94d73d80a1f978" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.13
+++ b/plugins/python-build/share/python-build/2.7.13
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.13" "https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tar.xz#35d543986882f78261f97787fd3e06274bfa6df29fac9b4a94f73930ff98f731" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.14
+++ b/plugins/python-build/share/python-build/2.7.14
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.14" "https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tar.xz#71ffb26e09e78650e424929b2b457b9c912ac216576e6bd9e7d204ed03296a66" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.15
+++ b/plugins/python-build/share/python-build/2.7.15
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.15" "https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tar.xz#22d9b1ac5b26135ad2b8c2901a9413537e08749a753356ee913c84dbd2df5574" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.2
+++ b/plugins/python-build/share/python-build/2.7.2
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-2.7.2" "https://www.python.org/ftp/python/2.7.2/Python-2.7.2.tgz#1d54b7096c17902c3f40ffce7e5b84e0072d0144024184fff184a84d563abbb3" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.3
+++ b/plugins/python-build/share/python-build/2.7.3
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-2.7.3" "https://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz#d4c20f2b5faf95999fd5fecb3f7d32071b0820516224a6d2b72932ab47a1cb8e" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.4
+++ b/plugins/python-build/share/python-build/2.7.4
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-2.7.4" "https://www.python.org/ftp/python/2.7.4/Python-2.7.4.tgz#98c5eb9c8e65effcc0122112ba17a0bce880aa23ecb560af56b55eb55632b81a" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.5
+++ b/plugins/python-build/share/python-build/2.7.5
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-2.7.5" "https://www.python.org/ftp/python/2.7.5/Python-2.7.5.tgz#8e1b5fa87b91835afb376a9c0d319d41feca07ffebc0288d97ab08d64f48afbf" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.6
+++ b/plugins/python-build/share/python-build/2.7.6
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-2.7.6" "https://www.python.org/ftp/python/2.7.6/Python-2.7.6.tgz#99c6860b70977befa1590029fae092ddb18db1d69ae67e8b9385b66ed104ba58" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.7
+++ b/plugins/python-build/share/python-build/2.7.7
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.7" "https://www.python.org/ftp/python/2.7.7/Python-2.7.7.tar.xz#2983e3cd089b30c50e2b2234f07c2ac4fb8a5df230ab8f2e1133a1d8b208da78" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.8
+++ b/plugins/python-build/share/python-build/2.7.8
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.8" "https://www.python.org/ftp/python/2.7.8/Python-2.7.8.tar.xz#edde10a0cb7d14e2735e682882d5b287028d1485c456758154c19573db68075a" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.9
+++ b/plugins/python-build/share/python-build/2.7.9
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.9" "https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tar.xz#90d27e14ea7e03570026850e2e50ba71ad20b7eb31035aada1cf3def8f8d4916" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/3.0.1
+++ b/plugins/python-build/share/python-build/3.0.1
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.0.1" "https://www.python.org/ftp/python/3.0.1/Python-3.0.1.tgz#7d5f2feae9035f1d3d9e6bb7f092dbf374d6bb4b25abd0d2d11f13bba1cb04de" ldflags_dirs standard verify_py30
 if [[ "Darwin" == "$(uname -s)" ]]; then

--- a/plugins/python-build/share/python-build/3.1
+++ b/plugins/python-build/share/python-build/3.1
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.1" "https://www.python.org/ftp/python/3.1/Python-3.1.tgz#99a034cf574ea3c26412b0a0728126d7fd6ea9593d099d807a25d216ed031e6a" ldflags_dirs standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python

--- a/plugins/python-build/share/python-build/3.1.1
+++ b/plugins/python-build/share/python-build/3.1.1
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.1.1" "https://www.python.org/ftp/python/3.1.1/Python-3.1.1.tgz#5d85d7bff11c4db44920af99f64f4227c816f897f6bfa9dd8a2611165ca5f0a1" ldflags_dirs standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python

--- a/plugins/python-build/share/python-build/3.1.2
+++ b/plugins/python-build/share/python-build/3.1.2
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.1.2" "https://www.python.org/ftp/python/3.1.2/Python-3.1.2.tgz#dffbc0561a161a4a576c6059e6990a9859a0be16ba9b5736eabe4abbb2700d1c" ldflags_dirs standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python

--- a/plugins/python-build/share/python-build/3.1.3
+++ b/plugins/python-build/share/python-build/3.1.3
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.1.3" "https://www.python.org/ftp/python/3.1.3/Python-3.1.3.tgz#6311823aeda8be6a7a2b67caaeff48abce6626c9940ba7ed81f9c978666a36bd" ldflags_dirs standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python

--- a/plugins/python-build/share/python-build/3.1.4
+++ b/plugins/python-build/share/python-build/3.1.4
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.1.4" "https://www.python.org/ftp/python/3.1.4/Python-3.1.4.tgz#fadc05ea6d05360cff189944a85ecd2180bbc308784d168b350450e70bbdd846" ldflags_dirs standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python

--- a/plugins/python-build/share/python-build/3.1.5
+++ b/plugins/python-build/share/python-build/3.1.5
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.1.5" "https://www.python.org/ftp/python/3.1.5/Python-3.1.5.tgz#d12dae6d06f52ef6bf1271db4d5b4d14b5dd39813e324314e72b648ef1bc0103" ldflags_dirs standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python

--- a/plugins/python-build/share/python-build/3.2
+++ b/plugins/python-build/share/python-build/3.2
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.2" "https://www.python.org/ftp/python/3.2/Python-3.2.tgz#27b35bfcbbf01de9564c0265d72b58ba3ff3d56df0615765372f2aa09dc20da9" ldflags_dirs standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python

--- a/plugins/python-build/share/python-build/3.2.1
+++ b/plugins/python-build/share/python-build/3.2.1
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.2.1" "https://www.python.org/ftp/python/3.2.1/Python-3.2.1.tgz#7cff29d984696d9fe8c7bea54da5b9ad36acef33ff5cf0d3e37e4d12fb21c572" ldflags_dirs standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python

--- a/plugins/python-build/share/python-build/3.2.2
+++ b/plugins/python-build/share/python-build/3.2.2
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.2.2" "https://www.python.org/ftp/python/3.2.2/Python-3.2.2.tgz#acc6a13cb4fed0b7e86716324a8437e326645b8076177eede5a0cad99ec0313c" ldflags_dirs standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python

--- a/plugins/python-build/share/python-build/3.2.3
+++ b/plugins/python-build/share/python-build/3.2.3
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.2.3" "https://www.python.org/ftp/python/3.2.3/Python-3.2.3.tgz#74c33e165edef7532cef95fd9a325a06878b5bfc8a5d038161573f283eaf9809" ldflags_dirs standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python

--- a/plugins/python-build/share/python-build/3.2.4
+++ b/plugins/python-build/share/python-build/3.2.4
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.2.4" "https://www.python.org/ftp/python/3.2.4/Python-3.2.4.tgz#71c3139908ccc1c544ba1e331a3c22b3f1c09f562438a054fd6f4e2628de8b9a" ldflags_dirs standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python

--- a/plugins/python-build/share/python-build/3.2.5
+++ b/plugins/python-build/share/python-build/3.2.5
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.2.5" "https://www.python.org/ftp/python/3.2.5/Python-3.2.5.tgz#5eae0ab92a0bb9e3a1bf9c7cd046bc3de58996b049bd894d095978b6b085099f" ldflags_dirs standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python

--- a/plugins/python-build/share/python-build/3.2.6
+++ b/plugins/python-build/share/python-build/3.2.6
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.2.6" "https://www.python.org/ftp/python/3.2.6/Python-3.2.6.tar.xz#1d12b501819fd26afafbf8459be1aa279b56f032b4c15412de0a713ce0de7bdc" ldflags_dirs standard verify_py32

--- a/plugins/python-build/share/python-build/3.3.0
+++ b/plugins/python-build/share/python-build/3.3.0
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.3.0" "https://www.python.org/ftp/python/3.3.0/Python-3.3.0.tgz#cfe531eaace2503e13a74addc7f4a89482e99f8b8fca51b469ae5c83f450604e" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.1
+++ b/plugins/python-build/share/python-build/3.3.1
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.3.1" "https://www.python.org/ftp/python/3.3.1/Python-3.3.1.tgz#671dc3632f311e63c6733703aa0a1ad90c99277ddc8299d39e487718a50319bd" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.2
+++ b/plugins/python-build/share/python-build/3.3.2
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.3.2" "https://www.python.org/ftp/python/3.3.2/Python-3.3.2.tgz#de664fca3b8e0ab20fb42bfed1a36e26f116f1853e88ada12dbc938761036172" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.3
+++ b/plugins/python-build/share/python-build/3.3.3
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.3.3" "https://www.python.org/ftp/python/3.3.3/Python-3.3.3.tgz#30b60839bfe0ae8a2dba11e909328459bb8ee4a258afe7494b06b2ceda080efc" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.4
+++ b/plugins/python-build/share/python-build/3.3.4
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.3.4" "https://www.python.org/ftp/python/3.3.4/Python-3.3.4.tgz#ea055db9dd004a6ecd7690abc9734573763686dd768122316bae2dfd026412af" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.5
+++ b/plugins/python-build/share/python-build/3.3.5
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "Python-3.3.5" "https://www.python.org/ftp/python/3.3.5/Python-3.3.5.tgz#916bc57dd8524dc27429bebae7b39d6942742cf9699b875b2b496a3d960c7168" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.6
+++ b/plugins/python-build/share/python-build/3.3.6
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.3.6" "https://www.python.org/ftp/python/3.3.6/Python-3.3.6.tar.xz#5226e4bf7a530c3ff2bcde0c94e0e09e59a8bcde0114fe0268bc925bdabb5d3f" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.7
+++ b/plugins/python-build/share/python-build/3.3.7
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.3.7" "https://www.python.org/ftp/python/3.3.7/Python-3.3.7.tar.xz#85f60c327501c36bc18c33370c14d472801e6af2f901dafbba056f61685429fe" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.4-dev
+++ b/plugins/python-build/share/python-build/3.4-dev
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.4-dev" "https://github.com/python/cpython" "3.4" standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.0
+++ b/plugins/python-build/share/python-build/3.4.0
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.4.0" "https://www.python.org/ftp/python/3.4.0/Python-3.4.0.tar.xz#f13686c0a2d45e7146759e9d5d1cbd8097a0606483c0cf7730e1e13f58b14cbe" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.1
+++ b/plugins/python-build/share/python-build/3.4.1
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.4.1" "https://www.python.org/ftp/python/3.4.1/Python-3.4.1.tar.xz#c595a163104399041fcbe1c5c04db4c1da94f917b82ce89e8944c8edff7aedc4" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.2
+++ b/plugins/python-build/share/python-build/3.4.2
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.4.2" "https://www.python.org/ftp/python/3.4.2/Python-3.4.2.tar.xz#1c6d9682d145c056537e477bbfa060ce727f9edd38df1827e0f970dcf04b2def" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.3
+++ b/plugins/python-build/share/python-build/3.4.3
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.4.3" "https://www.python.org/ftp/python/3.4.3/Python-3.4.3.tar.xz#b5b3963533768d5fc325a4d7a6bd6f666726002d696f1d399ec06b043ea996b8" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.4
+++ b/plugins/python-build/share/python-build/3.4.4
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.4.4" "https://www.python.org/ftp/python/3.4.4/Python-3.4.4.tar.xz#a797d3820155ec6cb654a652b9acfb11792d4e7d568eef1f9199009e042b6ba2" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.5
+++ b/plugins/python-build/share/python-build/3.4.5
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.4.5" "https://www.python.org/ftp/python/3.4.5/Python-3.4.5.tar.xz#ee64b1c8a47461009abf25252332d29a4e587cb4f0c1c96aa793a3732e9d898a" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.6
+++ b/plugins/python-build/share/python-build/3.4.6
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.4.6" "https://www.python.org/ftp/python/3.4.6/Python-3.4.6.tar.xz#f13428bbe6aa9e3b9b6499502dc488c26096349ed7a21f7a0c1db90911115f40" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.7
+++ b/plugins/python-build/share/python-build/3.4.7
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.4.7" "https://www.python.org/ftp/python/3.4.7/Python-3.4.7.tar.xz#8714cf2b56dd36922dec8fa184d4936e1001c22fb439798cb73dda069e129d1b" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.8
+++ b/plugins/python-build/share/python-build/3.4.8
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.4.8" "https://www.python.org/ftp/python/3.4.8/Python-3.4.8.tar.xz#29a472fa902c7b2add152f5e1e82e0885a8d360645689c1db5d1949a7e8ac3ea" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.5-dev
+++ b/plugins/python-build/share/python-build/3.5-dev
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.5-dev" "https://github.com/python/cpython" "3.5" standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.5.0
+++ b/plugins/python-build/share/python-build/3.5.0
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.5.0" "https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tar.xz#d6d7aa1634a5eeeca6ed4fca266982a04f84bd8f3945a9179e20b24ad2e2be91" ldflags_dirs standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.5.1
+++ b/plugins/python-build/share/python-build/3.5.1
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.5.1" "https://www.python.org/ftp/python/3.5.1/Python-3.5.1.tar.xz#c6d57c0c366d9060ab6c0cdf889ebf3d92711d466cc0119c441dbf2746f725c9" ldflags_dirs standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.5.2
+++ b/plugins/python-build/share/python-build/3.5.2
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.5.2" "https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tar.xz#0010f56100b9b74259ebcd5d4b295a32324b58b517403a10d1a2aa7cb22bca40" ldflags_dirs standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.5.3
+++ b/plugins/python-build/share/python-build/3.5.3
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.5.3" "https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tar.xz#eefe2ad6575855423ab630f5b51a8ef6e5556f774584c06beab4926f930ddbb0" ldflags_dirs standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.5.4
+++ b/plugins/python-build/share/python-build/3.5.4
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.5.4" "https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tar.xz#94d93bfabb3b109f8a10365a325f920f9ec98c6e2380bf228f9700a14054c84c" ldflags_dirs standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.5.5
+++ b/plugins/python-build/share/python-build/3.5.5
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.5.5" "https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tar.xz#063d2c3b0402d6191b90731e0f735c64830e7522348aeb7ed382a83165d45009" ldflags_dirs standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.6-dev
+++ b/plugins/python-build/share/python-build/3.6-dev
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.6-dev" "https://github.com/python/cpython" "3.6" standard verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/3.6.0
+++ b/plugins/python-build/share/python-build/3.6.0
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.6.0" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tar.xz#b0c5f904f685e32d9232f7bdcbece9819a892929063b6e385414ad2dd6a23622" ldflags_dirs standard verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/3.6.1
+++ b/plugins/python-build/share/python-build/3.6.1
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.6.1" "https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tar.xz#a01810ddfcec216bcdb357a84bfaafdfaa0ca42bbdaa4cb7ff74f5a9961e4041" ldflags_dirs standard verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/3.6.2
+++ b/plugins/python-build/share/python-build/3.6.2
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.6.2" "https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tar.xz#9229773be41ed144370f47f0f626a1579931f5a390f1e8e3853174d52edd64a9" ldflags_dirs standard verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/3.6.3
+++ b/plugins/python-build/share/python-build/3.6.3
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.6.3" "https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tar.xz#cda7d967c9a4bfa52337cdf551bcc5cff026b6ac50a8834e568ce4a794ca81da" ldflags_dirs standard verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/3.6.4
+++ b/plugins/python-build/share/python-build/3.6.4
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.6.4" "https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tar.xz#159b932bf56aeaa76fd66e7420522d8c8853d486b8567c459b84fe2ed13bcaba" ldflags_dirs standard verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/3.6.5
+++ b/plugins/python-build/share/python-build/3.6.5
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.6.5" "https://www.python.org/ftp/python/3.6.5/Python-3.6.5.tar.xz#f434053ba1b5c8a5cc597e966ead3c5143012af827fd3f0697d21450bb8d87a6" ldflags_dirs standard verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/3.6.6
+++ b/plugins/python-build/share/python-build/3.6.6
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.6.6" "https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tar.xz#d79bc15d456e73a3173a2938f18a17e5149c850ebdedf84a78067f501ee6e16f" ldflags_dirs standard verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/3.6.6rc1
+++ b/plugins/python-build/share/python-build/3.6.6rc1
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.6.6rc1" "https://www.python.org/ftp/python/3.6.6/Python-3.6.6rc1.tar.xz#dcbf5a4b944c4d5ef367c0c413f28081e053d920e759d0e4b64418ea7280050c" ldflags_dirs standard verify_py37 ensurepip

--- a/plugins/python-build/share/python-build/3.7-dev
+++ b/plugins/python-build/share/python-build/3.7-dev
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.7-dev" "https://github.com/python/cpython" "3.7" standard verify_py37 ensurepip

--- a/plugins/python-build/share/python-build/3.7.0
+++ b/plugins/python-build/share/python-build/3.7.0
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.7.0" "https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tar.xz#0382996d1ee6aafe59763426cf0139ffebe36984474d0ec4126dd1c40a8b3549" ldflags_dirs standard verify_py37 ensurepip

--- a/plugins/python-build/share/python-build/3.8-dev
+++ b/plugins/python-build/share/python-build/3.8-dev
@@ -1,4 +1,4 @@
 #require_gcc
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2o" "https://www.openssl.org/source/openssl-1.0.2o.tar.gz#ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.8-dev" "https://github.com/python/cpython" master standard verify_py38 ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1184

### Description
- [ ] pyenv builds/installs `openssl` into a sub-directory of a new installation prefix, but Python is not configured to use it. Without `./configure --with-openssl=${somewhere}` it will favor the system's OpenSSL. In the case of Darwin, this always fails because the version of OpenSSL is no longer supported (Python >=3.7.0).

### Tests
- [ ] My PR adds the following unit tests (if any)
