### PR TITLE
Prefer OpenSSL 1.1 only for specific python versions

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1486,8 +1486,8 @@ use_homebrew_readline() {
 
 prefer_openssl11() {
   # Allow overriding the preference of OpenSSL version per definition basis (#1302, #1325, #1326)
-  PYTHON_BUILD_HOMEBRE_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBRE_OPENSSL_FORMULA:-openssl@1.1 openssl}"
-  export PYTHON_BUILD_HOMEBRE_OPENSSL_FORMULA
+  PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl@1.1 openssl}"
+  export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA
 }
 
 has_broken_mac_openssl() {
@@ -1498,12 +1498,12 @@ has_broken_mac_openssl() {
 }
 
 use_homebrew_openssl() {
-  for openssl in ${PYTHON_BUILD_HOMEBRE_OPENSSL_FORMULA:-openssl}; do
+  for openssl in ${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl}; do
     local ssldir="$(brew --prefix "${openssl}" || true)"
     if [ -d "$ssldir" ]; then
       echo "python-build: use ${openssl} from homebrew"
       if [[ -n "${PYTHON_BUILD_CONFIGURE_WITH_OPENSSL:-}" ]]; then
-        # configure scriopt of newer CPython versions support `--with-openssl`
+        # configure script of newer CPython versions support `--with-openssl`
         # https://bugs.python.org/issue21541
         package_option python configure --with-openssl="${ssldir}"
       else
@@ -1526,7 +1526,7 @@ build_package_mac_openssl() {
 
   # Tell Python to use this openssl for its extension.
   if [[ -n "${PYTHON_BUILD_CONFIGURE_WITH_OPENSSL:-}" ]]; then
-    # configure scriopt of newer CPython versions support `--with-openssl`
+    # configure script of newer CPython versions support `--with-openssl`
     # https://bugs.python.org/issue21541
     package_option python configure --with-openssl="${OPENSSL_PREFIX_PATH}"
   else

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1502,9 +1502,15 @@ use_homebrew_openssl() {
     local ssldir="$(brew --prefix "${openssl}" || true)"
     if [ -d "$ssldir" ]; then
       echo "python-build: use ${openssl} from homebrew"
+      if [[ -n "${PYTHON_BUILD_CONFIGURE_WITH_OPENSSL:-}" ]]; then
+        # configure scriopt of newer CPython versions support `--with-openssl`
+        # https://bugs.python.org/issue21541
+        package_option python configure --with-openssl="${ssldir}"
+      else
+        export CPPFLAGS="-I$ssldir/include ${CPPFLAGS}"
+        export LDFLAGS="-L$ssldir/lib ${LDFLAGS}"
+      fi
       export PKG_CONFIG_PATH="$ssldir/lib/pkgconfig/:${PKG_CONFIG_PATH}"
-      export CPPFLAGS="-I$ssldir/include ${CPPFLAGS}"
-      export LDFLAGS="-L$ssldir/lib ${LDFLAGS}"
       return
     fi
   done
@@ -1519,8 +1525,14 @@ build_package_mac_openssl() {
   OPENSSLDIR="${OPENSSLDIR:-$OPENSSL_PREFIX_PATH/ssl}"
 
   # Tell Python to use this openssl for its extension.
-  export CPPFLAGS="-I${OPENSSL_PREFIX_PATH}/include ${CPPFLAGS}"
-  export LDFLAGS="-L${OPENSSL_PREFIX_PATH}/lib ${LDFLAGS}"
+  if [[ -n "${PYTHON_BUILD_CONFIGURE_WITH_OPENSSL:-}" ]]; then
+    # configure scriopt of newer CPython versions support `--with-openssl`
+    # https://bugs.python.org/issue21541
+    package_option python configure --with-openssl="${OPENSSL_PREFIX_PATH}"
+  else
+    export CPPFLAGS="-I${OPENSSL_PREFIX_PATH}/include ${CPPFLAGS}"
+    export LDFLAGS="-L${OPENSSL_PREFIX_PATH}/lib ${LDFLAGS}"
+  fi
 
   # Make sure pkg-config finds our build first.
   export PKG_CONFIG_PATH="${OPENSSL_PREFIX_PATH}/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1484,6 +1484,12 @@ use_homebrew_readline() {
   fi
 }
 
+prefer_openssl11() {
+  # Allow overriding the preference of OpenSSL version per definition basis (#1302, #1325, #1326)
+  PYTHON_BUILD_HOMEBRE_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBRE_OPENSSL_FORMULA:-openssl@1.1 openssl}"
+  export PYTHON_BUILD_HOMEBRE_OPENSSL_FORMULA
+}
+
 has_broken_mac_openssl() {
   is_mac || return 1
   local openssl_version="$(/usr/bin/openssl version 2>/dev/null || true)"
@@ -1492,20 +1498,17 @@ has_broken_mac_openssl() {
 }
 
 use_homebrew_openssl() {
-  local ssl11dir="$(brew --prefix openssl@1.1 2>/dev/null || true)"
-  local ssl10dir="$(brew --prefix openssl 2>/dev/null || true)"
-  if [ -d "$ssl11dir" ]; then
-    echo "python-build: use openssl 1.1 from homebrew"
-    local ssldir=$ssl11dir
-  elif [ -d "$ssl10dir" ]; then
-    echo "python-build: use openssl 1.0 from homebrew"
-    local ssldir=$ssl10dir
-  else
-    return 1
-  fi
-  export PKG_CONFIG_PATH="$ssldir/lib/pkgconfig/:${PKG_CONFIG_PATH}"
-  export CPPFLAGS="-I$ssldir/include ${CPPFLAGS}"
-  export LDFLAGS="-L$ssldir/lib ${LDFLAGS}"
+  for openssl in ${PYTHON_BUILD_HOMEBRE_OPENSSL_FORMULA:-openssl}; do
+    local ssldir="$(brew --prefix "${openssl}" || true)"
+    if [ -d "$ssldir" ]; then
+      echo "python-build: use ${openssl} from homebrew"
+      export PKG_CONFIG_PATH="$ssldir/lib/pkgconfig/:${PKG_CONFIG_PATH}"
+      export CPPFLAGS="-I$ssldir/include ${CPPFLAGS}"
+      export LDFLAGS="-L$ssldir/lib ${LDFLAGS}"
+      return
+    fi
+  done
+  return 1
 }
 
 build_package_mac_openssl() {

--- a/plugins/python-build/share/python-build/2.7-dev
+++ b/plugins/python-build/share/python-build/2.7-dev
@@ -1,5 +1,5 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-2.7-dev" "https://github.com/python/cpython" "2.7" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7-dev
+++ b/plugins/python-build/share/python-build/2.7-dev
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-2.7-dev" "https://github.com/python/cpython" "2.7" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.14
+++ b/plugins/python-build/share/python-build/2.7.14
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/2.7.14
+++ b/plugins/python-build/share/python-build/2.7.14
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.14" "https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tar.xz#71ffb26e09e78650e424929b2b457b9c912ac216576e6bd9e7d204ed03296a66" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.15
+++ b/plugins/python-build/share/python-build/2.7.15
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.15" "https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tar.xz#22d9b1ac5b26135ad2b8c2901a9413537e08749a753356ee913c84dbd2df5574" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.15
+++ b/plugins/python-build/share/python-build/2.7.15
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.4-dev
+++ b/plugins/python-build/share/python-build/3.4-dev
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.4-dev" "https://github.com/python/cpython" "3.4" standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4-dev
+++ b/plugins/python-build/share/python-build/3.4-dev
@@ -1,5 +1,5 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.4-dev" "https://github.com/python/cpython" "3.4" standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.5-dev
+++ b/plugins/python-build/share/python-build/3.5-dev
@@ -1,5 +1,5 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.5-dev" "https://github.com/python/cpython" "3.5" standard verify_py35 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.5-dev
+++ b/plugins/python-build/share/python-build/3.5-dev
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.5-dev" "https://github.com/python/cpython" "3.5" standard verify_py35 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.5.3
+++ b/plugins/python-build/share/python-build/3.5.3
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.5.3
+++ b/plugins/python-build/share/python-build/3.5.3
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.5.3" "https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tar.xz#eefe2ad6575855423ab630f5b51a8ef6e5556f774584c06beab4926f930ddbb0" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.5.4
+++ b/plugins/python-build/share/python-build/3.5.4
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.5.4
+++ b/plugins/python-build/share/python-build/3.5.4
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.5.4" "https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tar.xz#94d93bfabb3b109f8a10365a325f920f9ec98c6e2380bf228f9700a14054c84c" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.5.5
+++ b/plugins/python-build/share/python-build/3.5.5
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.5.5
+++ b/plugins/python-build/share/python-build/3.5.5
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.5.5" "https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tar.xz#063d2c3b0402d6191b90731e0f735c64830e7522348aeb7ed382a83165d45009" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.5.6
+++ b/plugins/python-build/share/python-build/3.5.6
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.5.6" "https://www.python.org/ftp/python/3.5.6/Python-3.5.6.tar.xz#f55cde04f521f273c7cba08912921cc5642cfc15ca7b22d5829f0aff4371155f" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.5.6
+++ b/plugins/python-build/share/python-build/3.5.6
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.5.7
+++ b/plugins/python-build/share/python-build/3.5.7
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.5.7
+++ b/plugins/python-build/share/python-build/3.5.7
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.5.7" "https://www.python.org/ftp/python/3.5.7/Python-3.5.7.tar.xz#285892899bf4d5737fd08482aa6171c6b2564a45b9102dfacfb72826aebdc7dc" ldflags_dirs standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.6-dev
+++ b/plugins/python-build/share/python-build/3.6-dev
@@ -1,5 +1,5 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.6-dev" "https://github.com/python/cpython" "3.6" standard verify_py36 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.6-dev
+++ b/plugins/python-build/share/python-build/3.6-dev
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.6-dev" "https://github.com/python/cpython" "3.6" standard verify_py36 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.6.7
+++ b/plugins/python-build/share/python-build/3.6.7
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.6.7" "https://www.python.org/ftp/python/3.6.7/Python-3.6.7.tar.xz#81fd1401a9d66533b0a3e9e3f4ea1c7c6702d57d5b90d659f971e6f1b745f77d" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.6.7
+++ b/plugins/python-build/share/python-build/3.6.7
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.6.8
+++ b/plugins/python-build/share/python-build/3.6.8
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.6.8" "https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tar.xz#35446241e995773b1bed7d196f4b624dadcadc8429f26282e756b2fb8a351193" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.6.8
+++ b/plugins/python-build/share/python-build/3.6.8
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.7-dev
+++ b/plugins/python-build/share/python-build/3.7-dev
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.7-dev" "https://github.com/python/cpython" "3.7" standard verify_py37 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.7-dev
+++ b/plugins/python-build/share/python-build/3.7-dev
@@ -1,5 +1,6 @@
 #require_gcc
 prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.7-dev" "https://github.com/python/cpython" "3.7" standard verify_py37 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.7-dev
+++ b/plugins/python-build/share/python-build/3.7-dev
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.7-dev" "https://github.com/python/cpython" "3.7" standard verify_py37 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.7.0
+++ b/plugins/python-build/share/python-build/3.7.0
@@ -1,5 +1,6 @@
 #require_gcc
 prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.7.0
+++ b/plugins/python-build/share/python-build/3.7.0
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.7.0
+++ b/plugins/python-build/share/python-build/3.7.0
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.7.0" "https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tar.xz#0382996d1ee6aafe59763426cf0139ffebe36984474d0ec4126dd1c40a8b3549" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.7.1
+++ b/plugins/python-build/share/python-build/3.7.1
@@ -1,5 +1,6 @@
 #require_gcc
 prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.7.1
+++ b/plugins/python-build/share/python-build/3.7.1
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.7.1
+++ b/plugins/python-build/share/python-build/3.7.1
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.7.1" "https://www.python.org/ftp/python/3.7.1/Python-3.7.1.tar.xz#fa7e2b8e8c9402f192ad56dc4f814089d1c4466c97d780f5e5acc02c04243d6d" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.7.2
+++ b/plugins/python-build/share/python-build/3.7.2
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.7.2" "https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tar.xz#d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.7.2
+++ b/plugins/python-build/share/python-build/3.7.2
@@ -1,5 +1,6 @@
 #require_gcc
 prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.7.2
+++ b/plugins/python-build/share/python-build/3.7.2
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.7.3
+++ b/plugins/python-build/share/python-build/3.7.3
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.7.3" "https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tar.xz#da60b54064d4cfcd9c26576f6df2690e62085123826cff2e667e72a91952d318" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.7.3
+++ b/plugins/python-build/share/python-build/3.7.3
@@ -1,5 +1,6 @@
 #require_gcc
 prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.7.3
+++ b/plugins/python-build/share/python-build/3.7.3
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.8-dev
+++ b/plugins/python-build/share/python-build/3.8-dev
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.8-dev" "https://github.com/python/cpython" master standard verify_py38 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.8-dev
+++ b/plugins/python-build/share/python-build/3.8-dev
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.8-dev" "https://github.com/python/cpython" master standard verify_py38 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.8-dev
+++ b/plugins/python-build/share/python-build/3.8-dev
@@ -1,5 +1,6 @@
 #require_gcc
 prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "Python-3.8-dev" "https://github.com/python/cpython" master standard verify_py38 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/pypy-1.5-src
+++ b/plugins/python-build/share/python-build/pypy-1.5-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-1.5-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.5-src.tar.bz2" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-1.5-src
+++ b/plugins/python-build/share/python-build/pypy-1.5-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-1.5-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.5-src.tar.bz2" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-src.tar.bz2#d92dfd418beac915d3efc28f8a2090f3c13a89ec653419deff3d7112c5c111f3" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-src.tar.bz2#d92dfd418beac915d3efc28f8a2090f3c13a89ec653419deff3d7112c5c111f3" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.0.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.0.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.0.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-src.tar.bz2#d1327bc325545939236ac609ec509548a545f97b1c933dedbe42f2482a130aa0" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.0.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.0.1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.0.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-src.tar.bz2#d1327bc325545939236ac609ec509548a545f97b1c933dedbe42f2482a130aa0" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.0.2-src
+++ b/plugins/python-build/share/python-build/pypy-2.0.2-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.0.2-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-src.tar.bz2#1991c90d6b98e2408b3790d4b57b71ec1c69346328b8321505ce8f6ab4544c3c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.0.2-src
+++ b/plugins/python-build/share/python-build/pypy-2.0.2-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.0.2-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-src.tar.bz2#1991c90d6b98e2408b3790d4b57b71ec1c69346328b8321505ce8f6ab4544c3c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-src.tar.bz2#31b3066c9739b117d6bb1bdc485a919dc3b67370ec00437de1b74069943f7f17" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-src.tar.bz2#31b3066c9739b117d6bb1bdc485a919dc3b67370ec00437de1b74069943f7f17" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.2-src
+++ b/plugins/python-build/share/python-build/pypy-2.2-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.2-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-src.tar.bz2#50fffcb86039e019530a63d656580bc53c173e5f19768bddd8699cd08448e04e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.2-src
+++ b/plugins/python-build/share/python-build/pypy-2.2-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.2-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-src.tar.bz2#50fffcb86039e019530a63d656580bc53c173e5f19768bddd8699cd08448e04e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.2.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.2.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.2.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-src.tar.bz2#252045187e443656a2beb412dadac9296e8fe8db0f75a66ed5265db58c35035f" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.2.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.2.1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.2.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-src.tar.bz2#252045187e443656a2beb412dadac9296e8fe8db0f75a66ed5265db58c35035f" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.3-src
+++ b/plugins/python-build/share/python-build/pypy-2.3-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-pypy-394146e9bb67" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-src.tar.bz2#be2c271e7f9d7c0059a551ba1501713c00336e551e7f13107f0f34c721d95b0c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.3-src
+++ b/plugins/python-build/share/python-build/pypy-2.3-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-pypy-394146e9bb67" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-src.tar.bz2#be2c271e7f9d7c0059a551ba1501713c00336e551e7f13107f0f34c721d95b0c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.3.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.3.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-pypy-32f35069a16d" "https://bitbucket.org/pypy/pypy/get/release-2.3.1.tar.bz2#3fd10d97c0177c33ed358a78eb26f5bf1f91b266af853564b1a9d8c310a1e439" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.3.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.3.1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-pypy-32f35069a16d" "https://bitbucket.org/pypy/pypy/get/release-2.3.1.tar.bz2#3fd10d97c0177c33ed358a78eb26f5bf1f91b266af853564b1a9d8c310a1e439" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.4.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.4.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-pypy-c6ad44ecf5d8" "https://bitbucket.org/pypy/pypy/get/release-2.4.0.tar.bz2#7e0dec2c40106f20f002121bdabb71939915254fb91bd55b01434e4b994113d2" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.4.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.4.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-pypy-c6ad44ecf5d8" "https://bitbucket.org/pypy/pypy/get/release-2.4.0.tar.bz2#7e0dec2c40106f20f002121bdabb71939915254fb91bd55b01434e4b994113d2" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.5.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.5.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-pypy-10f1b29a2bd2" "https://bitbucket.org/pypy/pypy/get/release-2.5.0.tar.bz2#8d644a55a3150cf3d18536c784e3410bb3f3438c1505000c4f761863bacedf88" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.5.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.5.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-pypy-10f1b29a2bd2" "https://bitbucket.org/pypy/pypy/get/release-2.5.0.tar.bz2#8d644a55a3150cf3d18536c784e3410bb3f3438c1505000c4f761863bacedf88" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.5.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.5.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.5.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-src.tar.bz2#ddb3a580b1ee99c5a699172d74be91c36dda9a38946d4731d8c6a63120a3ba2a" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.5.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.5.1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.5.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-src.tar.bz2#ddb3a580b1ee99c5a699172d74be91c36dda9a38946d4731d8c6a63120a3ba2a" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.6.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.6.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.6.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-src.tar.bz2#9bf353f22d25e97a85a6d3766619966055edea1ea1b2218445d683a8ad0399d9" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.6.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.6.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.6.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-src.tar.bz2#9bf353f22d25e97a85a6d3766619966055edea1ea1b2218445d683a8ad0399d9" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.6.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.6.1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.6.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-src.tar.bz2#7fddd414c9348c2f899f79ad86adc3fc2b19443855b5243f58487e1f0ac46560" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.6.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.6.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-2.6.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-src.tar.bz2#7fddd414c9348c2f899f79ad86adc3fc2b19443855b5243f58487e1f0ac46560" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-4.0.0-src
+++ b/plugins/python-build/share/python-build/pypy-4.0.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-4.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-src.tar.bz2#acff480e44ce92acd057f2e786775af36dc3c2cd12e9efc60a1ac6a562ad7b4d" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-4.0.0-src
+++ b/plugins/python-build/share/python-build/pypy-4.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-4.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-src.tar.bz2#acff480e44ce92acd057f2e786775af36dc3c2cd12e9efc60a1ac6a562ad7b4d" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-4.0.1-src
+++ b/plugins/python-build/share/python-build/pypy-4.0.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-4.0.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-src.tar.bz2#29f5aa6ba17b34fd980e85172dfeb4086fdc373ad392b1feff2677d2d8aea23c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-4.0.1-src
+++ b/plugins/python-build/share/python-build/pypy-4.0.1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-4.0.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-src.tar.bz2#29f5aa6ba17b34fd980e85172dfeb4086fdc373ad392b1feff2677d2d8aea23c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.0.0-src
+++ b/plugins/python-build/share/python-build/pypy-5.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-5.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-src.tar.bz2#89027b1b33553b53ff7733dc4838f0a76af23552c0d915d9f6de5875b8d7d4ab" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.0.0-src
+++ b/plugins/python-build/share/python-build/pypy-5.0.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-5.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-src.tar.bz2#89027b1b33553b53ff7733dc4838f0a76af23552c0d915d9f6de5875b8d7d4ab" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.0.1-src
+++ b/plugins/python-build/share/python-build/pypy-5.0.1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-5.0.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-src.tar.bz2#1573c9284d3ec236c8e6ef3b954753932dff29462c54b5885b761d1ee68b6e05" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.0.1-src
+++ b/plugins/python-build/share/python-build/pypy-5.0.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-5.0.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-src.tar.bz2#1573c9284d3ec236c8e6ef3b954753932dff29462c54b5885b761d1ee68b6e05" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.1-src
+++ b/plugins/python-build/share/python-build/pypy-5.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-5.1.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-src.tar.bz2#16bab9501e942c0704abbf9cd6c4e950c6a76dc226cf1e447ea084916aef4714" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.1-src
+++ b/plugins/python-build/share/python-build/pypy-5.1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-5.1.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-src.tar.bz2#16bab9501e942c0704abbf9cd6c4e950c6a76dc226cf1e447ea084916aef4714" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.1.1-src
+++ b/plugins/python-build/share/python-build/pypy-5.1.1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-5.1.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-src.tar.bz2#ca3d943d7fbd78bb957ee9e5833ada4bb8506ac99a41b7628790e286a65ed2be" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.1.1-src
+++ b/plugins/python-build/share/python-build/pypy-5.1.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy-5.1.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-src.tar.bz2#ca3d943d7fbd78bb957ee9e5833ada4bb8506ac99a41b7628790e286a65ed2be" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-dev
+++ b/plugins/python-build/share/python-build/pypy-dev
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_hg "pypy-dev" "https://bitbucket.org/pypy/pypy" "default" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-dev
+++ b/plugins/python-build/share/python-build/pypy-dev
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_hg "pypy-dev" "https://bitbucket.org/pypy/pypy" "default" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.3-src
+++ b/plugins/python-build/share/python-build/pypy2-5.3-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.3.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-src.tar.bz2#4142eb8f403810bc88a4911792bb5a502e152df95806e33e69050c828cd160d5" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.3-src
+++ b/plugins/python-build/share/python-build/pypy2-5.3-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.3.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-src.tar.bz2#4142eb8f403810bc88a4911792bb5a502e152df95806e33e69050c828cd160d5" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.3.1-src
+++ b/plugins/python-build/share/python-build/pypy2-5.3.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.3.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-src.tar.bz2#31a52bab584abf3a0f0defd1bf9a29131dab08df43885e7eeddfc7dc9b71836e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.3.1-src
+++ b/plugins/python-build/share/python-build/pypy2-5.3.1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.3.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-src.tar.bz2#31a52bab584abf3a0f0defd1bf9a29131dab08df43885e7eeddfc7dc9b71836e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.4-src
+++ b/plugins/python-build/share/python-build/pypy2-5.4-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.4.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.0-src.tar.bz2#d9568ebe9a14d0eaefde887d78f3cba63d665e95c0d234bb583932341f55a655" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.4-src
+++ b/plugins/python-build/share/python-build/pypy2-5.4-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.4.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.0-src.tar.bz2#d9568ebe9a14d0eaefde887d78f3cba63d665e95c0d234bb583932341f55a655" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.4.1-src
+++ b/plugins/python-build/share/python-build/pypy2-5.4.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.4.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.1-src.tar.bz2#45dbc50c81498f6f1067201b8fc887074b43b84ee32cc47f15e7db17571e9352" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.4.1-src
+++ b/plugins/python-build/share/python-build/pypy2-5.4.1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.4.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.1-src.tar.bz2#45dbc50c81498f6f1067201b8fc887074b43b84ee32cc47f15e7db17571e9352" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.6.0-src
+++ b/plugins/python-build/share/python-build/pypy2-5.6.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.6.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.6.0-src.tar.bz2#7411448045f77eb9e087afdce66fe7eafda1876c9e17aad88cf891f762b608b0" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.6.0-src
+++ b/plugins/python-build/share/python-build/pypy2-5.6.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.6.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.6.0-src.tar.bz2#7411448045f77eb9e087afdce66fe7eafda1876c9e17aad88cf891f762b608b0" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.7.0-src
+++ b/plugins/python-build/share/python-build/pypy2-5.7.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.7.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-src.tar.bz2#e522ea7ca51b16ee5505f22b86803664b762a263a6d69ba84c359fcf8365ad3e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.7.0-src
+++ b/plugins/python-build/share/python-build/pypy2-5.7.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.7.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-src.tar.bz2#e522ea7ca51b16ee5505f22b86803664b762a263a6d69ba84c359fcf8365ad3e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.7.1-src
+++ b/plugins/python-build/share/python-build/pypy2-5.7.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.7.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-src.tar.bz2#e522ea7ca51b16ee5505f22b86803664b762a263a6d69ba84c359fcf8365ad3e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.7.1-src
+++ b/plugins/python-build/share/python-build/pypy2-5.7.1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.7.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-src.tar.bz2#e522ea7ca51b16ee5505f22b86803664b762a263a6d69ba84c359fcf8365ad3e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-5.10.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-5.10.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.10.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-src.tar.bz2#1209f2db718e6afda17528baa5138177a14a0938588a7d3e1b7c722c483079a8" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-5.10.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-5.10.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.10.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-src.tar.bz2#1209f2db718e6afda17528baa5138177a14a0938588a7d3e1b7c722c483079a8" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-5.8.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-5.8.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.8.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.8.0-src.tar.bz2#504c2d522595baf8775ae1045a217a2b120732537861d31b889d47c340b58bd5" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-5.8.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-5.8.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.8.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.8.0-src.tar.bz2#504c2d522595baf8775ae1045a217a2b120732537861d31b889d47c340b58bd5" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-5.9.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-5.9.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.9.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-src.tar.bz2#de4bf05df47f1349dbac97233d9277bbaf1ef3331663ea2557fd5da3dbcfd0a7" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-5.9.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-5.9.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v5.9.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-src.tar.bz2#de4bf05df47f1349dbac97233d9277bbaf1ef3331663ea2557fd5da3dbcfd0a7" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-6.0.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-6.0.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v6.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-src.tar.bz2#6097ec5ee23d0d34d8cd27a1072bed041c8a080ad48731190a03a2223029212d" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-6.0.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-6.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2-v6.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-src.tar.bz2#6097ec5ee23d0d34d8cd27a1072bed041c8a080ad48731190a03a2223029212d" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.0.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.0.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2.7-v7.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.0.0-src.tar.bz2#f51d8bbfc4e73a8a01820b7871a45d13c59f1399822cdf8a19388c69eb20c18c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.0.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2.7-v7.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.0.0-src.tar.bz2#f51d8bbfc4e73a8a01820b7871a45d13c59f1399822cdf8a19388c69eb20c18c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.1.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.1.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2.7-v7.1.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.0-src.tar.bz2#b051a71ea5b4fa27d0a744b28e6054661adfce8904dcc82500716b5edff5ce4b" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.1.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.1.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy2.7-v7.1.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.0-src.tar.bz2#b051a71ea5b4fa27d0a744b28e6054661adfce8904dcc82500716b5edff5ce4b" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy3-2.3.1-src
+++ b/plugins/python-build/share/python-build/pypy3-2.3.1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-2.3.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-src.tar.bz2#924ca36bf85e02469c71d451c145f9a6d19b905df473a3d1c25179c63ea79d74" "pypy_builder" verify_py32 ensurepip

--- a/plugins/python-build/share/python-build/pypy3-2.3.1-src
+++ b/plugins/python-build/share/python-build/pypy3-2.3.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-2.3.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-src.tar.bz2#924ca36bf85e02469c71d451c145f9a6d19b905df473a3d1c25179c63ea79d74" "pypy_builder" verify_py32 ensurepip

--- a/plugins/python-build/share/python-build/pypy3-2.4.0-src
+++ b/plugins/python-build/share/python-build/pypy3-2.4.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-2.4.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-src.tar.bz2#d9ba207d6eecf8a0dc4414e9f4e92db1abd143e8cc6ec4a6bdcac75b29f104f3" "pypy_builder" verify_py32 ensurepip

--- a/plugins/python-build/share/python-build/pypy3-2.4.0-src
+++ b/plugins/python-build/share/python-build/pypy3-2.4.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-2.4.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-src.tar.bz2#d9ba207d6eecf8a0dc4414e9f4e92db1abd143e8cc6ec4a6bdcac75b29f104f3" "pypy_builder" verify_py32 ensurepip

--- a/plugins/python-build/share/python-build/pypy3-dev
+++ b/plugins/python-build/share/python-build/pypy3-dev
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_hg "pypy3-dev" "https://bitbucket.org/pypy/pypy" "py3k" "pypy_builder" verify_py32 ensurepip

--- a/plugins/python-build/share/python-build/pypy3-dev
+++ b/plugins/python-build/share/python-build/pypy3-dev
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_hg "pypy3-dev" "https://bitbucket.org/pypy/pypy" "py3k" "pypy_builder" verify_py32 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1-src
+++ b/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3.3-v5.2.0-alpha1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-src.tar.bz2#344c2f088c82ea1274964bb0505ab80d3f9e538cc03f91aa109325ddbaa61426" "pypy_builder" verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1-src
+++ b/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3.3-v5.2.0-alpha1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-src.tar.bz2#344c2f088c82ea1274964bb0505ab80d3f9e538cc03f91aa109325ddbaa61426" "pypy_builder" verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.3-5.5-alpha-src
+++ b/plugins/python-build/share/python-build/pypy3.3-5.5-alpha-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v5.5.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.5.0-alpha-src.tar.bz2#d5591c34d77253e9ed57d182b6f49585b95f7c09c3e121f0e8630e5a7e75ab5f" "pypy_builder" verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.3-5.5-alpha-src
+++ b/plugins/python-build/share/python-build/pypy3.3-5.5-alpha-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v5.5.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.5.0-alpha-src.tar.bz2#d5591c34d77253e9ed57d182b6f49585b95f7c09c3e121f0e8630e5a7e75ab5f" "pypy_builder" verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v5.10.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-src.tar.bz2#a6e4cffde71e3f08b6e1befa5c0352a9bcc5f4e9f5cbf395001e0763a1a0d9e3" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v5.10.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-src.tar.bz2#a6e4cffde71e3f08b6e1befa5c0352a9bcc5f4e9f5cbf395001e0763a1a0d9e3" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.1-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.1-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v5.10.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.1-src.tar.bz2#f5548e06e2fc0c24ec8b6e3c5b09f90081818f7caa3e436dc312592611724713" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.1-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v5.10.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.1-src.tar.bz2#f5548e06e2fc0c24ec8b6e3c5b09f90081818f7caa3e436dc312592611724713" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.7-beta-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.7-beta-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v5.7.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.7.0-src.tar.bz2#f0f563b74f8b82ec33b022393219b93cc0d81e9f9500614fe8417b67a52e9569" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.7-beta-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.7-beta-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v5.7.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.7.0-src.tar.bz2#f0f563b74f8b82ec33b022393219b93cc0d81e9f9500614fe8417b67a52e9569" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.7.1-beta-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.7.1-beta-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v5.7.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.7.1-src.tar.bz2#40ece0145282980ac121390f13709404c0532896507d5767496381180b631bd0" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.7.1-beta-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.7.1-beta-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v5.7.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.7.1-src.tar.bz2#40ece0145282980ac121390f13709404c0532896507d5767496381180b631bd0" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.8.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.8.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v5.8.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.8.0-src.tar.bz2#9d090127335c3c0fd2b14c8835bf91752e62756e55ea06aad3353f24a6854223" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.8.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.8.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v5.8.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.8.0-src.tar.bz2#9d090127335c3c0fd2b14c8835bf91752e62756e55ea06aad3353f24a6854223" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.9.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.9.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v5.9.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.9.0-src.tar.bz2#a014f47f50a1480f871a0b82705f904b38c93c4ca069850eb37653fedafb1b97" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.9.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.9.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v5.9.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.9.0-src.tar.bz2#a014f47f50a1480f871a0b82705f904b38c93c4ca069850eb37653fedafb1b97" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-6.0.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-6.0.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v6.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-src.tar.bz2#ed8005202b46d6fc6831df1d13a4613bc40084bfa42f275068edadf8954034a3" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-6.0.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-6.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3-v6.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-src.tar.bz2#ed8005202b46d6fc6831df1d13a4613bc40084bfa42f275068edadf8954034a3" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-7.0.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-7.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3.5-v7.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.5-v7.0.0-src.tar.bz2#b2ddb0f45cb4e0384fb498ef7fcca2ac96c730b9000affcf8d730169397f017f" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-7.0.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-7.0.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3.5-v7.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.5-v7.0.0-src.tar.bz2#b2ddb0f45cb4e0384fb498ef7fcca2ac96c730b9000affcf8d730169397f017f" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.0.0-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3.6-v7.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.0.0-src.tar.bz2#7ccbf81db5c647fa0c27636c7d18d059d2570fff7eaffc03857c67bee84b8a26" "pypy_builder" verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.0.0-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.0.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3.6-v7.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.0.0-src.tar.bz2#7ccbf81db5c647fa0c27636c7d18d059d2570fff7eaffc03857c67bee84b8a26" "pypy_builder" verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.1.0-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.1.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3.6-v7.1.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.0-src.tar.bz2#faa81f469bb2a7cbd22c64f22d4b4ddc5a1f7c798d43b7919b629b932f9b1c6f" "pypy_builder" verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.1.0-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.1.0-src
@@ -1,3 +1,4 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "pypy3.6-v7.1.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.0-src.tar.bz2#faa81f469bb2a7cbd22c64f22d4b4ddc5a1f7c798d43b7919b629b932f9b1c6f" "pypy_builder" verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7-dev
+++ b/plugins/python-build/share/python-build/stackless-2.7-dev
@@ -1,5 +1,5 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "stackless-2.7-dev" "https://github.com/stackless-dev/stackless/" "2.7-slp" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7-dev
+++ b/plugins/python-build/share/python-build/stackless-2.7-dev
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "stackless-2.7-dev" "https://github.com/stackless-dev/stackless/" "2.7-slp" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.14
+++ b/plugins/python-build/share/python-build/stackless-2.7.14
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "stackless-2.7.14-slp" "https://github.com/stackless-dev/stackless/archive/v2.7.14-slp.tar.gz#e67f60984d034bfd80fef58d26df9d5a1cdecb429c55ac7bc8d932cff6f88ab8" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.14
+++ b/plugins/python-build/share/python-build/stackless-2.7.14
@@ -1,5 +1,5 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "stackless-2.7.14-slp" "https://github.com/stackless-dev/stackless/archive/v2.7.14-slp.tar.gz#e67f60984d034bfd80fef58d26df9d5a1cdecb429c55ac7bc8d932cff6f88ab8" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.4-dev
+++ b/plugins/python-build/share/python-build/stackless-3.4-dev
@@ -1,5 +1,5 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "stackless-3.4-dev" "https://github.com/stackless-dev/stackless/" "3.4-slp" standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.4-dev
+++ b/plugins/python-build/share/python-build/stackless-3.4-dev
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "stackless-3.4-dev" "https://github.com/stackless-dev/stackless/" "3.4-slp" standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/stackless-dev
+++ b/plugins/python-build/share/python-build/stackless-dev
@@ -1,4 +1,5 @@
 #require_gcc
+prefer_openssl11
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "stackless-dev" "https://github.com/stackless-dev/stackless/" "master-slp" standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/stackless-dev
+++ b/plugins/python-build/share/python-build/stackless-dev
@@ -1,5 +1,5 @@
 #require_gcc
 prefer_openssl11
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_git "stackless-dev" "https://github.com/stackless-dev/stackless/" "master-slp" standard verify_py35 ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * Not yet planned, but I may gonna post the equivalent changes later once after proving this way works fine for our use case
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/pull/1302
  - https://github.com/pyenv/pyenv/issues/1325

### Description
- [x] Here are some details about my PR

In #1302, I've merged a PR that lets `python-build` to always prefer Homebrew's `openssl@1.1` over `openssl` (=== OpenSSL 1.0). However, in fact, some of _older_ python versions don't support OpenSSL 1.1 and it caused some build failures.

I ended up to tweak build definitions to add new parameter `prefer_openssl11` to enable OpenSSL 1.1 only for some definitions.

### Tests
- [ ] My PR adds the following unit tests (if any)

cc: @ThomasWaldmann @cculianu