### PR TITLE
force unset shell pipefail option

### DIFF
--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -64,6 +64,7 @@ create_prototype_shim() {
   cat > "$PROTOTYPE_SHIM_PATH" <<SH
 #!/usr/bin/env bash
 set -e
+set +o pipefail
 [ -n "\$PYENV_DEBUG" ] && set -x
 
 program="\${0##*/}"


### PR DESCRIPTION
pyenv fails with following script if greadlink cannot be found in PATH

```bash
export SHELLOPTS
set -o pipefail
set -e
python -V || echo python failed # python fails
```

looking forward patches to fix

and here one proposed