### PR TITLE
#1199 introduced Python 3.5.6 not 3.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.7
 
-* python-build: Add CPython 3.6.7 (#1199)
+* python-build: Add CPython 3.5.6 (#1199)
 * python-build: Add CPython 3.4.9
 
 ## 1.2.6


### PR DESCRIPTION
See https://github.com/pyenv/pyenv/issues/1199 and https://github.com/pyenv/pyenv/commit/1e96b2c3211a5112a9c348e8538d1f5f9f02b438