### PR TITLE
Use the newly built OpenSSL (fixes #1184).

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1537,6 +1537,9 @@ build_package_mac_openssl() {
   local pem_file="$OPENSSLDIR/cert.pem"
   security find-certificate -a -p /Library/Keychains/System.keychain > "$pem_file"
   security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain >> "$pem_file"
+
+  # Make sure we build Python with *this* OpenSSL
+  package_option python configure --with-openssl="$OPENSSL_PREFIX_PATH"
 }
 
 # Post-install check that the openssl extension was built.


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  - **Not applicable.**
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  - **Not applicable.**
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1184

### Description
- [x] Here are some details about my PR:

  For Mac builds, pyenv tries to build a copy of OpenSSL because older versions of the macOS ship with an ancient version of OpenSSL, while newer versions don't ship with any OpenSSL at all. Unfortunately, pyenv neglected to tell Python to actually *use* this version of OpenSSL, which means that you could only use pyenv if you had installed a copy of OpenSSL in a location that is checked by default (e.g. /usr/local/lib).

### Tests
- [x] My PR adds the following unit tests (if any)

   **No new tests**