### PR TITLE
Find zlib from Xcode or Homebrew on Mojave

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2147,6 +2147,20 @@ if [[ "$CONFIGURE_OPTS" == *"--enable-shared"* ]] || [[ "$PYTHON_CONFIGURE_OPTS"
   fi
 fi
 
+# Mojave and higher don't keep zlib in the usual compiler include path, so we
+# use xcrun or homebrew to find it (#1219)
+if is_mac && require_osx_version "10.14"; then
+  xc_sdk_path="$(xcrun --show-sdk-path 2>/dev/null)"
+  brew_zlib="$(brew --prefix zlib 2>/dev/null)"
+  if [ "$xc_sdk_path" ]; then
+    echo "python-build: use zlib from xcode"
+    export CFLAGS="-I${xc_sdk_path}/usr/include ${CFLAGS}"
+  elif [ "$brew_zlib" ]; then
+    echo "python-build: use zlib from homebrew"
+    export CFLAGS="-I${brew_zlib} ${CFLAGS}"
+  fi
+fi
+
 # python-build: Set `RPATH` if --shared` was given for PyPy (#244)
 if [[ "$PYPY_OPTS" == *"--shared"* ]]; then
   export LDFLAGS="-Wl,-rpath=${PREFIX_PATH}/lib ${LDFLAGS}"

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -263,6 +263,7 @@ OUT
   stub uname '-s : echo Darwin'
 
   stub uname '-s : echo Darwin'
+  stub sw_vers '-productVersion : echo 10.10'
 
   PYTHON_CONFIGURE_OPTS="--enable-framework" TMPDIR="$TMP" run_inline_definition <<OUT
 echo "PYTHON_CONFIGURE_OPTS_ARRAY=(\${PYTHON_CONFIGURE_OPTS_ARRAY[@]})"
@@ -282,6 +283,7 @@ EOS
   stub uname '-s : echo Darwin'
 
   stub uname '-s : echo Darwin'
+  stub sw_vers '-productVersion : echo 10.10'
 
   PYTHON_CONFIGURE_OPTS="--enable-universalsdk" TMPDIR="$TMP" run_inline_definition <<OUT
 echo "PYTHON_CONFIGURE_OPTS_ARRAY=(\${PYTHON_CONFIGURE_OPTS_ARRAY[@]})"
@@ -332,6 +334,7 @@ OUT
   stub uname '-s : echo Darwin'
 
   stub uname '-s : echo Darwin'
+  stub sw_vers '-productVersion : echo 10.4'
 
   MACOSX_DEPLOYMENT_TARGET="10.4" TMPDIR="$TMP" run_inline_definition <<OUT
 echo "\${MACOSX_DEPLOYMENT_TARGET}"


### PR DESCRIPTION
[this comment](https://github.com/pyenv/pyenv/issues/1219#issuecomment-428700763) from #1219 pretty well summarizes why building pythons on Mojave keeps failing because of lack of zlib.

In this PR, I use the zlib from the xcode commandline tools sdk if available, and homebrew zlib if it is not. If neither are available, the build continues until the checks at the end that assert the presence of zlib and direct the user to the common build issues wiki if no zlib module was compiled. I didn't try to be clever about what happens if both scenarios above fail because the user might have done the manual legacy sdk installation fix or has `CFLAGS` set in their shell or whatever.

Fixes #1219 
