### PR TITLE
Add support for fd(1), for a 4x+ definition speedup

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1879,7 +1879,12 @@ usage() {
 
 list_definitions() {
   { for DEFINITION_DIR in "${PYTHON_BUILD_DEFINITIONS[@]}"; do
-      [ -d "$DEFINITION_DIR" ] && find "$DEFINITION_DIR" -maxdepth 1 -type f -print0 | xargs -0 -n 1 basename 2>/dev/null
+      [ -d "$DEFINITION_DIR" ] || continue
+      if command -v fd >/dev/null; then
+        fd . "$DEFINITION_DIR" --max-depth 1 --type f --exec basename
+      else
+        find "$DEFINITION_DIR" -maxdepth 1 -type f -print0 | xargs -0 -n 1 basename 2>/dev/null
+      fi
     done
   } | sort_versions | uniq
 }


### PR DESCRIPTION
I'm not entirely sure why `find` is used instead of `ls` (changed in 4a52bfaff971b1326ab023c950f95f663f9dfc6e), as is used in upstream rbenv, but the command presents a significant bottleneck in `pyenv install -l`/`python-build --definitions`. 

If [fd](https://github.com/sharkdp/fd) is installed, we can use it to achieve a speedup of 4x, or better, in my testing:

```
Benchmark #1: ./plugins/python-build/bin/python-build --definitions
  Time (mean ± σ):     589.4 ms ±  28.2 ms    [User: 232.3 ms, System: 2252.9 ms]
  Range (min … max):   551.7 ms … 659.1 ms

Benchmark #2: /home/neersighted/.local/share/pyenv/plugins/python-build/bin/python-build --definitions
  Time (mean ± σ):      2.835 s ±  0.023 s    [User: 104.1 ms, System: 2396.6 ms]
  Range (min … max):    2.799 s …  2.871 s

Summary
  './plugins/python-build/bin/python-build --definitions' ran
    4.81 ± 0.23 times faster than '/home/neersighted/.local/share/pyenv/plugins/python-build/bin/python-build --definitions'
```