### PR TITLE
Fix for error with `set -u` being used (via SHELLOPTS in a makefile)

### DIFF
--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -64,6 +64,7 @@ create_prototype_shim() {
   cat > "$PROTOTYPE_SHIM_PATH" <<SH
 #!/usr/bin/env bash
 set -e
+set +u
 [ -n "\$PYENV_DEBUG" ] && set -x
 
 program="\${0##*/}"


### PR DESCRIPTION
### Prerequisite
* [X] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [X] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.

### Description

Given a makefile with the following:
```make
DEBUG ?= false
ifeq (${DEBUG}, true)
export SHELLOPTS += xtrace
endif

all:
  az account show
```

When I invoke make, I get this error:
```bash
$ make
++ az account show
+ export PYTHONPATH=/usr/local/Cellar/azure-cli/2.0.56/libexec/lib/python3.7/site-packages
+ PYTHONPATH=/usr/local/Cellar/azure-cli/2.0.56/libexec/lib/python3.7/site-packages
+ command -v python3.7
+ python3.7 -m azure.cli account show
+ set -e
/Users/xxx/.pyenv/shims/python3.7: line 12: PYENV_DEBUG: unbound variable
```

The script doesn't fail per see, but the python command is never executed.

The solution is to turn off `nounset` option.
Or perhaps just adding the edge case with:
```bash
if [[ "$SHELLOPTS" =~ xtrace ]]; then
  set +u
fi
```
Didn't see any harm in setting it without checking the variable.

I am sure this is an edge case, but thought to report it nonetheless. It only happens with SHELLOPTS and make.
It seems like it is not exclusive to xtrace, but something very specific with these two together, the below produces the same error (without tracing):
```make
export SHELLOPTS += emacs
```

### Tests
Not sure how to test this
