### PR TITLE
working with tcl-tk in PYTHON_CONFIGURE_OPTS

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2222,6 +2222,19 @@ if [[ "$PYTHON_CONFIGURE_OPTS" != *"--enable-unicode="* ]]; then
   fi
 fi
 
+# regex_to_match="(--with-tcltk-libs='([^']+)')"
+if [[ "$PYTHON_CONFIGURE_OPTS" =~ (--with-tcltk-libs=\'([^\']+)\') ]]; then
+  tcltk_match="${BASH_REMATCH[1]}"
+  tcltk_match_quoted="${tcltk_match//--with-tcltk-libs=/}"
+  # remove it from PYTHON_CONFIGURE_OPTS since it will mess up compile
+  PYTHON_CONFIGURE_OPTS="${PYTHON_CONFIGURE_OPTS//$tcltk_match/}"
+
+  # having issues passing the single quoted part, couldnt pass as single var and still work
+  package_option python configure "--with-tcltk-libs='${tcltk_match_quoted}'"
+  unset tcltk_match
+  unset tcltk_match_quoted
+fi
+
 # Unset `PIP_REQUIRE_VENV` during build (#216)
 unset PIP_REQUIRE_VENV
 unset PIP_REQUIRE_VIRTUALENV


### PR DESCRIPTION
Hey this should fix a few issues such as #1375 and #1125 .  I am not sure if there is a better way to go about doing this but this seems to work while not making issues for other variables passed to pyenv install.

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1125
  - https://github.com/pyenv/pyenv/issues/1375

### Description
- This fix would allow tcl-tk stuff passed in a string. For instance 
PYTHON_CONFIGURE_OPTS="--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6'" pyenv install 3.7.3
order doesnt matter: 
PYTHON_CONFIGURE_OPTS="--with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6' --with-tcltk-includes='-I/usr/local/opt/tcl-tk/include'" pyenv install 3.7.3

### Tests
- [ ] My PR adds the following unit tests (if any)

I'm not sure how to test this without manually building and running something like 
`python -m tkinter -c 'tkinter._test()'` and verifying the box pops up.  It is possible it installs the python version fine and the tkinter stuff doesn't work.  
