### PR TITLE
openssl related improvements

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -253,8 +253,7 @@ compute_sha2() {
     output="$(sha256sum -b)" || return 1
     echo "${output%% *}"
   elif type openssl &>/dev/null; then
-    local openssl="$(command -v "$(brew --prefix openssl 2>/dev/null || true)"/bin/openssl openssl | head -1)"
-    output="$("$openssl" dgst -sha256 2>/dev/null)" || return 1
+    output="$(openssl dgst -sha256)" || return 1
     echo "${output##* }"
   else
     return 1

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -249,13 +249,13 @@ compute_sha2() {
   if type shasum &>/dev/null; then
     output="$(shasum -a 256 -b)" || return 1
     echo "${output% *}"
+  elif type sha256sum &>/dev/null; then
+    output="$(sha256sum -b)" || return 1
+    echo "${output%% *}"
   elif type openssl &>/dev/null; then
     local openssl="$(command -v "$(brew --prefix openssl 2>/dev/null || true)"/bin/openssl openssl | head -1)"
     output="$("$openssl" dgst -sha256 2>/dev/null)" || return 1
     echo "${output##* }"
-  elif type sha256sum &>/dev/null; then
-    output="$(sha256sum -b)" || return 1
-    echo "${output%% *}"
   else
     return 1
   fi
@@ -265,12 +265,12 @@ compute_md5() {
   local output
   if type md5 &>/dev/null; then
     md5 -q
-  elif type openssl &>/dev/null; then
-    output="$(openssl md5)" || return 1
-    echo "${output##* }"
   elif type md5sum &>/dev/null; then
     output="$(md5sum -b)" || return 1
     echo "${output%% *}"
+  elif type openssl &>/dev/null; then
+    output="$(openssl md5)" || return 1
+    echo "${output##* }"
   else
     return 1
   fi


### PR DESCRIPTION
take this rather as an idea than a ready-to-use PR.

it's just 2 things i noticed when looking at that code that seemed strange:
- why is it invoking openssl before even trying sha256sum or md5sum? this commit is just moving the openssl based elif-block to the end.
- why invoke the brew openssl even for trivial stuff like `openssl dgst -sha256` (i found the historic reason, see commit comment - the question now is whether that is still needed). the code after this commit is now closer to the md5 openssl based code in the other function.

not tested on macOS yet.