### PR TITLE
Mention log file if an error happened before building, too

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -128,13 +128,13 @@ build_failed() {
 
     if ! rmdir "${BUILD_PATH}" 2>/dev/null; then
       echo "Inspect or clean up the working tree at ${BUILD_PATH}"
+    fi
 
-      if file_is_not_empty "$LOG_PATH"; then
-        colorize 33 "Results logged to ${LOG_PATH}"
-        printf "\n\n"
-        echo "Last 10 log lines:"
-        tail -n 10 "$LOG_PATH"
-      fi
+    if file_is_not_empty "$LOG_PATH"; then
+      colorize 33 "Results logged to ${LOG_PATH}"
+      printf "\n\n"
+      echo "Last 10 log lines:"
+      tail -n 10 "$LOG_PATH"
     fi
   } >&3
   exit 1


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
  **N/A -- bugfix**
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
  **N/A -- the code in question is not present in rbenv**
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1156
### Description
- [x] Here are some details about my PR
When a build fails, mention log file and its contents regardless of whether `$BUILD_PATH` exists
### Tests
- [x] My PR adds the following unit tests (if any)
The current tests seem to only be testing public functionality while `build_failed()` is private. Should I add a test for it? Is it okay to test it directly? If not, which endpoint should I test it via?