### PR TITLE
Update miniconda builds

### DIFF
--- a/plugins/python-build/scripts/README.md
+++ b/plugins/python-build/scripts/README.md
@@ -1,0 +1,22 @@
+# Scripts for updating python-build
+
+Install dependencies with `pip install -r requirements.txt`.
+
+## add_miniconda.py
+
+```_add_miniconda
+usage: add_miniconda.py [-h] [-d] [-v]
+
+Script to add non-"latest" miniconda releases. Written for python 3.7. Checks
+the miniconda download archives for new versions, then writes a build script
+for any which do not exist locally, saving it to plugins/python-
+build/share/python-build. Ignores releases below 4.3.30. Also ignores sub-
+patch releases if that major.minor.patch already exists, but otherwise, takes
+the latest sub-patch release for given OS/arch. Assumes all miniconda3
+releases < 4.7 default to python 3.6, and anything else 3.7.
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -d, --dry-run  Do not write scripts, just report them to stdout
+  -v, --verbose  Increase verbosity of logging
+```

--- a/plugins/python-build/scripts/add_miniconda.py
+++ b/plugins/python-build/scripts/add_miniconda.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3.7
+"""Script to add non-"latest" miniconda releases.
+
+- Ignores releases below 4.3.30.
+- Ignores sub-patch releases if that major.minor.patch already exists
+  - But otherwise, takes the latest sub-patch release for given OS/arch
+- Assumes all miniconda3 releases default to python 3.6 (correct at time of writing)
+
+Use -d for dry run.
+"""
+import textwrap
+from argparse import ArgumentParser
+from collections import defaultdict
+from enum import Enum
+from functools import total_ordering
+from pathlib import Path
+from typing import NamedTuple, List, Optional, DefaultDict, Dict
+
+import requests_html
+
+CONDA_REPO = "https://repo.anaconda.com"
+MINICONDA_REPO = CONDA_REPO + "/miniconda"
+# ANACONDA_REPO = CONDA_REPO + "/archive"
+
+install_script_fmt = """
+case "$(anaconda_architecture 2>/dev/null || true)" in
+{install_lines}
+* )
+  {{ echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  }} >&2
+  exit 1
+  ;;
+esac
+""".lstrip()
+
+install_line_fmt = """
+"{os}-{arch}" )
+  install_script "Miniconda{suffix}-{version_str}-{os}-{arch}" "{repo}/Miniconda{suffix}-{version_str}-{os}-{arch}.sh#{md5}" "miniconda" verify_{py_version}
+  ;;
+""".strip()
+
+here = Path(__file__).resolve()
+out_dir: Path = here.parent.parent / "share" / "python-build"
+
+
+class StrEnum(str, Enum):
+    """Enum subclass which members are also instances of str
+    and directly comparable to strings. str type is forced at declaration.
+
+    Adapted from https://github.com/kissgyorgy/enum34-custom/blob/dbc89596761c970398701d26c6a5bbcfcf70f548/enum_custom.py#L100
+    (MIT license)
+    """
+    def __new__(cls, *args):
+        for arg in args:
+            if not isinstance(arg, str):
+                raise TypeError('Not text %s:' % arg)
+
+        return super(StrEnum, cls).__new__(cls, *args)
+
+    def __str__(self):
+        return str(self.value)
+
+
+class SupportedOS(StrEnum):
+    LINUX = "Linux"
+    MACOSX = "MacOSX"
+
+
+class SupportedArch(StrEnum):
+    PPC64LE = "ppc64le"
+    X86_64 = "x86_64"
+    X86 = "x86"
+
+
+class Suffix(StrEnum):
+    TWO = "2"
+    THREE = "3"
+
+
+class PyVersion(StrEnum):
+    PY27 = "py27"
+    PY36 = "py36"
+    PY37 = "py37"
+    PY38 = "py38"
+    PY39 = "py39"
+
+    def version(self):
+        first, *others = self.value[2:]
+        return f"{first}.{''.join(others)}"
+
+    def version_info(self):
+        return tuple(int(n) for n in self.version().split('.'))
+
+
+@total_ordering
+class VersionStr(str):
+    def info(self):
+        return tuple(int(n) for n in self.split('.'))
+
+    def __eq__(self, other):
+        return str(self) == str(other)
+
+    def __lt__(self, other):
+        if isinstance(other, VersionStr):
+            return self.info() < other.info()
+        raise ValueError("VersionStr can only be compared to other VersionStr")
+
+    @classmethod
+    def from_info(cls, version_info):
+        return VersionStr('.'.join(str(n) for n in version_info))
+
+    def __hash__(self):
+        return hash(str(self))
+
+
+class MinicondaVersion(NamedTuple):
+    suffix: Suffix
+    version_str: VersionStr
+
+    @classmethod
+    def from_str(cls, s):
+        miniconda_n, ver = s.split('-')
+        return MinicondaVersion(Suffix(miniconda_n[-1]), VersionStr(ver))
+
+    def to_filename(self):
+        return f"miniconda{self.suffix}-{self.version_str}"
+
+    def default_py_version(self):
+        if self.suffix == Suffix.TWO:
+            return PyVersion.PY27
+        else:
+            # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-python.html
+            return PyVersion.PY36
+
+    def with_version_triple(self):
+        return MinicondaVersion(self.suffix, VersionStr.from_info(self.version_str.info()[:3]))
+
+
+class MinicondaSpec(NamedTuple):
+    version: MinicondaVersion
+    os: SupportedOS
+    arch: SupportedArch
+    md5: str
+    py_version: Optional[PyVersion] = None
+
+    @classmethod
+    def from_filestem(cls, stem, md5, py_version=None):
+        miniconda_n, ver, os, arch = stem.split('-')
+        spec = MinicondaSpec(
+            MinicondaVersion(
+                Suffix(miniconda_n[-1]),
+                VersionStr(ver),
+            ),
+            SupportedOS(os),
+            SupportedArch(arch),
+            md5,
+        )
+        if py_version is None:
+            spec = spec.with_py_version(spec.version.default_py_version())
+        return spec
+
+    def to_install_lines(self):
+        return install_line_fmt.format(
+            repo=MINICONDA_REPO,
+            suffix=self.version.suffix,
+            version_str=self.version.version_str,
+            os=self.os,
+            arch=self.arch,
+            md5=self.md5,
+            py_version=self.py_version,
+        )
+
+    def with_py_version(self, py_version: PyVersion):
+        return MinicondaSpec(*self[:-1], py_version=py_version)
+
+    def with_version_triple(self):
+        version, *others = self
+        return MinicondaSpec(version.with_version_triple(), *others)
+
+
+def make_script(specs: List[MinicondaSpec]):
+    install_lines = [s.to_install_lines() for s in specs]
+    return install_script_fmt.format(install_lines='\n'.join(install_lines))
+
+
+def get_existing_minicondas():
+    for p in out_dir.iterdir():
+        name = p.name
+        if not p.is_file() or not name.startswith("miniconda"):
+            continue
+        try:
+            v = MinicondaVersion.from_str(name)
+            if v.version_str != "latest":
+                yield v
+        except ValueError:
+            pass
+
+
+def get_available_minicondas():
+    session = requests_html.HTMLSession()
+    response = session.get(MINICONDA_REPO)
+    page: requests_html.HTML = response.html
+    table = page.find('table', first=True)
+    rows = table.find("tr")[1:]
+    for row in rows:
+        f, size, date, md5 = row.find('td')
+        fname = f.text
+        md5 = md5.text
+
+        if not fname.endswith(".sh"):
+            continue
+        stem = fname[:-3]
+
+        try:
+            s = MinicondaSpec.from_filestem(stem, md5)
+            if s.version.version_str != "latest":
+                yield s
+        except ValueError:
+            pass
+
+
+def key_fn(spec: MinicondaSpec):
+    return (
+        spec.version.version_str.info(),
+        spec.version.suffix.value,
+        spec.os.value,
+        spec.arch.value,
+    )
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("-d", "--dry_run", action="store_true")
+    parsed = parser.parse_args()
+
+    existing_versions = set(get_existing_minicondas())
+    available_specs = set(get_available_minicondas())
+
+    # version triple to triple-ified spec to raw spec
+    to_add: DefaultDict[MinicondaVersion, Dict[MinicondaSpec, MinicondaSpec]] = defaultdict(dict)
+
+    for s in sorted(available_specs, key=key_fn):
+        key = s.version.with_version_triple()
+        if key in existing_versions or key.version_str.info() <= (4, 3, 30):
+            continue
+
+        to_add[key][s.with_version_triple()] = s
+
+    for ver, d in to_add.items():
+        specs = list(d.values())
+        fpath = out_dir / ver.to_filename()
+        script_str = make_script(specs)
+
+        if parsed.dry_run:
+            print(f"Would write spec to {fpath}:\n" + textwrap.indent(script_str, '  '))
+        else:
+            with open(fpath, 'w') as f:
+                f.write(script_str)
+

--- a/plugins/python-build/scripts/requirements.txt
+++ b/plugins/python-build/scripts/requirements.txt
@@ -1,0 +1,1 @@
+requests-html

--- a/plugins/python-build/share/python-build/miniconda2-4.3.31
+++ b/plugins/python-build/share/python-build/miniconda2-4.3.31
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Miniconda2-4.3.31-Linux-x86" "https://repo.anaconda.com/miniconda/Miniconda2-4.3.31-Linux-x86.sh#4067ba22e1d687f92b11531a0b30b17f" "miniconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda2-4.3.31-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.3.31-Linux-x86_64.sh#da2dd466d26e33a2b1f72fdb853a8ff0" "miniconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda2-4.3.31-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.3.31-MacOSX-x86_64.sh#2c499488605bafd9e13a430f299f1489" "miniconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda2-4.4.10
+++ b/plugins/python-build/share/python-build/miniconda2-4.4.10
@@ -1,0 +1,22 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda2-4.4.10-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda2-4.4.10-Linux-ppc64le.sh#c6bf34cef423be4cda46df61fd09e069" "miniconda" verify_py27
+  ;;
+"Linux-x86" )
+  install_script "Miniconda2-4.4.10-Linux-x86" "https://repo.anaconda.com/miniconda/Miniconda2-4.4.10-Linux-x86.sh#1e8bf30cb77548f6aae9f4444b826fcb" "miniconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda2-4.4.10-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.4.10-Linux-x86_64.sh#dd54b344661560b861f86cc5ccff044b" "miniconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda2-4.4.10-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.4.10-MacOSX-x86_64.sh#20e0f8851c93331f763635c89840c39c" "miniconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda2-4.5.1
+++ b/plugins/python-build/share/python-build/miniconda2-4.5.1
@@ -1,0 +1,22 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda2-4.5.1-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.1-Linux-ppc64le.sh#02a0628652df3ab5917568606fecb8c3" "miniconda" verify_py27
+  ;;
+"Linux-x86" )
+  install_script "Miniconda2-4.5.1-Linux-x86" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.1-Linux-x86.sh#9da5b43024d7edba30d0359c547cd2e5" "miniconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda2-4.5.1-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.1-Linux-x86_64.sh#332aeff0bb6b45bbf7e220dec17ba867" "miniconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda2-4.5.1-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.1-MacOSX-x86_64.sh#ad96c4012ca4d84d94f94d9c2f90a889" "miniconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda2-4.5.11
+++ b/plugins/python-build/share/python-build/miniconda2-4.5.11
@@ -1,0 +1,22 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda2-4.5.11-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.11-Linux-ppc64le.sh#b85a019f75ff87714eb3254dd1f3390f" "miniconda" verify_py27
+  ;;
+"Linux-x86" )
+  install_script "Miniconda2-4.5.11-Linux-x86" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.11-Linux-x86.sh#187c460ffc6ea5f890b512320b2994c6" "miniconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda2-4.5.11-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.11-Linux-x86_64.sh#458324438b7b0e5afcc272b63d44195d" "miniconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda2-4.5.11-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.11-MacOSX-x86_64.sh#a444da43ad50a83c332ea1fb7a5bb96c" "miniconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda2-4.5.12
+++ b/plugins/python-build/share/python-build/miniconda2-4.5.12
@@ -1,0 +1,22 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda2-4.5.12-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.12-Linux-ppc64le.sh#e441328782c71c7ce71cc2a668df0451" "miniconda" verify_py27
+  ;;
+"Linux-x86" )
+  install_script "Miniconda2-4.5.12-Linux-x86" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.12-Linux-x86.sh#56c90370226fd410c9b0086bd693d9c0" "miniconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda2-4.5.12-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.12-Linux-x86_64.sh#4be03f925e992a8eda03758b72a77298" "miniconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda2-4.5.12-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.12-MacOSX-x86_64.sh#76041da218ab91e2c9538a5dc19cd14e" "miniconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda2-4.5.4
+++ b/plugins/python-build/share/python-build/miniconda2-4.5.4
@@ -1,0 +1,22 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda2-4.5.4-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.4-Linux-ppc64le.sh#3e26ee6447c8025609ea1e410f768417" "miniconda" verify_py27
+  ;;
+"Linux-x86" )
+  install_script "Miniconda2-4.5.4-Linux-x86" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.4-Linux-x86.sh#a638ae058a0ce15c5b289d151c488045" "miniconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda2-4.5.4-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.4-Linux-x86_64.sh#8a1c02f6941d8778f8afad7328265cf5" "miniconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda2-4.5.4-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.5.4-MacOSX-x86_64.sh#35f4ca99d33ed56f68745eeaf1449274" "miniconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda2-4.6.14
+++ b/plugins/python-build/share/python-build/miniconda2-4.6.14
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda2-4.6.14-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda2-4.6.14-Linux-ppc64le.sh#76eeccfcf127bb29ce71a279ebd185a9" "miniconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda2-4.6.14-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.6.14-Linux-x86_64.sh#faa7cb0b0c8986ac3cacdbbd00fe4168" "miniconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda2-4.6.14-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.6.14-MacOSX-x86_64.sh#6665a5911f92dce1cf6d1021249af9db" "miniconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda2-4.7.10
+++ b/plugins/python-build/share/python-build/miniconda2-4.7.10
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda2-4.7.10-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda2-4.7.10-Linux-ppc64le.sh#dee73c820a4e3af712f0b3ff02f57264" "miniconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda2-4.7.10-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.7.10-Linux-x86_64.sh#3bc6ffc6cda8efa467926dfd92a30bca" "miniconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda2-4.7.10-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.7.10-MacOSX-x86_64.sh#f540257a4b1df264e6f72c75f75620bb" "miniconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda2-4.7.12
+++ b/plugins/python-build/share/python-build/miniconda2-4.7.12
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda2-4.7.12-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda2-4.7.12-Linux-ppc64le.sh#59325e5b37e93f39ab4b3987abe1b7dd" "miniconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda2-4.7.12-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.7.12-Linux-x86_64.sh#5a218d9dce3a77905d17ae87ac72a1e8" "miniconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda2-4.7.12-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.7.12-MacOSX-x86_64.sh#2498099a426fcaafd1068fd6d79e3a6d" "miniconda" verify_py27
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda2-4.7.12.1-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda2-4.7.12.1-Linux-ppc64le.sh#f00e3c5881c2629a9b516cc7a62bbc3c" "miniconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda2-4.7.12.1-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.7.12.1-Linux-x86_64.sh#23bf3acd6aead6e91fb936fc185b033e" "miniconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda2-4.7.12.1-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-4.7.12.1-MacOSX-x86_64.sh#5a10de42eb90c1c21dbda191f1ec19b1" "miniconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-4.3.31
+++ b/plugins/python-build/share/python-build/miniconda3-4.3.31
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Miniconda3-4.3.31-Linux-x86" "https://repo.anaconda.com/miniconda/Miniconda3-4.3.31-Linux-x86.sh#df2f9770d83df8269f3f43f1e60285e6" "miniconda" verify_py36
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-4.3.31-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh#7fe70b214bee1143e3e3f0467b71453c" "miniconda" verify_py36
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-4.3.31-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.3.31-MacOSX-x86_64.sh#03c2dedc466886459e968157c63197f3" "miniconda" verify_py36
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-4.4.10
+++ b/plugins/python-build/share/python-build/miniconda3-4.4.10
@@ -1,0 +1,22 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda3-4.4.10-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-4.4.10-Linux-ppc64le.sh#57ca0b05eb96868b83aa69e4567b86ae" "miniconda" verify_py36
+  ;;
+"Linux-x86" )
+  install_script "Miniconda3-4.4.10-Linux-x86" "https://repo.anaconda.com/miniconda/Miniconda3-4.4.10-Linux-x86.sh#e770b4e45ac596c35f6393db988c5c33" "miniconda" verify_py36
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-4.4.10-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.4.10-Linux-x86_64.sh#bec6203dbb2f53011e974e9bf4d46e93" "miniconda" verify_py36
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-4.4.10-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.4.10-MacOSX-x86_64.sh#268ec716435aa19212901510f00815fd" "miniconda" verify_py36
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-4.5.1
+++ b/plugins/python-build/share/python-build/miniconda3-4.5.1
@@ -1,0 +1,22 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda3-4.5.1-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-4.5.1-Linux-ppc64le.sh#454e3b786937eeaa50fb7bee991ac19e" "miniconda" verify_py36
+  ;;
+"Linux-x86" )
+  install_script "Miniconda3-4.5.1-Linux-x86" "https://repo.anaconda.com/miniconda/Miniconda3-4.5.1-Linux-x86.sh#5d6627bfad03b87f1ad4173ebbeb933d" "miniconda" verify_py36
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-4.5.1-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.5.1-Linux-x86_64.sh#0c28787e3126238df24c5d4858bd0744" "miniconda" verify_py36
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-4.5.1-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.5.1-MacOSX-x86_64.sh#ac87d2074bd50103468b8681084236f6" "miniconda" verify_py36
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-4.5.11
+++ b/plugins/python-build/share/python-build/miniconda3-4.5.11
@@ -1,0 +1,22 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda3-4.5.11-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-ppc64le.sh#4b1ac3b4b70bfa710c9f1c5c6d3f3166" "miniconda" verify_py36
+  ;;
+"Linux-x86" )
+  install_script "Miniconda3-4.5.11-Linux-x86" "https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86.sh#d8c3ea1bd25cf02c4ea92df4d31ef652" "miniconda" verify_py36
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-4.5.11-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh#e1045ee415162f944b6aebfe560b8fee" "miniconda" verify_py36
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-4.5.11-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-MacOSX-x86_64.sh#7f7613bf98023f7d6ffe5df53c3a00a0" "miniconda" verify_py36
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-4.5.12
+++ b/plugins/python-build/share/python-build/miniconda3-4.5.12
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Miniconda3-4.5.12-Linux-x86" "https://repo.anaconda.com/miniconda/Miniconda3-4.5.12-Linux-x86.sh#38f586a269ac74f5f10195867c4f96ae" "miniconda" verify_py36
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-4.5.12-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.5.12-Linux-x86_64.sh#866ae9dff53ad0874e1d1a60b1ad1ef8" "miniconda" verify_py36
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-4.5.12-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.5.12-MacOSX-x86_64.sh#a583d1e174e1dc960e87fb4b026a9370" "miniconda" verify_py36
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-4.5.4
+++ b/plugins/python-build/share/python-build/miniconda3-4.5.4
@@ -1,0 +1,22 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda3-4.5.4-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-4.5.4-Linux-ppc64le.sh#05c1e073f262105179cf57920dfc4d43" "miniconda" verify_py36
+  ;;
+"Linux-x86" )
+  install_script "Miniconda3-4.5.4-Linux-x86" "https://repo.anaconda.com/miniconda/Miniconda3-4.5.4-Linux-x86.sh#0fcc79d640d82b7d36ea39654a82dd9d" "miniconda" verify_py36
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-4.5.4-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh#a946ea1d0c4a642ddf0c3a26a18bb16d" "miniconda" verify_py36
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-4.5.4-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.5.4-MacOSX-x86_64.sh#164ec263c4070db642ce31bb45d68813" "miniconda" verify_py36
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-4.6.14
+++ b/plugins/python-build/share/python-build/miniconda3-4.6.14
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda3-4.6.14-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-4.6.14-Linux-ppc64le.sh#6d3bd64dfc436f38755cde1a3ad40799" "miniconda" verify_py36
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-4.6.14-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh#718259965f234088d785cad1fbd7de03" "miniconda" verify_py36
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-4.6.14-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.6.14-MacOSX-x86_64.sh#ffa5f0eead5576fb26b7e6902f5eed09" "miniconda" verify_py36
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-4.7.10
+++ b/plugins/python-build/share/python-build/miniconda3-4.7.10
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda3-4.7.10-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-4.7.10-Linux-ppc64le.sh#f406a65d6362b33b22520186555c8d88" "miniconda" verify_py36
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-4.7.10-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh#1c945f2b3335c7b2b15130b1b2dc5cf4" "miniconda" verify_py36
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-4.7.10-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.7.10-MacOSX-x86_64.sh#9cc5819a400a3fd5c7363792483fef1e" "miniconda" verify_py36
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-4.7.10
+++ b/plugins/python-build/share/python-build/miniconda3-4.7.10
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-ppc64le" )
-  install_script "Miniconda3-4.7.10-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-4.7.10-Linux-ppc64le.sh#f406a65d6362b33b22520186555c8d88" "miniconda" verify_py36
+  install_script "Miniconda3-4.7.10-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-4.7.10-Linux-ppc64le.sh#f406a65d6362b33b22520186555c8d88" "miniconda" verify_py37
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-4.7.10-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh#1c945f2b3335c7b2b15130b1b2dc5cf4" "miniconda" verify_py36
+  install_script "Miniconda3-4.7.10-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh#1c945f2b3335c7b2b15130b1b2dc5cf4" "miniconda" verify_py37
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-4.7.10-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.7.10-MacOSX-x86_64.sh#9cc5819a400a3fd5c7363792483fef1e" "miniconda" verify_py36
+  install_script "Miniconda3-4.7.10-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.7.10-MacOSX-x86_64.sh#9cc5819a400a3fd5c7363792483fef1e" "miniconda" verify_py37
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-4.7.12
+++ b/plugins/python-build/share/python-build/miniconda3-4.7.12
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda3-4.7.12-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12-Linux-ppc64le.sh#bd5c2331edcbe87391465e6acf2d3f10" "miniconda" verify_py37
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-4.7.12-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12-Linux-x86_64.sh#0dba759b8ecfc8948f626fa18785e3d8" "miniconda" verify_py37
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-4.7.12-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12-MacOSX-x86_64.sh#677f38d5ab7e1ce4fef134068e3bd76a" "miniconda" verify_py37
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-4.7.12.1-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-ppc64le.sh#9de38932ed6a8865562e6057b578694f" "miniconda" verify_py37
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-4.7.12.1-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh#81c773ff87af5cfac79ab862942ab6b3" "miniconda" verify_py37
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-4.7.12.1-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-MacOSX-x86_64.sh#621daddf9de519014c6c38e8923583b8" "miniconda" verify_py37
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
We're pretty behind on miniconda versions. This includes all new major.minor.patch versions since 4.3.30, as well as a script to automatically populate new miniconda versions in the future.

- Ignores releases below 4.3.30
- Ignores "-latest" releases
- Ignores sub-patch releases if that major.minor.patch already exists
  - But otherwise, takes the latest sub-patch release for given OS/arch
- Assumes all miniconda3 releases > 4.3.30 default to python 3.6 (correct at time of writing)

### Description

- miniconda[23] versions 4.3.31 through 4.6.14.

### Tests

I am not sure how best to test adding new builds; is there anything more ergonomic than just trying to build each one, one at a time?

See also #1360 for a discussion on miniconda-latest. 