### PR TITLE
Update generated configuration files before run ./configure

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -791,7 +791,7 @@ build_package_standard() {
 }
 
 build_package_autoconf() {
-  { autoconf
+  { autoreconf
   } >&4 2>&1
 }
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
**Not applicable.**

* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
**Not applicable.**

* [x] My PR addresses the following pyenv issue (if any)
  - [1311](https://github.com/pyenv/pyenv/issues/1311)
  - [1184](https://github.com/pyenv/pyenv/issues/1184)
  - [1268](https://github.com/pyenv/pyenv/issues/1268)
  - [993](https://github.com/pyenv/pyenv/issues/993)

### Description
- [x] Here are some details about my PR
`python-build` plugin fails to find some dependency packages because it uses the default `configure` script,  so update the `configure` script and other generated scripts on target system to solve this issue by running autoreconf intead autoconf

### Tests
- [ ] My PR adds the following unit tests (if any)
