### PR TITLE
Fix 2.4 builds: redeclaration of posix_close

### DIFF
--- a/plugins/python-build/share/python-build/patches/2.4.0/Python-2.4/002_patch-posixmodule.diff
+++ b/plugins/python-build/share/python-build/patches/2.4.0/Python-2.4/002_patch-posixmodule.diff
@@ -1,0 +1,20 @@
+--- Modules/posixmodule.c.orig	2019-04-04 20:27:41.000000000 +0200
++++ Modules/posixmodule.c	2019-04-04 20:28:07.000000000 +0200
+@@ -5300,7 +5300,7 @@
+ Close a file descriptor (for low level IO).");
+ 
+ static PyObject *
+-posix_close(PyObject *self, PyObject *args)
++posix_closex(PyObject *self, PyObject *args)
+ {
+ 	int fd, res;
+ 	if (!PyArg_ParseTuple(args, "i:close", &fd))
+@@ -7554,7 +7554,7 @@
+ 	{"tcsetpgrp",	posix_tcsetpgrp, METH_VARARGS, posix_tcsetpgrp__doc__},
+ #endif /* HAVE_TCSETPGRP */
+ 	{"open",	posix_open, METH_VARARGS, posix_open__doc__},
+-	{"close",	posix_close, METH_VARARGS, posix_close__doc__},
++	{"close",	posix_closex, METH_VARARGS, posix_close__doc__},
+ 	{"dup",		posix_dup, METH_VARARGS, posix_dup__doc__},
+ 	{"dup2",	posix_dup2, METH_VARARGS, posix_dup2__doc__},
+ 	{"lseek",	posix_lseek, METH_VARARGS, posix_lseek__doc__},

--- a/plugins/python-build/share/python-build/patches/2.4.1/Python-2.4.1/002_patch-posixmodule.diff
+++ b/plugins/python-build/share/python-build/patches/2.4.1/Python-2.4.1/002_patch-posixmodule.diff
@@ -1,0 +1,20 @@
+--- Modules/posixmodule.c.orig	2019-04-04 20:27:41.000000000 +0200
++++ Modules/posixmodule.c	2019-04-04 20:28:07.000000000 +0200
+@@ -5300,7 +5300,7 @@
+ Close a file descriptor (for low level IO).");
+ 
+ static PyObject *
+-posix_close(PyObject *self, PyObject *args)
++posix_closex(PyObject *self, PyObject *args)
+ {
+ 	int fd, res;
+ 	if (!PyArg_ParseTuple(args, "i:close", &fd))
+@@ -7554,7 +7554,7 @@
+ 	{"tcsetpgrp",	posix_tcsetpgrp, METH_VARARGS, posix_tcsetpgrp__doc__},
+ #endif /* HAVE_TCSETPGRP */
+ 	{"open",	posix_open, METH_VARARGS, posix_open__doc__},
+-	{"close",	posix_close, METH_VARARGS, posix_close__doc__},
++	{"close",	posix_closex, METH_VARARGS, posix_close__doc__},
+ 	{"dup",		posix_dup, METH_VARARGS, posix_dup__doc__},
+ 	{"dup2",	posix_dup2, METH_VARARGS, posix_dup2__doc__},
+ 	{"lseek",	posix_lseek, METH_VARARGS, posix_lseek__doc__},

--- a/plugins/python-build/share/python-build/patches/2.4.2/Python-2.4.2/002_patch-posixmodule.diff
+++ b/plugins/python-build/share/python-build/patches/2.4.2/Python-2.4.2/002_patch-posixmodule.diff
@@ -1,0 +1,20 @@
+--- Modules/posixmodule.c.orig	2019-04-04 20:27:41.000000000 +0200
++++ Modules/posixmodule.c	2019-04-04 20:28:07.000000000 +0200
+@@ -5300,7 +5300,7 @@
+ Close a file descriptor (for low level IO).");
+ 
+ static PyObject *
+-posix_close(PyObject *self, PyObject *args)
++posix_closex(PyObject *self, PyObject *args)
+ {
+ 	int fd, res;
+ 	if (!PyArg_ParseTuple(args, "i:close", &fd))
+@@ -7554,7 +7554,7 @@
+ 	{"tcsetpgrp",	posix_tcsetpgrp, METH_VARARGS, posix_tcsetpgrp__doc__},
+ #endif /* HAVE_TCSETPGRP */
+ 	{"open",	posix_open, METH_VARARGS, posix_open__doc__},
+-	{"close",	posix_close, METH_VARARGS, posix_close__doc__},
++	{"close",	posix_closex, METH_VARARGS, posix_close__doc__},
+ 	{"dup",		posix_dup, METH_VARARGS, posix_dup__doc__},
+ 	{"dup2",	posix_dup2, METH_VARARGS, posix_dup2__doc__},
+ 	{"lseek",	posix_lseek, METH_VARARGS, posix_lseek__doc__},

--- a/plugins/python-build/share/python-build/patches/2.4.3/Python-2.4.3/002_patch-posixmodule.diff
+++ b/plugins/python-build/share/python-build/patches/2.4.3/Python-2.4.3/002_patch-posixmodule.diff
@@ -1,0 +1,20 @@
+--- Modules/posixmodule.c.orig	2019-04-04 20:27:41.000000000 +0200
++++ Modules/posixmodule.c	2019-04-04 20:28:07.000000000 +0200
+@@ -5300,7 +5300,7 @@
+ Close a file descriptor (for low level IO).");
+ 
+ static PyObject *
+-posix_close(PyObject *self, PyObject *args)
++posix_closex(PyObject *self, PyObject *args)
+ {
+ 	int fd, res;
+ 	if (!PyArg_ParseTuple(args, "i:close", &fd))
+@@ -7554,7 +7554,7 @@
+ 	{"tcsetpgrp",	posix_tcsetpgrp, METH_VARARGS, posix_tcsetpgrp__doc__},
+ #endif /* HAVE_TCSETPGRP */
+ 	{"open",	posix_open, METH_VARARGS, posix_open__doc__},
+-	{"close",	posix_close, METH_VARARGS, posix_close__doc__},
++	{"close",	posix_closex, METH_VARARGS, posix_close__doc__},
+ 	{"dup",		posix_dup, METH_VARARGS, posix_dup__doc__},
+ 	{"dup2",	posix_dup2, METH_VARARGS, posix_dup2__doc__},
+ 	{"lseek",	posix_lseek, METH_VARARGS, posix_lseek__doc__},

--- a/plugins/python-build/share/python-build/patches/2.4.4/Python-2.4.4/001_patch-posixmodule.diff
+++ b/plugins/python-build/share/python-build/patches/2.4.4/Python-2.4.4/001_patch-posixmodule.diff
@@ -1,0 +1,20 @@
+--- Modules/posixmodule.c.orig	2019-04-04 20:27:41.000000000 +0200
++++ Modules/posixmodule.c	2019-04-04 20:28:07.000000000 +0200
+@@ -5300,7 +5300,7 @@
+ Close a file descriptor (for low level IO).");
+ 
+ static PyObject *
+-posix_close(PyObject *self, PyObject *args)
++posix_closex(PyObject *self, PyObject *args)
+ {
+ 	int fd, res;
+ 	if (!PyArg_ParseTuple(args, "i:close", &fd))
+@@ -7554,7 +7554,7 @@
+ 	{"tcsetpgrp",	posix_tcsetpgrp, METH_VARARGS, posix_tcsetpgrp__doc__},
+ #endif /* HAVE_TCSETPGRP */
+ 	{"open",	posix_open, METH_VARARGS, posix_open__doc__},
+-	{"close",	posix_close, METH_VARARGS, posix_close__doc__},
++	{"close",	posix_closex, METH_VARARGS, posix_close__doc__},
+ 	{"dup",		posix_dup, METH_VARARGS, posix_dup__doc__},
+ 	{"dup2",	posix_dup2, METH_VARARGS, posix_dup2__doc__},
+ 	{"lseek",	posix_lseek, METH_VARARGS, posix_lseek__doc__},

--- a/plugins/python-build/share/python-build/patches/2.4.5/Python-2.4.5/001_patch-posixmodule.diff
+++ b/plugins/python-build/share/python-build/patches/2.4.5/Python-2.4.5/001_patch-posixmodule.diff
@@ -1,0 +1,20 @@
+--- Modules/posixmodule.c.orig	2019-04-04 20:27:41.000000000 +0200
++++ Modules/posixmodule.c	2019-04-04 20:28:07.000000000 +0200
+@@ -5300,7 +5300,7 @@
+ Close a file descriptor (for low level IO).");
+ 
+ static PyObject *
+-posix_close(PyObject *self, PyObject *args)
++posix_closex(PyObject *self, PyObject *args)
+ {
+ 	int fd, res;
+ 	if (!PyArg_ParseTuple(args, "i:close", &fd))
+@@ -7554,7 +7554,7 @@
+ 	{"tcsetpgrp",	posix_tcsetpgrp, METH_VARARGS, posix_tcsetpgrp__doc__},
+ #endif /* HAVE_TCSETPGRP */
+ 	{"open",	posix_open, METH_VARARGS, posix_open__doc__},
+-	{"close",	posix_close, METH_VARARGS, posix_close__doc__},
++	{"close",	posix_closex, METH_VARARGS, posix_close__doc__},
+ 	{"dup",		posix_dup, METH_VARARGS, posix_dup__doc__},
+ 	{"dup2",	posix_dup2, METH_VARARGS, posix_dup2__doc__},
+ 	{"lseek",	posix_lseek, METH_VARARGS, posix_lseek__doc__},

--- a/plugins/python-build/share/python-build/patches/2.4.6/Python-2.4.6/001_patch-posixmodule.diff
+++ b/plugins/python-build/share/python-build/patches/2.4.6/Python-2.4.6/001_patch-posixmodule.diff
@@ -1,0 +1,20 @@
+--- Modules/posixmodule.c.orig	2019-04-04 20:27:41.000000000 +0200
++++ Modules/posixmodule.c	2019-04-04 20:28:07.000000000 +0200
+@@ -5300,7 +5300,7 @@
+ Close a file descriptor (for low level IO).");
+ 
+ static PyObject *
+-posix_close(PyObject *self, PyObject *args)
++posix_closex(PyObject *self, PyObject *args)
+ {
+ 	int fd, res;
+ 	if (!PyArg_ParseTuple(args, "i:close", &fd))
+@@ -7554,7 +7554,7 @@
+ 	{"tcsetpgrp",	posix_tcsetpgrp, METH_VARARGS, posix_tcsetpgrp__doc__},
+ #endif /* HAVE_TCSETPGRP */
+ 	{"open",	posix_open, METH_VARARGS, posix_open__doc__},
+-	{"close",	posix_close, METH_VARARGS, posix_close__doc__},
++	{"close",	posix_closex, METH_VARARGS, posix_close__doc__},
+ 	{"dup",		posix_dup, METH_VARARGS, posix_dup__doc__},
+ 	{"dup2",	posix_dup2, METH_VARARGS, posix_dup2__doc__},
+ 	{"lseek",	posix_lseek, METH_VARARGS, posix_lseek__doc__},


### PR DESCRIPTION

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.

### Description
I need to run some ancient app that only supports 2.4.

When running `pyenv install 2.4.6` on Alpine Linux, the following error occurs and the build is aborted:

```
Downloading Python-2.4.6.tgz...
-> https://www.python.org/ftp/python/2.4.6/Python-2.4.6.tgz
Installing Python-2.4.6...
patching file setup.py
Hunk #2 succeeded at 239 with fuzz 2 (offset -4 lines).

BUILD FAILED (Alpine Linux 3.8.4 using python-build 1.2.10)

Inspect or clean up the working tree at /tmp/python-build.20190404185130.79
Results logged to /tmp/python-build.20190404185130.79.log

Last 10 log lines:
 posix_close(PyObject *self, PyObject *args)
 ^~~~~~~~~~~
In file included from /usr/include/fortify/unistd.h:20:0,
                 from ./Include/Python.h:41,
                 from ./Modules/posixmodule.c:28:
/usr/include/unistd.h:38:5: note: previous declaration of 'posix_close' was here
 int posix_close(int, int);
     ^~~~~~~~~~~
make: *** [Makefile:1071: Modules/posixmodule.o] Error 1
make: *** Waiting for unfinished jobs....
```

This is a known issue from 2014: https://bugs.python.org/issue20594
The patch from this issue did the trick. I just ported it to the 2.4.x posixmodule.c. Building 2.4.1 and 2.4.6 worked afterwards.

