### PR TITLE
Build mpy-cross dependency for micropython builds

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1008,7 +1008,9 @@ build_package_micropython() {
   elif [ -z "${MAKE_OPTS+defined}" ]; then
     MAKE_OPTS="-j $(num_cpu_cores)"
   fi
-  { cd ports/unix
+  { cd mpy-cross
+    "$MAKE" $MAKE_OPTS
+    cd ports/unix
     "$MAKE" $MAKE_OPTS axtls
     "$MAKE" $MAKE_OPTS CFLAGS_EXTRA="-DMICROPY_PY_SYS_PATH_DEFAULT='\"${PREFIX_PATH}/lib/micropython\"'"
     "$MAKE" install $MAKE_INSTALL_OPTS PREFIX="${PREFIX_PATH}"


### PR DESCRIPTION
This PR builds `mpy-cross` before building `micropython`.  If `mpy-cross` dependency is not built, you get errors like this:

```
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
mkdir -p build/genhdr
mkdir -p build
mkdir -p build/build
mkdir -p build/extmod
mkdir -p build/lib/axtls/crypto
mkdir -p build/lib/axtls/ssl
mkdir -p build/lib/berkeley-db-1.xx/btree
mkdir -p build/lib/berkeley-db-1.xx/mpool
mkdir -p build/lib/embed
mkdir -p build/lib/mp-readline
mkdir -p build/lib/oofatfs
mkdir -p build/lib/timeutils
mkdir -p build/lib/utils
mkdir -p build/py
GEN build/frozen.c
MPY modules/upip_utarfile.py
MPY modules/upip.py
make: ../../mpy-cross/mpy-cross: No such file or directory
make: ../../mpy-cross/mpy-cross: No such file or directory
make: *** [build/frozen_mpy/upip_utarfile.mpy] Error 1
make: *** Waiting for unfinished jobs....
make: *** [build/frozen_mpy/upip.mpy] Error 1
```