### PR TITLE
Remove infocmp from shims

### DIFF
--- a/pyenv.d/rehash/conda.d/default.list
+++ b/pyenv.d/rehash/conda.d/default.list
@@ -22,6 +22,7 @@ gsettings
 gio-querymodules
 glib-compile-resources
 glib-compile-schemas
+infocmp
 # libpng
 libpng-config
 # libxml2


### PR DESCRIPTION
infocmp is a system utility that returns information about the user's terminal. When it is shimmed it can cause problems for various programs that use it to determine terminal settings. In particular, the library used by the Scala shell reads it and problems can occur where various control keys don't work (e.g. backspace does not work).

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
