### PR TITLE
Install python-gdb.py.

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1813,6 +1813,16 @@ build_package_verify_py38() {
   build_package_verify_py37 "$1" "${2:-3.8}"
 }
 
+# Copy Tools/gdb/libpython.py to pythonX.Y-gdb.py (#1190)
+build_package_copy_python_gdb() {
+  if [ -e "$BUILD_PATH/$1/Tools/gdb/libpython.py" ]; then
+    local version_re='-([0-9]\.[0-9]+)'
+    [[ "$1" =~ $version_re ]]
+    local python_bin="$PREFIX_PATH/bin/python${BASH_REMATCH[1]}"
+    cp "$BUILD_PATH/$1/Tools/gdb/libpython.py" "$python_bin-gdb.py"
+  fi
+}
+
 build_package_ez_setup() {
   local ez_setup="ez_setup.py"
   rm -f "${ez_setup}"

--- a/plugins/python-build/share/python-build/2.7-dev
+++ b/plugins/python-build/share/python-build/2.7-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_git "Python-2.7-dev" "https://github.com/python/cpython" "2.7" standard verify_py27 ensurepip
+install_git "Python-2.7-dev" "https://github.com/python/cpython" "2.7" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.0
+++ b/plugins/python-build/share/python-build/2.7.0
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7" "https://www.python.org/ftp/python/2.7/Python-2.7.tgz#5670dd6c0c93b0b529781d070852f7b51ce6855615b16afcd318341af2910fb5" ldflags_dirs standard verify_py27 ensurepip
+install_package "Python-2.7" "https://www.python.org/ftp/python/2.7/Python-2.7.tgz#5670dd6c0c93b0b529781d070852f7b51ce6855615b16afcd318341af2910fb5" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.1
+++ b/plugins/python-build/share/python-build/2.7.1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.1" "https://www.python.org/ftp/python/2.7.1/Python-2.7.1.tgz#ca13e7b1860821494f70de017202283ad73b1fb7bd88586401c54ef958226ec8" ldflags_dirs standard verify_py27 ensurepip
+install_package "Python-2.7.1" "https://www.python.org/ftp/python/2.7.1/Python-2.7.1.tgz#ca13e7b1860821494f70de017202283ad73b1fb7bd88586401c54ef958226ec8" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.10
+++ b/plugins/python-build/share/python-build/2.7.10
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.10" "https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tar.xz#1cd3730781b91caf0fa1c4d472dc29274186480161a150294c42ce9b5c5effc0" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.10" "https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tar.xz#1cd3730781b91caf0fa1c4d472dc29274186480161a150294c42ce9b5c5effc0" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.10" "https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tgz#eda8ce6eec03e74991abb5384170e7c65fcd7522e409b8e83d7e6372add0f12a" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.10" "https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tgz#eda8ce6eec03e74991abb5384170e7c65fcd7522e409b8e83d7e6372add0f12a" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.11
+++ b/plugins/python-build/share/python-build/2.7.11
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.11" "https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tar.xz#962b4c45af50124ea61f11a30deb4342fc0bc21126790fa1d7f6c79809413f46" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.11" "https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tar.xz#962b4c45af50124ea61f11a30deb4342fc0bc21126790fa1d7f6c79809413f46" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.11" "https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz#82929b96fd6afc8da838b149107078c02fa1744b7e60999a8babbc0d3fa86fc6" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.11" "https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz#82929b96fd6afc8da838b149107078c02fa1744b7e60999a8babbc0d3fa86fc6" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.12
+++ b/plugins/python-build/share/python-build/2.7.12
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.12" "https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tar.xz#d7837121dd5652a05fef807c361909d255d173280c4e1a4ded94d73d80a1f978" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.12" "https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tar.xz#d7837121dd5652a05fef807c361909d255d173280c4e1a4ded94d73d80a1f978" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.12" "https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tgz#3cb522d17463dfa69a155ab18cffa399b358c966c0363d6c8b5b3bf1384da4b6" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.12" "https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tgz#3cb522d17463dfa69a155ab18cffa399b358c966c0363d6c8b5b3bf1384da4b6" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.13
+++ b/plugins/python-build/share/python-build/2.7.13
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.13" "https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tar.xz#35d543986882f78261f97787fd3e06274bfa6df29fac9b4a94f73930ff98f731" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.13" "https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tar.xz#35d543986882f78261f97787fd3e06274bfa6df29fac9b4a94f73930ff98f731" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.13" "https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz#a4f05a0720ce0fd92626f0278b6b433eee9a6173ddf2bced7957dfb599a5ece1" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.13" "https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz#a4f05a0720ce0fd92626f0278b6b433eee9a6173ddf2bced7957dfb599a5ece1" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.14
+++ b/plugins/python-build/share/python-build/2.7.14
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.14" "https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tar.xz#71ffb26e09e78650e424929b2b457b9c912ac216576e6bd9e7d204ed03296a66" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.14" "https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tar.xz#71ffb26e09e78650e424929b2b457b9c912ac216576e6bd9e7d204ed03296a66" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.14" "https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tgz#304c9b202ea6fbd0a4a8e0ad3733715fbd4749f2204a9173a58ec53c32ea73e8" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.14" "https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tgz#304c9b202ea6fbd0a4a8e0ad3733715fbd4749f2204a9173a58ec53c32ea73e8" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.15
+++ b/plugins/python-build/share/python-build/2.7.15
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.15" "https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tar.xz#22d9b1ac5b26135ad2b8c2901a9413537e08749a753356ee913c84dbd2df5574" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.15" "https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tar.xz#22d9b1ac5b26135ad2b8c2901a9413537e08749a753356ee913c84dbd2df5574" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.15" "https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tgz#18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.15" "https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tgz#18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.2
+++ b/plugins/python-build/share/python-build/2.7.2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.2" "https://www.python.org/ftp/python/2.7.2/Python-2.7.2.tgz#1d54b7096c17902c3f40ffce7e5b84e0072d0144024184fff184a84d563abbb3" ldflags_dirs standard verify_py27 ensurepip
+install_package "Python-2.7.2" "https://www.python.org/ftp/python/2.7.2/Python-2.7.2.tgz#1d54b7096c17902c3f40ffce7e5b84e0072d0144024184fff184a84d563abbb3" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.3
+++ b/plugins/python-build/share/python-build/2.7.3
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.3" "https://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz#d4c20f2b5faf95999fd5fecb3f7d32071b0820516224a6d2b72932ab47a1cb8e" ldflags_dirs standard verify_py27 ensurepip
+install_package "Python-2.7.3" "https://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz#d4c20f2b5faf95999fd5fecb3f7d32071b0820516224a6d2b72932ab47a1cb8e" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.4
+++ b/plugins/python-build/share/python-build/2.7.4
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.4" "https://www.python.org/ftp/python/2.7.4/Python-2.7.4.tgz#98c5eb9c8e65effcc0122112ba17a0bce880aa23ecb560af56b55eb55632b81a" ldflags_dirs standard verify_py27 ensurepip
+install_package "Python-2.7.4" "https://www.python.org/ftp/python/2.7.4/Python-2.7.4.tgz#98c5eb9c8e65effcc0122112ba17a0bce880aa23ecb560af56b55eb55632b81a" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.5
+++ b/plugins/python-build/share/python-build/2.7.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.5" "https://www.python.org/ftp/python/2.7.5/Python-2.7.5.tgz#8e1b5fa87b91835afb376a9c0d319d41feca07ffebc0288d97ab08d64f48afbf" ldflags_dirs standard verify_py27 ensurepip
+install_package "Python-2.7.5" "https://www.python.org/ftp/python/2.7.5/Python-2.7.5.tgz#8e1b5fa87b91835afb376a9c0d319d41feca07ffebc0288d97ab08d64f48afbf" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.6
+++ b/plugins/python-build/share/python-build/2.7.6
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.6" "https://www.python.org/ftp/python/2.7.6/Python-2.7.6.tgz#99c6860b70977befa1590029fae092ddb18db1d69ae67e8b9385b66ed104ba58" ldflags_dirs standard verify_py27 ensurepip
+install_package "Python-2.7.6" "https://www.python.org/ftp/python/2.7.6/Python-2.7.6.tgz#99c6860b70977befa1590029fae092ddb18db1d69ae67e8b9385b66ed104ba58" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.7
+++ b/plugins/python-build/share/python-build/2.7.7
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.7" "https://www.python.org/ftp/python/2.7.7/Python-2.7.7.tar.xz#2983e3cd089b30c50e2b2234f07c2ac4fb8a5df230ab8f2e1133a1d8b208da78" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.7" "https://www.python.org/ftp/python/2.7.7/Python-2.7.7.tar.xz#2983e3cd089b30c50e2b2234f07c2ac4fb8a5df230ab8f2e1133a1d8b208da78" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.7" "https://www.python.org/ftp/python/2.7.7/Python-2.7.7.tgz#7f49c0a6705ad89d925181e27d0aaa025ee4731ce0de64776c722216c3e66c42" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.7" "https://www.python.org/ftp/python/2.7.7/Python-2.7.7.tgz#7f49c0a6705ad89d925181e27d0aaa025ee4731ce0de64776c722216c3e66c42" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.8
+++ b/plugins/python-build/share/python-build/2.7.8
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.8" "https://www.python.org/ftp/python/2.7.8/Python-2.7.8.tar.xz#edde10a0cb7d14e2735e682882d5b287028d1485c456758154c19573db68075a" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.8" "https://www.python.org/ftp/python/2.7.8/Python-2.7.8.tar.xz#edde10a0cb7d14e2735e682882d5b287028d1485c456758154c19573db68075a" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.8" "https://www.python.org/ftp/python/2.7.8/Python-2.7.8.tgz#74d70b914da4487aa1d97222b29e9554d042f825f26cb2b93abd20fdda56b557" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.8" "https://www.python.org/ftp/python/2.7.8/Python-2.7.8.tgz#74d70b914da4487aa1d97222b29e9554d042f825f26cb2b93abd20fdda56b557" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.9
+++ b/plugins/python-build/share/python-build/2.7.9
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.9" "https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tar.xz#90d27e14ea7e03570026850e2e50ba71ad20b7eb31035aada1cf3def8f8d4916" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.9" "https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tar.xz#90d27e14ea7e03570026850e2e50ba71ad20b7eb31035aada1cf3def8f8d4916" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.9" "https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tgz#c8bba33e66ac3201dabdc556f0ea7cfe6ac11946ec32d357c4c6f9b018c12c5b" ldflags_dirs standard verify_py27 ensurepip
+  install_package "Python-2.7.9" "https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tgz#c8bba33e66ac3201dabdc556f0ea7cfe6ac11946ec32d357c4c6f9b018c12c5b" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5-dev
+++ b/plugins/python-build/share/python-build/3.5-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_git "Python-3.5-dev" "https://github.com/python/cpython" "3.5" standard verify_py35 ensurepip
+install_git "Python-3.5-dev" "https://github.com/python/cpython" "3.5" standard verify_py35 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.5.0
+++ b/plugins/python-build/share/python-build/3.5.0
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.0" "https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tar.xz#d6d7aa1634a5eeeca6ed4fca266982a04f84bd8f3945a9179e20b24ad2e2be91" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.0" "https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tar.xz#d6d7aa1634a5eeeca6ed4fca266982a04f84bd8f3945a9179e20b24ad2e2be91" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
 else
-  install_package "Python-3.5.0" "https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tgz#584e3d5a02692ca52fce505e68ecd77248a6f2c99adf9db144a39087336b0fe0" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.0" "https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tgz#584e3d5a02692ca52fce505e68ecd77248a6f2c99adf9db144a39087336b0fe0" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.1
+++ b/plugins/python-build/share/python-build/3.5.1
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.1" "https://www.python.org/ftp/python/3.5.1/Python-3.5.1.tar.xz#c6d57c0c366d9060ab6c0cdf889ebf3d92711d466cc0119c441dbf2746f725c9" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.1" "https://www.python.org/ftp/python/3.5.1/Python-3.5.1.tar.xz#c6d57c0c366d9060ab6c0cdf889ebf3d92711d466cc0119c441dbf2746f725c9" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
 else
-  install_package "Python-3.5.1" "https://www.python.org/ftp/python/3.5.1/Python-3.5.1.tgz#687e067d9f391da645423c7eda8205bae9d35edc0c76ef5218dcbe4cc770d0d7" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.1" "https://www.python.org/ftp/python/3.5.1/Python-3.5.1.tgz#687e067d9f391da645423c7eda8205bae9d35edc0c76ef5218dcbe4cc770d0d7" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.2
+++ b/plugins/python-build/share/python-build/3.5.2
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.2" "https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tar.xz#0010f56100b9b74259ebcd5d4b295a32324b58b517403a10d1a2aa7cb22bca40" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.2" "https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tar.xz#0010f56100b9b74259ebcd5d4b295a32324b58b517403a10d1a2aa7cb22bca40" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
 else
-  install_package "Python-3.5.2" "https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tgz#1524b840e42cf3b909e8f8df67c1724012c7dc7f9d076d4feef2d3eff031e8a0" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.2" "https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tgz#1524b840e42cf3b909e8f8df67c1724012c7dc7f9d076d4feef2d3eff031e8a0" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.3
+++ b/plugins/python-build/share/python-build/3.5.3
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.3" "https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tar.xz#eefe2ad6575855423ab630f5b51a8ef6e5556f774584c06beab4926f930ddbb0" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.3" "https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tar.xz#eefe2ad6575855423ab630f5b51a8ef6e5556f774584c06beab4926f930ddbb0" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
 else
-  install_package "Python-3.5.3" "https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tgz#d8890b84d773cd7059e597dbefa510340de8336ec9b9e9032bf030f19291565a" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.3" "https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tgz#d8890b84d773cd7059e597dbefa510340de8336ec9b9e9032bf030f19291565a" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.4
+++ b/plugins/python-build/share/python-build/3.5.4
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.4" "https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tar.xz#94d93bfabb3b109f8a10365a325f920f9ec98c6e2380bf228f9700a14054c84c" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.4" "https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tar.xz#94d93bfabb3b109f8a10365a325f920f9ec98c6e2380bf228f9700a14054c84c" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
 else
-  install_package "Python-3.5.4" "https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tgz#6ed87a8b6c758cc3299a8b433e8a9a9122054ad5bc8aad43299cff3a53d8ca44" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.4" "https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tgz#6ed87a8b6c758cc3299a8b433e8a9a9122054ad5bc8aad43299cff3a53d8ca44" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.5
+++ b/plugins/python-build/share/python-build/3.5.5
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.5" "https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tar.xz#063d2c3b0402d6191b90731e0f735c64830e7522348aeb7ed382a83165d45009" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.5" "https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tar.xz#063d2c3b0402d6191b90731e0f735c64830e7522348aeb7ed382a83165d45009" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
 else
-  install_package "Python-3.5.5" "https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tgz#2f988db33913dcef17552fd1447b41afb89dbc26e3cdfc068ea6c62013a3a2a5" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.5" "https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tgz#2f988db33913dcef17552fd1447b41afb89dbc26e3cdfc068ea6c62013a3a2a5" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.6
+++ b/plugins/python-build/share/python-build/3.5.6
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.6" "https://www.python.org/ftp/python/3.5.6/Python-3.5.6.tar.xz#f55cde04f521f273c7cba08912921cc5642cfc15ca7b22d5829f0aff4371155f" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.6" "https://www.python.org/ftp/python/3.5.6/Python-3.5.6.tar.xz#f55cde04f521f273c7cba08912921cc5642cfc15ca7b22d5829f0aff4371155f" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
 else
-  install_package "Python-3.5.6" "https://www.python.org/ftp/python/3.5.6/Python-3.5.6.tgz#30d2ff093988e74283e1abfee823292c6b59590796b9827e95ba4940b27d26f8" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.6" "https://www.python.org/ftp/python/3.5.6/Python-3.5.6.tgz#30d2ff093988e74283e1abfee823292c6b59590796b9827e95ba4940b27d26f8" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6-dev
+++ b/plugins/python-build/share/python-build/3.6-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_git "Python-3.6-dev" "https://github.com/python/cpython" "3.6" standard verify_py36 ensurepip
+install_git "Python-3.6-dev" "https://github.com/python/cpython" "3.6" standard verify_py36 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.6.0
+++ b/plugins/python-build/share/python-build/3.6.0
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.0" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tar.xz#b0c5f904f685e32d9232f7bdcbece9819a892929063b6e385414ad2dd6a23622" ldflags_dirs standard verify_py36 ensurepip
+  install_package "Python-3.6.0" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tar.xz#b0c5f904f685e32d9232f7bdcbece9819a892929063b6e385414ad2dd6a23622" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.0" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tgz#aa472515800d25a3739833f76ca3735d9f4b2fe77c3cb21f69275e0cce30cb2b" ldflags_dirs standard verify_py36 ensurepip
+  install_package "Python-3.6.0" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tgz#aa472515800d25a3739833f76ca3735d9f4b2fe77c3cb21f69275e0cce30cb2b" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.1
+++ b/plugins/python-build/share/python-build/3.6.1
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.1" "https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tar.xz#a01810ddfcec216bcdb357a84bfaafdfaa0ca42bbdaa4cb7ff74f5a9961e4041" ldflags_dirs standard verify_py36 ensurepip
+  install_package "Python-3.6.1" "https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tar.xz#a01810ddfcec216bcdb357a84bfaafdfaa0ca42bbdaa4cb7ff74f5a9961e4041" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.1" "https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tgz#aa50b0143df7c89ce91be020fe41382613a817354b33acdc6641b44f8ced3828" ldflags_dirs standard verify_py36 ensurepip
+  install_package "Python-3.6.1" "https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tgz#aa50b0143df7c89ce91be020fe41382613a817354b33acdc6641b44f8ced3828" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.2
+++ b/plugins/python-build/share/python-build/3.6.2
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.2" "https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tar.xz#9229773be41ed144370f47f0f626a1579931f5a390f1e8e3853174d52edd64a9" ldflags_dirs standard verify_py36 ensurepip
+  install_package "Python-3.6.2" "https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tar.xz#9229773be41ed144370f47f0f626a1579931f5a390f1e8e3853174d52edd64a9" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.2" "https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz#7919489310a5f17f7acbab64d731e46dca0702874840dadce8bd4b2b3b8e7a82" ldflags_dirs standard verify_py36 ensurepip
+  install_package "Python-3.6.2" "https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz#7919489310a5f17f7acbab64d731e46dca0702874840dadce8bd4b2b3b8e7a82" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.3
+++ b/plugins/python-build/share/python-build/3.6.3
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.3" "https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tar.xz#cda7d967c9a4bfa52337cdf551bcc5cff026b6ac50a8834e568ce4a794ca81da" ldflags_dirs standard verify_py36 ensurepip
+  install_package "Python-3.6.3" "https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tar.xz#cda7d967c9a4bfa52337cdf551bcc5cff026b6ac50a8834e568ce4a794ca81da" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.3" "https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tgz#ab6193af1921b30f587b302fe385268510e80187ca83ca82d2bfe7ab544c6f91" ldflags_dirs standard verify_py36 ensurepip
+  install_package "Python-3.6.3" "https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tgz#ab6193af1921b30f587b302fe385268510e80187ca83ca82d2bfe7ab544c6f91" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.4
+++ b/plugins/python-build/share/python-build/3.6.4
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.4" "https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tar.xz#159b932bf56aeaa76fd66e7420522d8c8853d486b8567c459b84fe2ed13bcaba" ldflags_dirs standard verify_py36 ensurepip
+  install_package "Python-3.6.4" "https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tar.xz#159b932bf56aeaa76fd66e7420522d8c8853d486b8567c459b84fe2ed13bcaba" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.4" "https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tgz#7dc453e1a93c083388eb1a23a256862407f8234a96dc4fae0fc7682020227486" ldflags_dirs standard verify_py36 ensurepip
+  install_package "Python-3.6.4" "https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tgz#7dc453e1a93c083388eb1a23a256862407f8234a96dc4fae0fc7682020227486" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.5
+++ b/plugins/python-build/share/python-build/3.6.5
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.5" "https://www.python.org/ftp/python/3.6.5/Python-3.6.5.tar.xz#f434053ba1b5c8a5cc597e966ead3c5143012af827fd3f0697d21450bb8d87a6" ldflags_dirs standard verify_py36 ensurepip
+  install_package "Python-3.6.5" "https://www.python.org/ftp/python/3.6.5/Python-3.6.5.tar.xz#f434053ba1b5c8a5cc597e966ead3c5143012af827fd3f0697d21450bb8d87a6" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.5" "https://www.python.org/ftp/python/3.6.5/Python-3.6.5.tgz#53a3e17d77cd15c5230192b6a8c1e031c07cd9f34a2f089a731c6f6bd343d5c6" ldflags_dirs standard verify_py36 ensurepip
+  install_package "Python-3.6.5" "https://www.python.org/ftp/python/3.6.5/Python-3.6.5.tgz#53a3e17d77cd15c5230192b6a8c1e031c07cd9f34a2f089a731c6f6bd343d5c6" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.6
+++ b/plugins/python-build/share/python-build/3.6.6
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.6" "https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tar.xz#d79bc15d456e73a3173a2938f18a17e5149c850ebdedf84a78067f501ee6e16f" ldflags_dirs standard verify_py36 ensurepip
+  install_package "Python-3.6.6" "https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tar.xz#d79bc15d456e73a3173a2938f18a17e5149c850ebdedf84a78067f501ee6e16f" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.6" "https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tgz#7d56dadf6c7d92a238702389e80cfe66fbfae73e584189ed6f89c75bbf3eda58" ldflags_dirs standard verify_py36 ensurepip
+  install_package "Python-3.6.6" "https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tgz#7d56dadf6c7d92a238702389e80cfe66fbfae73e584189ed6f89c75bbf3eda58" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.7
+++ b/plugins/python-build/share/python-build/3.6.7
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.7" "https://www.python.org/ftp/python/3.6.7/Python-3.6.7.tar.xz#81fd1401a9d66533b0a3e9e3f4ea1c7c6702d57d5b90d659f971e6f1b745f77d" ldflags_dirs standard verify_py37 ensurepip
+  install_package "Python-3.6.7" "https://www.python.org/ftp/python/3.6.7/Python-3.6.7.tar.xz#81fd1401a9d66533b0a3e9e3f4ea1c7c6702d57d5b90d659f971e6f1b745f77d" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.7" "https://www.python.org/ftp/python/3.6.7/Python-3.6.7.tgz#b7c36f7ed8f7143b2c46153b7332db2227669f583ea0cce753facf549d1a4239" ldflags_dirs standard verify_py37 ensurepip
+  install_package "Python-3.6.7" "https://www.python.org/ftp/python/3.6.7/Python-3.6.7.tgz#b7c36f7ed8f7143b2c46153b7332db2227669f583ea0cce753facf549d1a4239" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.8
+++ b/plugins/python-build/share/python-build/3.6.8
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.8" "https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tar.xz#35446241e995773b1bed7d196f4b624dadcadc8429f26282e756b2fb8a351193" ldflags_dirs standard verify_py37 ensurepip
+  install_package "Python-3.6.8" "https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tar.xz#35446241e995773b1bed7d196f4b624dadcadc8429f26282e756b2fb8a351193" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.8" "https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tgz#7f5b1f08b3b0a595387ef6c64c85b1b13b38abef0dd871835ee923262e4f32f0" ldflags_dirs standard verify_py37 ensurepip
+  install_package "Python-3.6.8" "https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tgz#7f5b1f08b3b0a595387ef6c64c85b1b13b38abef0dd871835ee923262e4f32f0" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.7-dev
+++ b/plugins/python-build/share/python-build/3.7-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_git "Python-3.7-dev" "https://github.com/python/cpython" "3.7" standard verify_py37 ensurepip
+install_git "Python-3.7-dev" "https://github.com/python/cpython" "3.7" standard verify_py37 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.7.0
+++ b/plugins/python-build/share/python-build/3.7.0
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.0" "https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tar.xz#0382996d1ee6aafe59763426cf0139ffebe36984474d0ec4126dd1c40a8b3549" ldflags_dirs standard verify_py37 ensurepip
+  install_package "Python-3.7.0" "https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tar.xz#0382996d1ee6aafe59763426cf0139ffebe36984474d0ec4126dd1c40a8b3549" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.0" "https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tgz#85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d" ldflags_dirs standard verify_py37 ensurepip
+  install_package "Python-3.7.0" "https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tgz#85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.7.1
+++ b/plugins/python-build/share/python-build/3.7.1
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.1" "https://www.python.org/ftp/python/3.7.1/Python-3.7.1.tar.xz#fa7e2b8e8c9402f192ad56dc4f814089d1c4466c97d780f5e5acc02c04243d6d" ldflags_dirs standard verify_py37 ensurepip
+  install_package "Python-3.7.1" "https://www.python.org/ftp/python/3.7.1/Python-3.7.1.tar.xz#fa7e2b8e8c9402f192ad56dc4f814089d1c4466c97d780f5e5acc02c04243d6d" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.1" "https://www.python.org/ftp/python/3.7.1/Python-3.7.1.tgz#36c1b81ac29d0f8341f727ef40864d99d8206897be96be73dc34d4739c9c9f06" ldflags_dirs standard verify_py37 ensurepip
+  install_package "Python-3.7.1" "https://www.python.org/ftp/python/3.7.1/Python-3.7.1.tgz#36c1b81ac29d0f8341f727ef40864d99d8206897be96be73dc34d4739c9c9f06" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.7.2
+++ b/plugins/python-build/share/python-build/3.7.2
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.2" "https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tar.xz#d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb" ldflags_dirs standard verify_py37 ensurepip
+  install_package "Python-3.7.2" "https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tar.xz#d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.2" "https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tgz#f09d83c773b9cc72421abba2c317e4e6e05d919f9bcf34468e192b6a6c8e328d" ldflags_dirs standard verify_py37 ensurepip
+  install_package "Python-3.7.2" "https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tgz#f09d83c773b9cc72421abba2c317e4e6e05d919f9bcf34468e192b6a6c8e328d" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.8-dev
+++ b/plugins/python-build/share/python-build/3.8-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_git "Python-3.8-dev" "https://github.com/python/cpython" master standard verify_py38 ensurepip
+install_git "Python-3.8-dev" "https://github.com/python/cpython" master standard verify_py38 copy_python_gdb ensurepip


### PR DESCRIPTION
The script in `Tools/gdb/libpython.py` has helper functions for
debugging Python processes under gdb. When installed to `{exe}-gdb.py`
it will automatically be loaded by gdb assuming it is in the safe path.

gdb resolves all symlinks, so having the single script is sufficient
regardless of how Python is invoked.

Since it is usually only included as part of a dbg/dev package, this
file is intentionally excluded from install by the CPython build
scripts. Like the packaging with EPEL/Debian, we opt to manually copy
it after the build/install.

To ensure this file gets picked up it is enough for users to put this in
their `~/.gdbinit`:

```
add-auto-load-safe-path ~/.pyenv
```

Fixes #1190.