### PR TITLE
Add PyPy 7.3.0

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1030,6 +1030,7 @@ pypy_architecture() {
     "ppc64" ) echo "linux-ppc64" ;;
     "ppc64le" ) echo "linux-ppc64le" ;;
     "x86_64" ) echo "linux64" ;;
+    "aarch64" ) echo "linux-aarch64" ;;
     * ) return 1 ;;
     esac
     ;;

--- a/plugins/python-build/share/python-build/pypy2.7-7.3.0
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.0
@@ -1,0 +1,39 @@
+VERSION='7.3.0'
+PYVER='2.7'
+
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux" )
+  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#eac1308b7d523003a5f6d20f58406d52ab14611bcec750122ae513a5a35110db" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux64" )
+  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#f4950a54378ac637da2a6defa52d6ffed96af12fcd5d74e1182fb834883c9826" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux-aarch64" )
+  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#a3dd8d5e2a656849fa344dce4679d854a19bc4a096a0cf62b46a1be127a5d56c" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"osx64" )
+  if require_osx_version "10.13"; then
+    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#ca7b056b243a6221ad04fa7fc8696e36a2fb858396999dcaa31dbbae53c54474" "pypy" "verify_py${PYVER//./}" ensurepip
+  else
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true), OS X < 10.13."
+      echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+      echo
+    } >&2
+    exit 1
+  fi
+  ;;
+"win32" )
+  install_zip "pypy${PYVER}-v${VERSION}-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-win32.zip#a9e3c5c983edba0313a41d3c1ab55b080816c4129e67a6c272c53b9dbcdd97ec" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/pypy2.7-7.3.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.0-src
@@ -1,0 +1,4 @@
+#require_gcc
+prefer_openssl11
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "pypy2.7-v7.3.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.3.0-src.tar.bz2#b0b25c7f8938ab0fedd8dedf26b9e73c490913b002b484c1b2f19d5844a518de" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.3.0
+++ b/plugins/python-build/share/python-build/pypy3.6-7.3.0
@@ -1,0 +1,39 @@
+VERSION='7.3.0'
+PYVER='3.6'
+
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux" )
+  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#7045b295d38ba0b5ee65bd3f078ca249fcf1de73fedeaab2d6ad78de2eab0f0e" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux64" )
+  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#d3d549e8f43de820ac3385b698b83fa59b4d7dd6cf3fe34c115f731e26ad8856" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux-aarch64" )
+  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#b900241bca7152254c107a632767f49edede99ca6360b9a064141267b47ef598" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"osx64" )
+  if require_osx_version "10.13"; then
+    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#87b2545dad75fe3027b4b2108aceb9fdadcdd24e61ae312ac48b449fdd452bf3" "pypy" "verify_py${PYVER//./}" ensurepip
+  else
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true), OS X < 10.13."
+      echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+      echo
+    } >&2
+    exit 1
+  fi
+  ;;
+"win32" )
+  install_zip "pypy${PYVER}-v${VERSION}-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-win32.zip#30e6870c4f3d8ef91890a6556a98080758000ba7c207cccdd86a8f5d358998c1" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/pypy3.6-7.3.0-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.3.0-src
@@ -1,0 +1,4 @@
+#require_gcc
+prefer_openssl11
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "pypy3.6-v7.3.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.3.0-src.tar.bz2#48d12c15fbcbcf4a32882a883195e1f922997cde78e7a16d4342b9b521eefcfa" "pypy_builder" verify_py36 ensurepip


### PR DESCRIPTION
The official pypy builds should now be portable on linux.
Also add aarch64 builds.