### PR TITLE
pyenv-shell: $PYENV_VERSION may not be set

### DIFF
--- a/libexec/pyenv-sh-shell
+++ b/libexec/pyenv-sh-shell
@@ -49,7 +49,7 @@ if [ "$versions" = "--unset" ]; then
     echo "set -e PYENV_VERSION"
     ;;
   * )
-    echo 'PYENV_VERSION_OLD="$PYENV_VERSION"'
+    echo 'PYENV_VERSION_OLD="${PYENV_VERSION-}"'
     echo "unset PYENV_VERSION"
     ;;
   esac
@@ -80,12 +80,12 @@ EOS
     cat <<EOS
 if [ -n "\${PYENV_VERSION_OLD+x}" ]; then
   if [ -n "\$PYENV_VERSION_OLD" ]; then
-    PYENV_VERSION_OLD_="\$PYENV_VERSION"
+    PYENV_VERSION_OLD_="\${PYENV_VERSION-}"
     export PYENV_VERSION="\$PYENV_VERSION_OLD"
     PYENV_VERSION_OLD="\$PYENV_VERSION_OLD_"
     unset PYENV_VERSION_OLD_
   else
-    PYENV_VERSION_OLD="\$PYENV_VERSION"
+    PYENV_VERSION_OLD="\${PYENV_VERSION-}"
     unset PYENV_VERSION
   fi
 else
@@ -103,14 +103,14 @@ if pyenv-prefix "${versions[@]}" >/dev/null; then
   OLDIFS="$IFS"
   IFS=: version="${versions[*]}"
   IFS="$OLDIFS"
-  if [ "$version" != "$PYENV_VERSION" ]; then
+  if [ "$version" != "${PYENV_VERSION-}" ]; then
     case "$shell" in
     fish )
       echo 'set -gu PYENV_VERSION_OLD "$PYENV_VERSION"'
       echo "set -gx PYENV_VERSION \"$version\""
       ;;
     * )
-      echo 'PYENV_VERSION_OLD="$PYENV_VERSION"'
+      echo 'PYENV_VERSION_OLD="${PYENV_VERSION-}"'
       echo "export PYENV_VERSION=\"${version}\""
       ;;
     esac

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -47,7 +47,7 @@ load test_helper
   PYENV_SHELL=bash run pyenv-sh-shell --unset
   assert_success
   assert_output <<OUT
-PYENV_VERSION_OLD="\$PYENV_VERSION"
+PYENV_VERSION_OLD="\${PYENV_VERSION-}"
 unset PYENV_VERSION
 OUT
 }
@@ -75,7 +75,7 @@ SH
   PYENV_SHELL=bash run pyenv-sh-shell 1.2.3
   assert_success
   assert_output <<OUT
-PYENV_VERSION_OLD="\$PYENV_VERSION"
+PYENV_VERSION_OLD="\${PYENV_VERSION-}"
 export PYENV_VERSION="1.2.3"
 OUT
 }


### PR DESCRIPTION
### Prerequisite

I'll issue PR to rbenv once fish is fixed/tested.

### Description

`pyenv shell` assumes `$PYENV_VERSION` is set, when it might not be (yet). Use `${PYENV_VERSION-}` instead of $PYENV_VERSION.

I don't have fish so didn't fix for fish. It seems obvious, but would rather have someone familiar with fish fix.

### Tests

Fixed shell.bats to check for `${PYENV_VERSION-}`.
