### PR TITLE
Enable users to discover how to update the python-build plugin

### DIFF
--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -24,6 +24,10 @@
 # python-build, including a list of environment variables for adjusting
 # compilation, see: https://github.com/pyenv/pyenv#readme
 #
+# If the version you are looking for is missing, you probably need to update
+# your pyenv python-build plugin. For information on how to do so, run:
+#   pyenv install how-do-i-update-my-pyenv-build-plugin
+#
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
@@ -82,6 +86,10 @@ for option in "${OPTIONS[@]}"; do
   "l" | "list" )
     echo "Available versions:"
     definitions | indent
+    {
+      echo "Can't find the version you want? Run:"
+      echo "pyenv install how-do-i-update-my-pyenv-build-plugin"
+    } >&2
     exit
     ;;
   "f" | "force" )

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -46,6 +46,8 @@ Available versions:
   2.7.9-rc1
   2.7.9-rc2
   3.4.2
+Can't find the version you want? Run:
+pyenv install how-do-i-update-my-pyenv-build-plugin
 OUT
 
   unstub python-build
@@ -130,6 +132,8 @@ Available versions:
   
   ${PYENV_ROOT}/plugins/bar/share/python-build
   ${PYENV_ROOT}/plugins/foo/share/python-build
+Can't find the version you want? Run:
+pyenv install how-do-i-update-my-pyenv-build-plugin
 OUT
 }
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
Considered. Declined.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
rbenv/ruby-build#1380
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] I was using a `brew install pyenv` environment and was instructed to install `python 3.8`. I ran `pyenv install -l` and all I saw was `3.8-dev`. I checked with `brew` and confirmed I was running the latest version of `pyenv`. We checked and the person who instructed me to install it was using an older version of `pyenv`. This was incredibly confusing. I checked the `pyenv install --help` and there was nothing obvious that indicated what I was doing wrong.

At some point, we decided that I should just install `3.8-dev`, and I managed to mistype the name (as `python3.8-dev` iirc) and then I saw the command that explained how to update, and that's when we understood what was missing.

This PR attempts to address that missing link by making the standard path for normal users easier.

### Tests
- [ ] My PR adds the following unit tests (if any)
