### PR TITLE
macOS: prefer homebrew openssl 1.1.x over 1.0.x, see #839

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1492,15 +1492,20 @@ has_broken_mac_openssl() {
 }
 
 use_homebrew_openssl() {
-  local ssldir="$(brew --prefix openssl 2>/dev/null || true)"
-  if [ -d "$ssldir" ]; then
-    echo "python-build: use openssl from homebrew"
-    export PKG_CONFIG_PATH="$ssldir/lib/pkgconfig/:${PKG_CONFIG_PATH}"
-    export CPPFLAGS="-I$ssldir/include ${CPPFLAGS}"
-    export LDFLAGS="-L$ssldir/lib ${LDFLAGS}"
+  local ssl11dir="$(brew --prefix openssl@1.1 2>/dev/null || true)"
+  local ssl10dir="$(brew --prefix openssl 2>/dev/null || true)"
+  if [ -d "$ssl11dir" ]; then
+    echo "python-build: use openssl 1.1 from homebrew"
+    local ssldir=$ssl11dir
+  elif [ -d "$ssl10dir" ]; then
+    echo "python-build: use openssl 1.0 from homebrew"
+    local ssldir=$ssl10dir
   else
     return 1
   fi
+  export PKG_CONFIG_PATH="$ssldir/lib/pkgconfig/:${PKG_CONFIG_PATH}"
+  export CPPFLAGS="-I$ssldir/include ${CPPFLAGS}"
+  export LDFLAGS="-L$ssldir/lib ${LDFLAGS}"
 }
 
 build_package_mac_openssl() {


### PR DESCRIPTION
previously, it was not possible to compile a python with homebrew openssl 1.1 because the code always queried "openssl" and ignored "openssl@1.1".

now, if 1.1 is installed, it is used to compile python and only if it is not, 1.0 is checked and used.
