### PR TITLE
Vagrant config for testing python-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,21 @@ tracker](https://github.com/pyenv/pyenv/issues).
   [pyenv-virtualenv]: https://github.com/pyenv/pyenv-virtualenv#readme
   [hooks]: https://github.com/pyenv/pyenv/wiki/Authoring-plugins#pyenv-hooks
 
+### Testing new python versions
+
+This repository contains a [vagrant](https://www.vagrantup.com/) configuration,
+to spin up and provision a Ubuntu 18.04 virtual machine with your local copy of the repo
+mounted at `~/.pyenv`.
+
+With vagrant and [virtualbox](https://www.virtualbox.org/) installed, simply
+
+```sh
+vagrant up
+vagrant ssh
+```
+
+and you will be dropped into a bash shell where you can test your pyenv changes.
+
 ### Version History
 
 See [CHANGELOG.md](CHANGELOG.md).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,18 @@
+# VM provisioning for testing new python versions
+
+# required to prevent virtualbox trying to start several servers
+# on the same interface
+# https://github.com/hashicorp/vagrant/issues/8878#issuecomment-345112810
+class VagrantPlugins::ProviderVirtualBox::Action::Network
+  def dhcp_server_matches_config?(dhcp_server, config)
+    true
+  end
+end
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-18.04"
+  config.vm.synced_folder "./", "/home/vagrant/.pyenv"
+  #config.vm.network "private_network", type: "dhcp"
+
+  config.vm.provision :shell, path: "test/vagrant/provision.sh"
+end

--- a/test/vagrant/provision.sh
+++ b/test/vagrant/provision.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+set -x
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+sudo apt-get install -y \
+	make \
+	build-essential \
+	libssl-dev \
+	zlib1g-dev \
+	libbz2-dev \
+	libreadline-dev \
+	libsqlite3-dev \
+	wget \
+	curl \
+	llvm \
+	libncurses5-dev \
+	libncursesw5-dev \
+	xz-utils \
+	tk-dev \
+	libffi-dev \
+	liblzma-dev \
+	python-openssl \
+	git
+
+echo 'export PYENV_ROOT="$HOME/.pyenv"' >> /home/vagrant/.profile
+echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> /home/vagrant/.profile
+echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> /home/vagrant/.profile
+chown vagrant:vagrant /home/vagrant/.profile
+


### PR DESCRIPTION
### Prerequisite

* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1445

### Description
- [x] Here are some details about my PR

For some time, there hasn't been a clear path for testing python-build. I suspect that most pyenv developers are pyenv users as well: there has been no documented way of keeping the development version of pyenv away from the version of pyenv supporting their python work.

The deafening silence in #1445 and #1361 suggests it's an issue which currently doesn't have an easy answer. Now it does.

With vagrant and virtualbox installed, a single command will spin up a clean ubuntu 18.04 virtual machine with all of the build dependencies, and the user's local pyenv repo mounted at `~/.pyenv` and installed in the usual way. Then they can install python versions to their heart's content, and can trash the VM whenever they want, with zero impact on their host machine and its pyenv installation. It's completely optional and doesn't impact the development of anyone not using this workflow (I don't know how those people are testing their builds, and apparently they don't want to tell me). Changes made inside the VM are persisted on the host, and vice versa. Users just have to be careful not to make commits inside the VM if they are relying on the host's global git config.

### Tests
- [ ] My PR adds the following unit tests (if any)

### Alternatives

Could use docker instead of vagrant, and provide a docker image which has the build requirements installed already. Rebuilding a clean container would probably be faster under docker, and I think docker has fewer restrictions on e.g. virtualisation being enabled in the BIOS. However, docker as a tool is MUCH less ergonomic than vagrant (unless you also use docker-compose), and you run into issues with persistence and file ownership when trying to use docker for development rather than deployment.

### Possible extensions

An additional script for attempting to build lots of python versions in a batch, possibly in a multi-threaded way, and report successes/ failures.
