### PR TITLE
Support XCode 10 on Mac OS

### DIFF
--- a/src/shobj-conf
+++ b/src/shobj-conf
@@ -199,6 +199,10 @@ darwin*)
 			;;
 		 *) 	# Mac OS X 10.9 (Mavericks) and later
 			SHOBJ_ARCHFLAGS=
+
+			# Xcode 10 and later no longer install mac OS SDK headers in the base system
+			SHOBJ_CFLAGS="${SHOBJ_CFLAGS} -I${xcrun --show-sdk-path}/usr/include"
+
 			# for 32 and 64bit universal library
 			#SHOBJ_ARCHFLAGS='-arch i386 -arch x86_64'
 			#SHOBJ_CFLAGS=${SHOBJ_CFLAGS}' -arch i386 -arch x86_64'
@@ -209,7 +213,7 @@ darwin*)
 		;;
 	esac
 
-	SHLIB_LIBS='-lncurses'	# see if -lcurses works on MacOS X 10.1 
+	SHLIB_LIBS='-lncurses'	# see if -lcurses works on MacOS X 10.1
 	;;
 
 openbsd*|netbsd*|mirbsd*)
@@ -349,7 +353,7 @@ hpux9*)
 #
 #	SHLIB_XLDFLAGS='+b $(libdir)'
 #	SHLIB_LIBSUFF='sl'
-#	SHLIB_LIBVERSION='$(SHLIB_LIBSUFF).$(SHLIB_MAJOR)'	
+#	SHLIB_LIBVERSION='$(SHLIB_LIBSUFF).$(SHLIB_MAJOR)'
 
 	;;
 
@@ -381,7 +385,7 @@ hpux10*)
 #
 #	SHLIB_XLDFLAGS='+b $(libdir)'
 #	SHLIB_LIBSUFF='sl'
-#	SHLIB_LIBVERSION='$(SHLIB_LIBSUFF).$(SHLIB_MAJOR)'	
+#	SHLIB_LIBVERSION='$(SHLIB_LIBSUFF).$(SHLIB_MAJOR)'
 
 	;;
 
@@ -412,7 +416,7 @@ hpux11*)
 #
 #	SHLIB_XLDFLAGS='+b $(libdir)'
 #	SHLIB_LIBSUFF='sl'
-#	SHLIB_LIBVERSION='$(SHLIB_LIBSUFF).$(SHLIB_MAJOR)'	
+#	SHLIB_LIBVERSION='$(SHLIB_LIBSUFF).$(SHLIB_MAJOR)'
 
 	;;
 

--- a/src/shobj-conf
+++ b/src/shobj-conf
@@ -201,7 +201,7 @@ darwin*)
 			SHOBJ_ARCHFLAGS=
 
 			# Xcode 10 and later no longer install mac OS SDK headers in the base system
-			SHOBJ_CFLAGS="${SHOBJ_CFLAGS} -I${xcrun --show-sdk-path}/usr/include"
+			SHOBJ_CFLAGS="${SHOBJ_CFLAGS} -I$(xcrun --show-sdk-path)/usr/include"
 
 			# for 32 and 64bit universal library
 			#SHOBJ_ARCHFLAGS='-arch i386 -arch x86_64'

--- a/src/shobj-conf
+++ b/src/shobj-conf
@@ -200,7 +200,7 @@ darwin*)
 		 *) 	# Mac OS X 10.9 (Mavericks) and later
 			SHOBJ_ARCHFLAGS=
 
-			# Xcode 10 and later no longer install mac OS SDK headers in the base system
+			# Xcode 10 and later no longer install macOS SDK headers in the base system
 			SHOBJ_CFLAGS="${SHOBJ_CFLAGS} -I$(xcrun --show-sdk-path)/usr/include"
 
 			# for 32 and 64bit universal library


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1219

### Description

Fixes #1219

On MacOS 10.9 and later, uses `xcrun --show-sdk-path` to find SDK path, instead of relying on Mac OS headers being available at the system level.  This is required because of a change in XCode 10's default behaviour.

https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes#3035624

Inspired by these comments:

https://github.com/pyenv/pyenv/issues/1219#issuecomment-429331397

https://github.com/pyenv/pyenv/issues/1219#issuecomment-451643266

https://github.com/pyenv/pyenv/issues/1219#issuecomment-452315815

and this blog post:

https://medium.com/@pimterry/setting-up-pyenv-on-os-x-with-homebrew-56c7541fd331