### PR TITLE
Add OPENSSL_NO_SSL3 patch for 3.3.7

### DIFF
--- a/plugins/python-build/share/python-build/patches/3.3.7/Python-3.3.7/010_ssl_no_ssl3.patch
+++ b/plugins/python-build/share/python-build/patches/3.3.7/Python-3.3.7/010_ssl_no_ssl3.patch
@@ -1,0 +1,102 @@
+diff -r -u ../Python-3.3.6.orig/Lib/ssl.py ./Lib/ssl.py
+--- ../Python-3.3.6.orig/Lib/ssl.py	2014-10-12 07:03:53.000000000 +0000
++++ ./Lib/ssl.py	2015-12-20 06:43:59.175134734 +0000
+@@ -66,47 +66,32 @@
+     SSLSyscallError, SSLEOFError,
+     )
+ from _ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
+-from _ssl import (
+-    OP_ALL, OP_NO_SSLv2, OP_NO_SSLv3, OP_NO_TLSv1,
+-    OP_CIPHER_SERVER_PREFERENCE, OP_SINGLE_DH_USE
+-    )
+-try:
+-    from _ssl import OP_NO_COMPRESSION
+-except ImportError:
+-    pass
++from _ssl import RAND_status, RAND_add, RAND_bytes, RAND_pseudo_bytes
+ try:
+-    from _ssl import OP_SINGLE_ECDH_USE
++    from _ssl import RAND_egd
+ except ImportError:
++    # LibreSSL does not provide RAND_egd
+     pass
+-from _ssl import RAND_status, RAND_egd, RAND_add, RAND_bytes, RAND_pseudo_bytes
+-from _ssl import (
+-    SSL_ERROR_ZERO_RETURN,
+-    SSL_ERROR_WANT_READ,
+-    SSL_ERROR_WANT_WRITE,
+-    SSL_ERROR_WANT_X509_LOOKUP,
+-    SSL_ERROR_SYSCALL,
+-    SSL_ERROR_SSL,
+-    SSL_ERROR_WANT_CONNECT,
+-    SSL_ERROR_EOF,
+-    SSL_ERROR_INVALID_ERROR_CODE,
+-    )
++
++def _import_symbols(prefix):
++    for n in dir(_ssl):
++        if n.startswith(prefix):
++            globals()[n] = getattr(_ssl, n)
++
++_import_symbols('OP_')
++_import_symbols('SSL_ERROR_')
++_import_symbols('PROTOCOL_')
++
+ from _ssl import HAS_SNI, HAS_ECDH, HAS_NPN
+-from _ssl import (PROTOCOL_SSLv3, PROTOCOL_SSLv23,
+-                  PROTOCOL_TLSv1)
++
+ from _ssl import _OPENSSL_API_VERSION
+ 
+-_PROTOCOL_NAMES = {
+-    PROTOCOL_TLSv1: "TLSv1",
+-    PROTOCOL_SSLv23: "SSLv23",
+-    PROTOCOL_SSLv3: "SSLv3",
+-}
++_PROTOCOL_NAMES = {value: name for name, value in globals().items() if name.startswith('PROTOCOL_')}
++
+ try:
+-    from _ssl import PROTOCOL_SSLv2
+     _SSLv2_IF_EXISTS = PROTOCOL_SSLv2
+-except ImportError:
++except NameError:
+     _SSLv2_IF_EXISTS = None
+-else:
+-    _PROTOCOL_NAMES[PROTOCOL_SSLv2] = "SSLv2"
+ 
+ from socket import getnameinfo as _getnameinfo
+ from socket import error as socket_error
+@@ -664,7 +649,7 @@
+     d = pem_cert_string.strip()[len(PEM_HEADER):-len(PEM_FOOTER)]
+     return base64.decodebytes(d.encode('ASCII', 'strict'))
+ 
+-def get_server_certificate(addr, ssl_version=PROTOCOL_SSLv3, ca_certs=None):
++def get_server_certificate(addr, ssl_version=PROTOCOL_SSLv23, ca_certs=None):
+     """Retrieve the certificate from the server at the specified address,
+     and return it as a PEM-encoded string.
+     If 'ca_certs' is specified, validate the server cert against it.
+diff -r -u ../Python-3.3.6.orig/Modules/_ssl.c ./Modules/_ssl.c
+--- ../Python-3.3.6.orig/Modules/_ssl.c	2014-10-12 07:03:53.000000000 +0000
++++ ./Modules/_ssl.c	2015-12-20 06:42:45.773667904 +0000
+@@ -1746,8 +1746,10 @@
+     PySSL_BEGIN_ALLOW_THREADS
+     if (proto_version == PY_SSL_VERSION_TLS1)
+         ctx = SSL_CTX_new(TLSv1_method());
++#ifndef OPENSSL_NO_SSL3
+     else if (proto_version == PY_SSL_VERSION_SSL3)
+         ctx = SSL_CTX_new(SSLv3_method());
++#endif
+ #ifndef OPENSSL_NO_SSL2
+     else if (proto_version == PY_SSL_VERSION_SSL2)
+         ctx = SSL_CTX_new(SSLv2_method());
+@@ -2842,8 +2844,10 @@
+     PyModule_AddIntConstant(m, "PROTOCOL_SSLv2",
+                             PY_SSL_VERSION_SSL2);
+ #endif
++#ifndef OPENSSL_NO_SSL3
+     PyModule_AddIntConstant(m, "PROTOCOL_SSLv3",
+                             PY_SSL_VERSION_SSL3);
++#endif
+     PyModule_AddIntConstant(m, "PROTOCOL_SSLv23",
+                             PY_SSL_VERSION_SSL23);
+     PyModule_AddIntConstant(m, "PROTOCOL_TLSv1",


### PR DESCRIPTION
This is the same patch that was used for other Python 3.3.X versions.