### PR TITLE
Filter out 'realpath' bash builtin extension from 'commands'

### DIFF
--- a/libexec/pyenv-commands
+++ b/libexec/pyenv-commands
@@ -40,4 +40,4 @@ shopt -s nullglob
       fi
     done
   done
-} | sort | uniq
+} | grep -v '^realpath' | sort | uniq

--- a/test/commands.bats
+++ b/test/commands.bats
@@ -37,3 +37,10 @@ load test_helper
   assert_line "init"
   refute_line "shell"
 }
+
+@test "commands excludes realpath builtin extension" {
+  run pyenv-commands
+  assert_success
+  refute_line "realpath.so"
+  refute_line "realpath.dylib"
+}


### PR DESCRIPTION
Due to fcf539ec enabling the help message being dynamic and discovering
everything from `pyenv-commands`, a side effect was the `realpath*`
`bash` builtin extension being listed.  This change elides the shared
library from being listed since it is not a command one can execute via
`pyenv <command>`.

Closes: #1454 