### PR TITLE
python-build: add anaconda[23]-5.3.0

### DIFF
--- a/plugins/python-build/share/python-build/anaconda2-5.3.0
+++ b/plugins/python-build/share/python-build/anaconda2-5.3.0
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Anaconda2-5.3.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda2-5.3.0-Linux-x86.sh#58d4229ad7097e1f3387d7f6582dcf2bbc684bffea284cd25096bd87530ba590" "anaconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda2-5.3.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda2-5.3.0-Linux-x86_64.sh#50eeaab24bfa2472bc6485fe8f0e612ed67e561eda1ff9fbf07b62c96443c1be" "anaconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda2-5.3.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda2-5.3.0-MacOSX-x86_64.sh#bea3eb7667d265c8fe678ddde8432ac1f8286224baae498d092bb068b8185e88" "anaconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda2 is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/anaconda3-5.3.0
+++ b/plugins/python-build/share/python-build/anaconda3-5.3.0
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Anaconda3-5.3.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda3-5.3.0-Linux-x86.sh#c15ffac2ae35179a15dc5872e5bb405b4027a0fd76c6817e9cee39545bc5ca0b" "anaconda" verify_py36
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda3-5.3.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-5.3.0-Linux-x86_64.sh#cfbf5fe70dd1b797ec677e63c61f8efc92dad930fd1c94d60390bb07fdc09959" "anaconda" verify_py36
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda3-5.3.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-5.3.0-MacOSX-x86_64.sh#bc073b6e6d3b2ef29d01a2caf1de7c206c95968231ef0492d958eae1a314b4e9" "anaconda" verify_py36
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda3 is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  * No issue is addressed in my PR.

### Description
- [x] Here are some details about my PR

This PR consists of a single commit adding two new files, which allow the user to install both Anaconda2 5.3.0 and Anaconda3 5.3.0 for macOS (64 bit) and Linux (both 32 and 64 bit).

All the six Anaconda installation .sh files in the URLs in these two files are at least downloadable; however, the only one of the six files (Anaconda3 5.3.0) has been tested only on macOS to see if it is installable. Every other script should also work properly on each OS platform; please check if the rest of the other possible scripts and OSs combinations are installable.

The SHA-256 checksum for each Anaconda shell file is copied from the following pages:

- [Hashes for Anaconda2-5.3.0-Linux-x86.sh — Anaconda 2.0 documentation](https://docs.anaconda.com/anaconda/install/hashes/Anaconda2-5.3.0-Linux-x86.sh-hash/)
- [Hashes for Anaconda2-5.3.0-Linux-x86_64.sh — Anaconda 2.0 documentation](https://docs.anaconda.com/anaconda/install/hashes/Anaconda2-5.3.0-Linux-x86_64.sh-hash/)
- [Hashes for Anaconda2-5.3.0-MacOSX-x86_64.sh — Anaconda 2.0 documentation](https://docs.anaconda.com/anaconda/install/hashes/Anaconda2-5.3.0-MacOSX-x86_64.sh-hash/)
- [Hashes for Anaconda3-5.3.0-Linux-x86.sh — Anaconda 2.0 documentation](https://docs.anaconda.com/anaconda/install/hashes/Anaconda3-5.3.0-Linux-x86.sh-hash/)
- [Hashes for Anaconda3-5.3.0-Linux-x86_64.sh — Anaconda 2.0 documentation](https://docs.anaconda.com/anaconda/install/hashes/Anaconda3-5.3.0-Linux-x86_64.sh-hash/)
- [Hashes for Anaconda3-5.3.0-MacOSX-x86_64.sh — Anaconda 2.0 documentation](https://docs.anaconda.com/anaconda/install/hashes/Anaconda3-5.3.0-MacOSX-x86_64.sh-hash/)

### Tests
- [x] My PR adds the following unit tests (if any)

As mentioned in the section above, I have only checked one of the six Anaconda installation scripts installable, which is Anaconda3 5.3.0 on macOS (10.12.6). But I believe five of the other scripts should work on each OS platform. Please note that every other script files are at least downloadable. 

Just to mention that I did quadruple-check to make sure the SHA-256 checksum for each Anaconda shell file is properly copied and pasted from the pages listed above to the newly added anaconda2-5.3.0 and anaconda3-5.3.0 files (they are the renamed duplicates of its predecessor files, i.e. anaconda2-5.2.0 and anaconda3-5.2.0). For this reason, I believe they all should work fine (unless copy-and-pasting was wrongly done by me, even after the quadruple-checks).

---

### Message from the contributor

Please review my commit and if necessary, rectify as appropriate.

Thank you!

sho