### PR TITLE
Docker config for testing python-build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+.python-version
+.vscode/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:18.04
+
+LABEL maintainer="Chris L. Barnes <chrislloydbarnes@gmail.com>"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y \
+    && apt-get install -y \
+        make \
+        build-essential \
+        libssl-dev \
+        zlib1g-dev \
+        libbz2-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        wget \
+        curl \
+        llvm \
+        libncurses5-dev \
+        libncursesw5-dev \
+        xz-utils \
+        tk-dev \
+        libffi-dev \
+        liblzma-dev \
+        python-openssl \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PYENV_ROOT "/pyenv"
+ENV PATH "$PYENV_ROOT/bin:$PATH"
+
+COPY . /pyenv
+
+RUN eval "$(pyenv init -)"
+

--- a/README.md
+++ b/README.md
@@ -391,6 +391,29 @@ tracker](https://github.com/pyenv/pyenv/issues).
   [pyenv-virtualenv]: https://github.com/pyenv/pyenv-virtualenv#readme
   [hooks]: https://github.com/pyenv/pyenv/wiki/Authoring-plugins#pyenv-hooks
 
+### Testing new python versions
+
+If you are contributing a new python version for python-build, 
+you can test the build in a [docker](https://www.docker.com/) container based on Ubuntu 18.04.
+
+With docker installed:
+
+```sh
+docker build -t my_container .
+docker run my_container pyenv install <my_version>
+```
+
+To enter a shell which will allow you to build and then test a python version,
+replace the second line with
+
+```sh
+docker run -it my_container
+```
+
+The container will need to be rebuilt whenever you change the repo,
+but after the first build, this will be very fast, 
+as the layer including the build dependencies will be cached.
+
 ### Version History
 
 See [CHANGELOG.md](CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -391,31 +391,6 @@ tracker](https://github.com/pyenv/pyenv/issues).
   [pyenv-virtualenv]: https://github.com/pyenv/pyenv-virtualenv#readme
   [hooks]: https://github.com/pyenv/pyenv/wiki/Authoring-plugins#pyenv-hooks
 
-### Testing new python versions
-
-If you are contributing a new python version for python-build, 
-you can test the build in a [docker](https://www.docker.com/) container based on Ubuntu 18.04.
-
-With docker installed:
-
-```sh
-docker build -t my_container .
-docker run my_container pyenv install <my_version>
-```
-
-To enter a shell which will allow you to build and then test a python version,
-replace the second line with
-
-```sh
-docker run -it my_container
-```
-
-The container will need to be rebuilt whenever you change the repo,
-but after the first build, this will be very fast, 
-as the layer including the build dependencies will be cached.
-
-Changes made inside the container will not be persisted.
-
 ### Version History
 
 See [CHANGELOG.md](CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -414,6 +414,8 @@ The container will need to be rebuilt whenever you change the repo,
 but after the first build, this will be very fast, 
 as the layer including the build dependencies will be cached.
 
+Changes made inside the container will not be persisted.
+
 ### Version History
 
 See [CHANGELOG.md](CHANGELOG.md).

--- a/plugins/python-build/README.md
+++ b/plugins/python-build/README.md
@@ -220,3 +220,51 @@ Please see the [pyenv wiki](https://github.com/pyenv/pyenv/wiki) for solutions t
 If you can't find an answer on the wiki, open an issue on the [issue
 tracker](https://github.com/pyenv/pyenv/issues). Be sure to include
 the full build log for build failures.
+
+## Contributing
+
+### Testing new python versions
+
+If you are contributing a new python version for python-build, 
+you can test the build in a [docker](https://www.docker.com/) container based on Ubuntu 18.04.
+
+With docker installed:
+
+```sh
+docker build -t my_container .
+docker run my_container pyenv install <my_version>
+```
+
+To enter a shell which will allow you to build and then test a python version,
+replace the second line with
+
+```sh
+docker run -it my_container
+```
+
+The container will need to be rebuilt whenever you change the repo,
+but after the first build, this will be very fast, 
+as the layer including the build dependencies will be cached.
+
+Changes made inside the container will not be persisted.
+
+To test *all* new versions since a particular revision (e.g. `master`), `cd` to the root of your `pyenv` repo, and run this script:
+
+```sh
+set -e
+set -x
+
+docker build -t pyenv-test-container .
+
+git diff --name-only master \
+  | grep '^plugins/python-build/share/python-build/' \
+  | awk -F '/' '{print $NF}' \
+  | xargs -I _ docker run pyenv-test-container pyenv install _
+```
+
+- Build the docker image with the **t**ag pyenv-test-container
+- Look for the names files changed since revision `master`
+- Filter out any which don't live where python-build keeps its build scripts
+- Look only at the file name (i.e. the python version name)
+- Run a new docker container for each, building that version
+


### PR DESCRIPTION
An alternative to #1547 (see there for more discussion).

Pick this one if you want a faster spin up -> build python -> destroy environment cycle. Pick vagrant if you want to be able to make changes to your build script, have them persisted outside of the container, and re-test in the same container.