### PR TITLE
Update help docs to clarify multiple version(s) are allowed

### DIFF
--- a/libexec/pyenv-global
+++ b/libexec/pyenv-global
@@ -1,16 +1,24 @@
 #!/usr/bin/env bash
 #
-# Summary: Set or show the global Python version
+# Summary: Set or show the global Python version(s)
 #
-# Usage: pyenv global <version>
+# Usage: pyenv global <version> <version2> <..>
 #
-# Sets the global Python version. You can override the global version at
+# Sets the global Python version(s). You can override the global version at
 # any time by setting a directory-specific version with `pyenv local'
 # or by setting the `PYENV_VERSION' environment variable.
 #
-# <version> should be a string matching a Python version known to pyenv.
-# The special version string `system' will use your default system Python.
-# Run `pyenv versions' for a list of available Python versions.
+# <version> should be a space-separated list of Python versions known
+# to pyenv.  The special version string `system' will use your default
+# system Python.  Run `pyenv versions' for a list of available Python
+# versions.
+#
+# Example: To enable the python2.7 and python3.7 shims to find their
+#          respective executables you could set both versions with:
+#
+# 'pyenv global 3.7.0 2.7.15'
+#
+
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x

--- a/libexec/pyenv-global
+++ b/libexec/pyenv-global
@@ -8,10 +8,10 @@
 # any time by setting a directory-specific version with `pyenv local'
 # or by setting the `PYENV_VERSION' environment variable.
 #
-# <version> should be a space-separated list of Python versions known
-# to pyenv.  The special version string `system' will use your default
-# system Python.  Run `pyenv versions' for a list of available Python
-# versions.
+# <version> can be specified multiple times and should be a version
+# tag known to pyenv.  The special version string `system' will use
+# your default system Python.  Run `pyenv versions' for a list of
+# available Python versions.
 #
 # Example: To enable the python2.7 and python3.7 shims to find their
 #          respective executables you could set both versions with:

--- a/libexec/pyenv-local
+++ b/libexec/pyenv-local
@@ -15,10 +15,10 @@
 # `PYENV_VERSION' environment variable takes precedence over local
 # and global versions.
 #
-# <version> should be a space-separated list of Python version known
-# to pyenv.  The special version string `system' will use your default
-# system Python.  Run `pyenv versions' for a list of available Python
-# versions.
+# <version> can be specified multiple times and should be a version
+# tag known to pyenv.  The special version string `system' will use
+# your default system Python.  Run `pyenv versions' for a list of
+# available Python versions.
 #
 # Example: To enable the python2.7 and python3.7 shims to find their
 #          respective executables you could set both versions with:

--- a/libexec/pyenv-local
+++ b/libexec/pyenv-local
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
-# Summary: Set or show the local application-specific Python version
+# Summary: Set or show the local application-specific Python version(s)
 #
-# Usage: pyenv local <version>
+# Usage: pyenv local <version> <version2> <..>
 #        pyenv local --unset
 #
-# Sets the local application-specific Python version by writing the
+# Sets the local application-specific Python version(s) by writing the
 # version name to a file named `.python-version'.
 #
 # When you run a Python command, pyenv will look for a `.python-version'
@@ -15,9 +15,16 @@
 # `PYENV_VERSION' environment variable takes precedence over local
 # and global versions.
 #
-# <version> should be a string matching a Python version known to pyenv.
-# The special version string `system' will use your default system Python.
-# Run `pyenv versions' for a list of available Python versions.
+# <version> should be a space-separated list of Python version known
+# to pyenv.  The special version string `system' will use your default
+# system Python.  Run `pyenv versions' for a list of available Python
+# versions.
+#
+# Example: To enable the python2.7 and python3.7 shims to find their
+#          respective executables you could set both versions with:
+#
+# 'pyenv local 3.7.0 2.7.15'
+
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x

--- a/libexec/pyenv-version
+++ b/libexec/pyenv-version
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Summary: Show the current Python version and its origin
+# Summary: Show the current Python version(s) and its origin
 #
-# Shows the currently selected Python version and how it was
+# Shows the currently selected Python version(s) and how it was
 # selected. To obtain only the version string, use `pyenv
 # version-name'.
 

--- a/libexec/pyenv-which
+++ b/libexec/pyenv-which
@@ -6,6 +6,7 @@
 #
 # Displays the full path to the executable that pyenv will invoke when
 # you run the given command.
+#
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
@@ -82,6 +83,8 @@ else
       echo "The \`$1' command exists in these Python versions:"
       echo "$versions" | sed 's/^/  /g'
       echo
+      echo "Note: See 'pyenv help global' for tips on allowing both"
+      echo "      python2 and python3 to be found."
     } >&2
   fi
 

--- a/test/which.bats
+++ b/test/which.bats
@@ -107,6 +107,9 @@ pyenv: py.test: command not found
 The \`py.test' command exists in these Python versions:
   3.3
   3.4
+
+Note: See 'pyenv help global' for tips on allowing both
+      python2 and python3 to be found.
 OUT
 }
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [X] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [X] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [X] My PR addresses the following pyenv issue (if any)
  - closes #566 
  - closes #1159 
  - #1078 


### Description
- [X] This seems like a common usage issue that it is not entirely clear from the CLI that you can specify multiple versions.  The README.md documents this, but I thought it might be helpful to enhance the docs and tips in the CLI when users encounter these "command found in versions" messages.

These changes are just documentation changes, and an added tip in the output of pyenv-where.

fwiw, I thought perhaps the help could also provide the link reference to https://github.com/pyenv/pyenv#choosing-the-python-version, but I didn't include that here.

### Tests
- n/a

### Example output
<pre>
$ PYENV_VERSION=3.7.0 ./bin/pyenv which python2.7
pyenv: python2.7: command not found

The `python2.7' command exists in these Python versions:
  2.7.15

<b>Note: See 'pyenv help global' for tips on allowing both
      python2 and python3 to be found.</b>
</pre>

<pre>
$ ./bin/pyenv help global
Usage: pyenv global &lt;version&gt; &lt;version2&gt; &lt;..&gt;

Sets the global Python version(s). You can override the global version at
any time by setting a directory-specific version with `pyenv local'
or by setting the `PYENV_VERSION' environment variable.

<b>&lt;version&gt; should be a space-separated list</b> of Python versions known
to pyenv.  The special version string `system' will use your default
system Python.  Run `pyenv versions' for a list of available Python
versions.

<b>Example: To enable the python2.7 and python3.7 shims to find their
         respective executables you could set both versions with:

'pyenv global 3.7.0 2.7.15'</b>

</pre>