### PR TITLE
Add CI builds that actually build Python.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,78 @@
-sudo: false
-install: git clone --depth 1 https://github.com/sstephenson/bats.git
-script: make test
+# Two types of tests:
+#
+# 1. shell tests run using bats
+# 2. build tests also run using bats
+#
+# Shell tests are run unconditionally on Linux (see jobs.include).
+#
+# Build tests can be skipped by starting the commit message with
+# '[skip build]'.
+#
+# Build tests are run on platforms generated from all combinations
+# of keys below.
 language: c
+
+os:
+- linux
+- osx
+
+dist:
+- xenial
+
+# https://docs.travis-ci.com/user/reference/osx/#macos-version
+osx_image:
+- xcode9.4
+- xcode10
+
 env:
-  - PYENV_NATIVE_EXT=
-  - PYENV_NATIVE_EXT=1
+- PYTHON_BUILD_VERSION=3.8-dev
+- PYTHON_BUILD_VERSION=3.7.2
+
+before_install:
+- date +%Y-%m-%dT%H:%M:%S
+
+install: git clone --depth 1 https://github.com/bats-core/bats-core.git bats
+
+# Default for auto-generated jobs.
+script: make test-build
+
+after_script: |
+  cat "$(ls -tr ${TMPDIR:-/tmp}/python-build.*.log | tail -1)"
+
+jobs:
+  include:
+  # Shell-based tests should execute every time.
+  - stage: test shell
+    script: make test
+    env: PYENV_NATIVE_EXT=1
+    after_script: []
+    os: linux
+  - stage: test shell
+    script: make test
+    env: PYENV_NATIVE_EXT=
+    after_script: []
+    os: linux
+
+  exclude:
+  # For each osx_image but one there should be an entry in the exclude
+  # list, to prevent duplicate Linux builds.
+  - os: linux
+    osx_image: xcode9.4
+
+  allow_failures:
+  - env: PYTHON_BUILD_VERSION=3.8-dev
+
+stages:
+- test shell
+- name: test
+  if: NOT (commit_message =~ /^\[skip build\]/)
+
+# Default 
+
 notifications:
   email:
     on_success: never
+
 deploy:
   provider: releases
   api_key:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test
+.PHONY: test test-build
 
 # Do not pass in user flags to build tests.
 unexport PYTHON_CFLAGS
@@ -8,5 +8,8 @@ test: bats
 	PATH="./bats/bin:$$PATH" test/run
 	cd plugins/python-build && $(PWD)/bats/bin/bats $${CI:+--tap} test
 
+test-build: bats
+	cd plugins/python-build && $(PWD)/bats/bin/bats $${CI:+--tap} test/build
+
 bats:
-	git clone --depth 1 https://github.com/sstephenson/bats.git
+	git clone --depth 1 https://github.com/bats-core/bats-core.git bats

--- a/plugins/python-build/test/build/test.bats
+++ b/plugins/python-build/test/build/test.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+load ../test_helper
+export PATH="$BATS_TEST_DIRNAME/../../bin:$PATH"
+
+export PYTHON_BUILD_VERSION="${PYTHON_BUILD_VERSION:-3.8-dev}"
+
+@test "Python build works" {
+  run python-build "$PYTHON_BUILD_VERSION" "$BATS_TMPDIR/dist"
+  assert_success
+
+  [ -e "$BATS_TMPDIR/dist/bin/python" ]
+  run "$BATS_TMPDIR/dist/bin/python" -V
+  assert_success
+  "$BATS_TMPDIR/dist/bin/python" -V >&3 2>&3
+
+  [ -e "$BATS_TMPDIR/dist/bin/pip" ]
+  run "$BATS_TMPDIR/dist/bin/pip" -V
+  assert_success
+  "$BATS_TMPDIR/dist/bin/pip" -V >&3 2>&3
+}


### PR DESCRIPTION
For now this just builds the latest CPython, but it can be
extended to include other versions.

Skip with `[skip build]` in commit message.

This covers (Ubuntu Xenial) Linux and macOS.

Currently there is an issue in Travis where multiple `osx_image` entries results in multiple linux builds being created. I've raised a support ticket, but it shouldn't cause problems unless we add many more build tests (limit is 200).