### PR TITLE
stop re export shims if exists

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -97,7 +97,8 @@ bin_path="$(abs_dirname "$0")"
 for plugin_bin in "${PYENV_ROOT}/plugins/"*/bin; do
   PATH="${plugin_bin}:${PATH}"
 done
-export PATH="${bin_path}:${PATH}"
+
+[[ ":$PATH:" != *":${bin_path}:"* ]] && export PATH="${bin_path}:${PATH}"
 
 PYENV_HOOK_PATH="${PYENV_HOOK_PATH}:${PYENV_ROOT}/pyenv.d"
 if [ "${bin_path%/*}" != "$PYENV_ROOT" ]; then

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -43,6 +43,6 @@ done
 shift 1
 if [ "${PYENV_BIN_PATH#${PYENV_ROOT}}" != "${PYENV_BIN_PATH}" ]; then
   # Only add to $PATH for non-system version.
-  export PATH="${PYENV_BIN_PATH}:${PATH}"
+  [[ ":$PATH:" != *":${PYENV_BIN_PATH}:"* ]] && export PATH="${PYENV_BIN_PATH}:${PATH}"
 fi
 exec "$PYENV_COMMAND_PATH" "$@"

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -90,7 +90,7 @@ fish )
   echo "set -gx PYENV_SHELL $shell"
 ;;
 * )
-  echo 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
+  [[ ":$PATH:" != *":${PYENV_ROOT}/shims:"* ]] && echo 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
   echo "export PYENV_SHELL=$shell"
 ;;
 esac

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1391,7 +1391,7 @@ require_java() {
 # Let Jython installer to generate shell script instead of python script even if there's `python2.7` available in `$PATH` (#800)
 # FIXME: better function naming
 unrequire_python27() {
-  export PATH="${BUILD_PATH}/bin:${PATH}"
+  [[ ":$PATH:" != *":${BUILD_PATH}/bin:"* ]] && export PATH="${BUILD_PATH}/bin:${PATH}"
   mkdir -p "${BUILD_PATH}/bin"
   if command -v python2.7 1>/dev/null 2>&1; then
     echo false > "${BUILD_PATH}/bin/python2.7"
@@ -1707,7 +1707,7 @@ isolated_gem_dependency() {
 
 isolated_gem_install() {
   export GEM_HOME="${PWD}/.gem"
-  export PATH="${GEM_HOME}/bin:${PATH}"
+  [[ ":$PATH:" != *":${GEM_HOME}/bin:"* ]] && export PATH="${GEM_HOME}/bin:${PATH}"
   gem install "$@"
 }
 

--- a/pyenv.d/exec/pip-rehash/conda
+++ b/pyenv.d/exec/pip-rehash/conda
@@ -14,7 +14,7 @@ PATH="${_PATH}"
 PYENV_COMMAND_PATH="$(pyenv-which "${PYENV_REHASH_REAL_COMMAND}")"
 PYENV_BIN_PATH="${PYENV_COMMAND_PATH%/*}"
 
-export PATH="${PYENV_BIN_PATH}:${PATH}"
+[[ ":$PATH:" != *":${PYENV_BIN_PATH}:"* ]] && export PATH="${PYENV_BIN_PATH}:${PATH}"
 
 STATUS=0
 "$PYENV_COMMAND_PATH" "$@" || STATUS="$?"

--- a/pyenv.d/exec/pip-rehash/easy_install
+++ b/pyenv.d/exec/pip-rehash/easy_install
@@ -14,7 +14,7 @@ PATH="${_PATH}"
 PYENV_COMMAND_PATH="$(pyenv-which "${PYENV_REHASH_REAL_COMMAND}")"
 PYENV_BIN_PATH="${PYENV_COMMAND_PATH%/*}"
 
-export PATH="${PYENV_BIN_PATH}:${PATH}"
+[[ ":$PATH:" != *":${PYENV_BIN_PATH}:"* ]] && export PATH="${PYENV_BIN_PATH}:${PATH}"
 
 STATUS=0
 "$PYENV_COMMAND_PATH" "$@" || STATUS="$?"

--- a/pyenv.d/exec/pip-rehash/pip
+++ b/pyenv.d/exec/pip-rehash/pip
@@ -14,7 +14,7 @@ PATH="${_PATH}"
 PYENV_COMMAND_PATH="$(pyenv-which "${PYENV_REHASH_REAL_COMMAND}")"
 PYENV_BIN_PATH="${PYENV_COMMAND_PATH%/*}"
 
-export PATH="${PYENV_BIN_PATH}:${PATH}"
+[[ ":$PATH:" != *":${PYENV_BIN_PATH}:"* ]] && export PATH="${PYENV_BIN_PATH}:${PATH}"
 
 STATUS=0
 "$PYENV_COMMAND_PATH" "$@" || STATUS="$?"


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/969

### Description
- [x] Here are some details about my PR

If there is a better solution like use macro for reusable code plz guide me :)

Just make it works cause it's really annoying when I have to restart the shell with `exec zsh` and the PATH get populated

### Tests
- [ ] My PR adds the following unit tests (if any)
