### PR TITLE
Add CPython 3.5.8 and remove 3.5.8rc1

### DIFF
--- a/plugins/python-build/share/python-build/3.5.8
+++ b/plugins/python-build/share/python-build/3.5.8
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.8rc1" "https://www.python.org/ftp/python/3.5.8/Python-3.5.8rc1.tar.xz#4ebf6c2b432064d68cd6804fde7bb6a2df567776b74205d9636a5ea6e4f3122a" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.8" "https://www.python.org/ftp/python/3.5.8/Python-3.5.8.tar.xz#1bb1319bcd05d95c4d9752c7f6378c5378b8f467fb9045e07023e94b28b2ff41" ldflags_dirs standard verify_py35 ensurepip
 else
-  install_package "Python-3.5.8rc1" "https://www.python.org/ftp/python/3.5.8/Python-3.5.8rc1.tgz#fd80351d0f2a08f102e33eb1b24e6dfb8c755f11928abc05ccae480321ffd13a" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.8" "https://www.python.org/ftp/python/3.5.8/Python-3.5.8.tgz#18c88dfd260147bc7247e6356010e5d4916dfbfc480f6434917f88e61228177a" ldflags_dirs standard verify_py35 ensurepip
 fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Add [CPython 3.5.8](https://www.python.org/downloads/release/python-358/)

### Tests
- [x] My PR adds the following unit tests (if any)