### PR TITLE
help: fix summary for repeated/binary commands

### DIFF
--- a/libexec/pyenv-help
+++ b/libexec/pyenv-help
@@ -89,7 +89,7 @@ collect_documentation() {
 documentation_for() {
   local filename
   filename="$(command_path "$1")"
-  if [ -n "$filename" ]; then
+  if [ -n "$filename" ] && [[ $(file -b --mime-type "$filename") == "text/"* ]]; then
     extract_initial_comment_block < "$filename" | collect_documentation
   fi
 }
@@ -151,7 +151,7 @@ if [ -z "$1" ] || [ "$1" == "pyenv" ]; then
   [ -z "$usage" ] || exit
   echo
   echo "Some useful pyenv commands are:"
-  print_summaries commands $(exec pyenv-commands | sort -u)
+  print_summaries $(exec pyenv-commands | sort -u)
   echo
   echo "See \`pyenv help <command>' for information on a specific command."
   echo "For full documentation, see: https://github.com/pyenv/pyenv#readme"


### PR DESCRIPTION
fix fcf539e: 'commands' command is repeated; commands which call binary
executables (e.g. pyenv-realpath.dylib) are also grabbed, which cause
help message parsing to fail. depending on the system locale, sed may
also emit an error.

remove extra 'commands' command; restrict help message parsing to files
of mime-type 'text/*t'.

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)
