### PR TITLE
"shasum": Permission denied

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -247,10 +247,7 @@ make_package() {
 
 compute_sha2() {
   local output
-  if type shasum &>/dev/null; then
-    output="$(shasum -a 256 -b)" || return 1
-    echo "${output% *}"
-  elif type openssl &>/dev/null; then
+  if type openssl &>/dev/null; then
     local openssl="$(command -v "$(brew --prefix openssl 2>/dev/null || true)"/bin/openssl openssl | head -1)"
     output="$("$openssl" dgst -sha256 2>/dev/null)" || return 1
     echo "${output##* }"


### PR DESCRIPTION
some perl installations leave zombie files on MacOS, mine is perl 5.18, one of them is `/usr/bin/shasum`, it has no execution authority and gives the wrong result for type command on bash.
https://github.com/pyenv/pyenv/issues/1414
```
#!/usr/bin/perl

=for comment

The contents of this script should normally never run!  The perl wrapper
should pick the correct script in /usr/bin by appending the appropriate version.
You can try appending the appropriate perl version number.  See perlmacosx.pod
for more information about multiple version support in Mac OS X.

=cut

use strict;
use Config ();

my @alt = grep {m,^$0\d+\.\d+(?:\.\d+)?$,} glob("$0*");
print STDERR <<"EOF-A";
perl version $Config::Config{version} can't run $0.  Try the alternative(s):

EOF-A
if(scalar(@alt) > 0) {
    for(@alt) {
	my($ver) = /(\d+\.\d+(?:\.\d+)?)/;
	print STDERR "$_ (uses perl $ver)\n";
    }
} else {
	print STDERR "(Error: no alternatives found)\n";
}
die <<'EOF-B';

Run "man perl" for more information about multiple version support in
Mac OS X.
EOF-B
```

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
