### PR TITLE
Force y, Y, yes or YES to confirm installation

### DIFF
--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -160,7 +160,7 @@ if [ -d "${PREFIX}/bin" ]; then
     read -p "continue with installation? (y/N) "
 
     case "$REPLY" in
-    y* | Y* ) ;;
+    y | Y | yes | YES ) ;;
     * ) exit 1 ;;
     esac
   elif [ -n "$SKIP_EXISTING" ]; then

--- a/plugins/python-build/bin/pyenv-uninstall
+++ b/plugins/python-build/bin/pyenv-uninstall
@@ -71,7 +71,7 @@ if [ -z "$FORCE" ]; then
 
   read -p "pyenv: remove $PREFIX? "
   case "$REPLY" in
-  y* | Y* ) ;;
+  y | Y | yes | YES ) ;;
   * ) exit 1 ;;
   esac
 fi


### PR DESCRIPTION
When installing or removing a python version `pyenv` access anything starting with a y as a confirmation.

This lead to an issue where one of our scripts returned an error message starting by Y. The proposed patch checks explicitly for one of y, Y, yes or YES in order to avoid errors.