### PR TITLE
List versions starting with a dot

### DIFF
--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -106,7 +106,7 @@ if [ -n "$include_system" ] && PYENV_VERSION=system pyenv-which python >/dev/nul
   print_version system
 fi
 
-shopt -s nullglob
+shopt -s dotglob nullglob
 for path in "$versions_dir"/*; do
   if [ -d "$path" ]; then
     if [ -n "$skip_aliases" ] && [ -L "$path" ]; then
@@ -123,7 +123,7 @@ for path in "$versions_dir"/*; do
     done
   fi
 done
-shopt -u nullglob
+shopt -u dotglob nullglob
 
 if [ "$num_versions" -eq 0 ] && [ -n "$include_system" ]; then
   echo "Warning: no Python detected on the system" >&2

--- a/pyenv.d/rehash/conda.bash
+++ b/pyenv.d/rehash/conda.bash
@@ -5,9 +5,9 @@
 # This hooks is intended to skip creating shims for those executables.
 
 conda_exists() {
-  shopt -s nullglob
+  shopt -s dotglob nullglob
   local condas=($(echo "${PYENV_ROOT}/versions/"*"/bin/conda" "${PYENV_ROOT}/versions/"*"/envs/"*"/bin/conda"))
-  shopt -u nullglob
+  shopt -u dotglob nullglob
   [ -n "${condas}" ]
 }
 

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -154,3 +154,10 @@ OUT
 1.9
 OUT
 }
+
+@test "lists dot directories under versions" {
+  create_version ".venv"
+
+  run pyenv-versions --bare
+  assert_success ".venv"
+}


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] ~~Please consider implementing the feature as a hook script or plugin as a first step.~~
  * ~~pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.~~
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] ~~My PR addresses the following pyenv issue (if any)~~

### Description

`pyenv-virtualenv` allows to create virtualenvs with names starting with a dot (e.g. `.dotfiles`), but those cannot be listed. This PR enables `dotglob` option when listing versions.
I don't think this change is necessary to the upstream (`rbenv`) since they probably only deal with version numbers.

I have also opened a similar PR in the `pyenv-virtualenv` repo: pyenv/pyenv-virtualenv#317

### Tests
- [x] My PR adds the following unit tests (if any)
  - test "lists dot directories under versions" (`test/versions.bats`)
