### PR TITLE
don't print summary for `commands` command twice

### DIFF
--- a/libexec/pyenv-help
+++ b/libexec/pyenv-help
@@ -151,7 +151,7 @@ if [ -z "$1" ] || [ "$1" == "pyenv" ]; then
   [ -z "$usage" ] || exit
   echo
   echo "Some useful pyenv commands are:"
-  print_summaries commands $(exec pyenv-commands | sort -u)
+  print_summaries commands $(exec pyenv-commands | sort -u | grep -vFx commands)
   echo
   echo "See \`pyenv help <command>' for information on a specific command."
   echo "For full documentation, see: https://github.com/pyenv/pyenv#readme"


### PR DESCRIPTION
Remove duplicate entry in the command list.

### Before PR

```
$ pyenv help
Usage: pyenv <command> [<args>]

Some useful pyenv commands are:
   commands    List all available pyenv commands
   activate    Activate virtual environment
   commands    List all available pyenv commands
   deactivate   Deactivate virtual environment
...
```
### After

```
$ pyenv help
Usage: pyenv <command> [<args>]

Some useful pyenv commands are:
   commands    List all available pyenv commands
   activate    Activate virtual environment
   deactivate   Deactivate virtual environment
...