### PR TITLE
Update README.md to use .zshrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ easy to fork and contribute any changes back upstream.
     $ echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
     $ echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
     ```
-    - **Zsh note**: Modify your `~/.zshenv` file instead of `~/.bash_profile`.
+    - **Zsh note**: Modify your `~/.zshrc` file instead of `~/.bash_profile`.
     - **Ubuntu and Fedora note**: Modify your `~/.bashrc` file instead of `~/.bash_profile`.
     - **Proxy note**: If you use a proxy, export `http_proxy` and `HTTPS_PROXY` too.
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ easy to fork and contribute any changes back upstream.
     ```sh
     $ echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
     ```
-    - **Zsh note**: Modify your `~/.zshenv` file instead of `~/.bash_profile`.
+    - **Zsh note**: Modify your `~/.zshrc` file instead of `~/.bash_profile`.
     - **fish note**: Use `pyenv init - | source` instead of `eval (pyenv init -)`.
     - **Ubuntu and Fedora note**: Modify your `~/.bashrc` file instead of `~/.bash_profile`.
 


### PR DESCRIPTION
### Description
- With the latest macOS Catalina, I found that setting PYENV and PATHs in `.zshenv` did not properly load the python shim. Moving the commands to `.zshrc` fixed this. 
- Furthermore, I would suggest changing all `.zshenv` references to `.zshrc`
> macOS Terminal considers every new shell to be a login shell and an interactive shell. So, in Terminal a new zsh will potentially run all configuration files. For simplicity’s sake, you should use just one file. The common choice is .zshrc.

