### PR TITLE
Version alias

### DIFF
--- a/libexec/pyenv-version-display-name
+++ b/libexec/pyenv-version-display-name
@@ -5,54 +5,12 @@ set -e
 
 if [ -z "$PYENV_VERSION" ]; then
   PYENV_VERSION_FILE="$(pyenv-version-file)"
-  PYENV_VERSION="$(pyenv-version-file-read "$PYENV_VERSION_FILE" || true)"
+  PYENV_VERSION_NAME="$(pyenv-version-name)"
   PYENV_VERSION_ALIAS="$(pyenv-version-file-read-alias "$PYENV_VERSION_FILE" || true)"
 fi
-
-OLDIFS="$IFS"
-IFS=$'\n' scripts=(`pyenv-hooks version-name`)
-IFS="$OLDIFS"
-for script in "${scripts[@]}"; do
-  source "$script"
-done
-
-if [ -z "$PYENV_VERSION" ] || [ "$PYENV_VERSION" = "system" ]; then
-  echo "system"
-  exit
-fi
-
-version_exists() {
-  local version="$1"
-  [ -d "${PYENV_ROOT}/versions/${version}" ]
-}
-
-versions=()
-OLDIFS="$IFS"
-{ IFS=:
-  any_not_installed=0
-  for version in ${PYENV_VERSION}; do
-    if version_exists "$version" || [ "$version" = "system" ]; then
-      versions=("${versions[@]}" "${version}")
-    elif version_exists "${version#python-}"; then
-      versions=("${versions[@]}" "${version#python-}")
-    else
-      echo "pyenv: version \`$version' is not installed (set by $(pyenv-version-origin))" >&2
-      any_not_installed=1
-    fi
-  done
-}
-IFS="$OLDIFS"
 
 if [ -n "$PYENV_VERSION_ALIAS" ]; then
     echo "$PYENV_VERSION_ALIAS"
 else
-    OLDIFS="$IFS"
-    { IFS=:
-      echo "${versions[*]}"
-    }
-    IFS="$OLDIFS"
-fi
-
-if [ "$any_not_installed" = 1 ]; then
-  exit 1
+    echo "$PYENV_VERSION_NAME"
 fi

--- a/libexec/pyenv-version-display-name
+++ b/libexec/pyenv-version-display-name
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Summary: Show the current Python version
+set -e
+[ -n "$PYENV_DEBUG" ] && set -x
+
+if [ -z "$PYENV_VERSION" ]; then
+  PYENV_VERSION_FILE="$(pyenv-version-file)"
+  PYENV_VERSION="$(pyenv-version-file-read "$PYENV_VERSION_FILE" || true)"
+  PYENV_VERSION_ALIAS="$(pyenv-version-file-read-alias "$PYENV_VERSION_FILE" || true)"
+fi
+
+OLDIFS="$IFS"
+IFS=$'\n' scripts=(`pyenv-hooks version-name`)
+IFS="$OLDIFS"
+for script in "${scripts[@]}"; do
+  source "$script"
+done
+
+if [ -z "$PYENV_VERSION" ] || [ "$PYENV_VERSION" = "system" ]; then
+  echo "system"
+  exit
+fi
+
+version_exists() {
+  local version="$1"
+  [ -d "${PYENV_ROOT}/versions/${version}" ]
+}
+
+versions=()
+OLDIFS="$IFS"
+{ IFS=:
+  any_not_installed=0
+  for version in ${PYENV_VERSION}; do
+    if version_exists "$version" || [ "$version" = "system" ]; then
+      versions=("${versions[@]}" "${version}")
+    elif version_exists "${version#python-}"; then
+      versions=("${versions[@]}" "${version#python-}")
+    else
+      echo "pyenv: version \`$version' is not installed (set by $(pyenv-version-origin))" >&2
+      any_not_installed=1
+    fi
+  done
+}
+IFS="$OLDIFS"
+
+if [ -n "$PYENV_VERSION_ALIAS" ]; then
+    echo "$PYENV_VERSION_ALIAS"
+else
+    OLDIFS="$IFS"
+    { IFS=:
+      echo "${versions[*]}"
+    }
+    IFS="$OLDIFS"
+fi
+
+if [ "$any_not_installed" = 1 ]; then
+  exit 1
+fi

--- a/libexec/pyenv-version-file-read
+++ b/libexec/pyenv-version-file-read
@@ -9,7 +9,7 @@ if [ -e "$VERSION_FILE" ]; then
   # Read the first non-whitespace word from the specified version file.
   # Be careful not to load it whole in case there's something crazy in it.
   IFS="${IFS}"$'\r'
-  words=($(cut -b 1-1024 "$VERSION_FILE" | sed 's/^\s*\(\S\+\).*/\1/'))
+  words=($(cut -b 1-1024 "$VERSION_FILE" | grep -v "alias:" | sed 's/^\s*\(\S\+\).*/\1/'))
   versions=("${words[@]}")
 
   if [ -n "$versions" ]; then

--- a/libexec/pyenv-version-file-read-alias
+++ b/libexec/pyenv-version-file-read-alias
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Usage: pyenv version-file-read-alias <file>
+set -e
+[ -n "$PYENV_DEBUG" ] && set -x
+
+VERSION_FILE="$1"
+
+if [ -e "$VERSION_FILE" ]; then
+    version_alias=$(grep "alias:" $VERSION_FILE | cut -d":" -f2)
+    if [ -n "$version_alias" ]; then
+        echo "$version_alias"
+        exit
+    fi
+fi
+
+exit 1


### PR DESCRIPTION
This PR addresses #1364. The goal is to be able to display an alias for the local or global python version so that tools that display your pyenv version can use that instead.

I could try to turn this into a plugin if it doesn't fit into the ideas for core functionality. Please let me know what you think, and help me turn it into a module if need be.