### PR TITLE
Remove duplicate help message

### DIFF
--- a/libexec/pyenv-help
+++ b/libexec/pyenv-help
@@ -153,7 +153,7 @@ if [ -z "$1" ] || [ "$1" == "pyenv" ]; then
   [ -z "$usage" ] || exit
   echo
   echo "Some useful pyenv commands are:"
-  print_summaries commands $(exec pyenv-commands | sort -u)
+  print_summaries $(exec pyenv-commands | sort -u)
   echo
   echo "See \`pyenv help <command>' for information on a specific command."
   echo "For full documentation, see: https://github.com/pyenv/pyenv#readme"


### PR DESCRIPTION
The pyenv help listing offered the "commands" command twice.
