### PR TITLE
Fix Readme fo zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ easy to fork and contribute any changes back upstream.
     $ echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
     $ echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
     ```
-    - **Zsh note**: Modify your `~/.zshenv` file instead of `~/.bash_profile`.
+    - **Zsh note**: Modify your `~/.zprofile` file instead of `~/.bash_profile`.
     - **Ubuntu and Fedora note**: Modify your `~/.bashrc` file instead of `~/.bash_profile`.
     - **Proxy note**: If you use a proxy, export `http_proxy` and `HTTPS_PROXY` too.
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR
pyenv resides in /usr/local/bin. This path is not yet in the PATH when .zshenv is being sourced. It is added to path during .zprofile sourcing so .zprofile seems a better place thatn .zshenv

### Tests
- [ ] My PR adds the following unit tests (if any)
