### PR TITLE
Find zlib from xcode or brew on Mojave

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ dist:
 osx_image:
 - xcode9.4
 - xcode10
+- xcode10.2
 
 env:
 - PYTHON_BUILD_VERSION=3.8-dev
@@ -55,6 +56,8 @@ jobs:
   # list, to prevent duplicate Linux builds.
   - os: linux
     osx_image: xcode9.4
+  - os: linux
+    osx_image: xcode10
 
   allow_failures:
   - env: PYTHON_BUILD_VERSION=3.8-dev

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -759,7 +759,10 @@ build_package_standard_build() {
   local PACKAGE_CFLAGS="${package_var_name}_CFLAGS"
 
   if [ "$package_var_name" = "PYTHON" ]; then
-      use_homebrew_readline || use_freebsd_pkg ||true
+      use_homebrew_readline || use_freebsd_pkg || true
+    if is_mac -ge 1014; then
+      use_xcode_sdk_zlib || use_homebrew_zlib || true
+    fi
   fi
 
   ( if [ "${CFLAGS+defined}" ] || [ "${!PACKAGE_CFLAGS+defined}" ]; then
@@ -1626,6 +1629,22 @@ build_package_verify_openssl() {
       exit 1
     end
   ' "$(basename "$(type -p yum apt-get | head -1)")" >&4 2>&1
+}
+
+use_homebrew_zlib() {
+  local brew_zlib="$(brew --prefix zlib 2>/dev/null || true)"
+  if [ -d "$brew_zlib" ]; then
+    echo "python-build: use zlib from homebrew"
+    export CFLAGS="-I${brew_zlib} ${CFLAGS}"
+  fi
+}
+
+use_xcode_sdk_zlib() {
+  local xc_sdk_path="$(xcrun --show-sdk-path 2>/dev/null || true)"
+  if [ -d "$xc_sdk_path" ]; then
+    echo "python-build: use zlib from xcode sdk"
+    export CFLAGS="-I${xc_sdk_path}/usr/include ${CFLAGS}"
+  fi
 }
 
 # Ensure that directories listed in LDFLAGS exist

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -65,7 +65,7 @@ assert_build_log() {
   # pyenv/pyenv#1026
   stub uname false false
 
-  stub uname '-s : echo Linux'
+  stub uname '-s : echo Linux' '-s : echo Linux'
   stub brew false
   stub_make_install
   stub_make_install
@@ -95,7 +95,7 @@ OUT
   # pyenv/pyenv#1026
   stub uname false false
 
-  stub uname '-s : echo Linux'
+  stub uname '-s : echo Linux' '-s : echo Linux'
   stub brew false
   stub_make_install
   stub_make_install
@@ -125,7 +125,7 @@ OUT
   cached_tarball "yaml-0.1.6"
   cached_tarball "Python-3.6.2"
 
-  stub uname '-s : echo Linux'
+  stub uname '-s : echo Linux' '-s : echo Linux'
   stub brew false
   stub_make_install
   stub_make_install
@@ -164,6 +164,7 @@ OUT
   stub uname false false
 
   stub uname '-s : echo Linux'
+  stub uname '-s : echo Darwin'
   stub brew "--prefix libyaml : echo '$brew_libdir'" false
   stub_make_install
 
@@ -251,7 +252,7 @@ OUT
   # yyuu/pyenv#257
   stub uname '-s : echo Darwin'
 
-  stub uname '-s : echo Darwin' false
+  stub uname '-s : echo Darwin' false '-s : echo Darwin'
   stub sysctl false
   stub_make_install
 
@@ -282,7 +283,7 @@ OUT
   # yyuu/pyenv#257
   stub uname '-s : echo Darwin'
 
-  stub uname '-s : echo Darwin' false
+  stub uname '-s : echo Darwin' false '-s : echo Darwin'
   stub sysctl '-n hw.ncpu : echo 4'
   stub_make_install
 
@@ -310,7 +311,7 @@ OUT
   # pyenv/pyenv#1026
   stub uname false false
 
-  stub uname '-s : echo FreeBSD' false
+  stub uname '-s : echo FreeBSD' false false
   stub sysctl '-n hw.ncpu : echo 1'
   stub_make_install
 
@@ -336,7 +337,7 @@ OUT
   cached_tarball "Python-3.6.2"
 
   # pyenv/pyenv#1026
-  stub uname false false
+  stub uname false false false
 
   stub uname '-s : echo Linux'
   stub_make_install
@@ -362,7 +363,7 @@ OUT
   cached_tarball "Python-3.6.2"
 
   # pyenv/pyenv#1026
-  stub uname false false
+  stub uname false false false
 
   stub uname '-s : echo Linux'
   stub_make_install
@@ -399,7 +400,7 @@ OUT
   stub uname "-s : echo FreeBSD" "-r : echo 9.1" false
 
   # pyenv/pyenv#1026
-  stub uname false false
+  stub uname false false false
 
   MAKE=gmake stub_make_install
 
@@ -416,7 +417,7 @@ OUT
   stub uname "-s : echo FreeBSD" "-r : echo 10.0-RELEASE" false
 
   # pyenv/pyenv#1026
-  stub uname false false
+  stub uname false false false
 
   stub_make_install
 
@@ -432,7 +433,7 @@ OUT
   stub uname "-s : echo FreeBSD" "-r : echo 11.0-RELEASE" false
 
   # pyenv/pyenv#1026
-  stub uname false false
+  stub uname false false false
 
   stub_make_install
 
@@ -456,6 +457,7 @@ CONF
   stub_make_install
 
   # yyuu/pyenv#257
+  stub uname '-s : echo Linux'
   stub uname '-s : echo Linux'
   stub uname '-s : echo Linux'
 

--- a/plugins/python-build/test/compiler.bats
+++ b/plugins/python-build/test/compiler.bats
@@ -64,9 +64,11 @@ DEF
   cd "$INSTALL_ROOT"
 
   # pyenv/pyenv#1026
-  stub uname false '-s : echo Darwin' false '-s : echo Darwin'
+  stub uname false '-s : echo Darwin' false '-s : echo Darwin' '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.10'
 
+  stub sw_vers '-productVersion : echo 10.10'
+  stub sw_vers '-productVersion : echo 10.10'
   stub sw_vers '-productVersion : echo 10.10'
   stub cc 'false'
   stub brew 'false'


### PR DESCRIPTION
An alternative take on #1219, based on the original attempt to fix that in #1339.
- The `zlib` search flow is organized similarly to the `readline` one, and placed nearby.
- The tests have been updated to account for the extra `is_mac/uname` call.

Fixes #1219 
Closes #1339, #1333