### PR TITLE
Replace `type cmd` with `cmd --help`

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -339,7 +339,7 @@ http() {
 detect_http_client() {
   local client
   for client in aria2c curl wget; do
-    if type "$client" &>/dev/null; then
+    if "$client" --help &>/dev/null; then
       echo "$client"
       return
     fi

--- a/plugins/python-build/test/fetch.bats
+++ b/plugins/python-build/test/fetch.bats
@@ -21,6 +21,7 @@ setup() {
 @test "using aria2c if available" {
   export PYTHON_BUILD_ARIA2_OPTS=
   export -n PYTHON_BUILD_HTTP_CLIENT
+  stub aria2c "--help : true"
   stub aria2c "--allow-overwrite=true --no-conf=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$4"
 
   install_fixture definitions/without-checksum


### PR DESCRIPTION
### Description
This addresses a case I find myself in where aria2c is "present" on a system, but broken due to system libraries being in a bad state.  It replaces the `type cmd` check to see if an executable is present with a `cmd --help` to see if the executable can be executed, and exit non-zero.

### Tests
No new tests added (should still prefer aria2c/curl/wget as before)
