### PR TITLE
Customise `.python-version` filename for local project versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ name | default | description
 `PYENV_DEBUG` | | Outputs debug information.<br>Also as: `pyenv --debug <subcommand>`
 `PYENV_HOOK_PATH` | [_see wiki_][hooks] | Colon-separated list of paths searched for pyenv hooks.
 `PYENV_DIR` | `$PWD` | Directory to start searching for `.python-version` files.
+`PYENV_VERSION_FILENAME`  | `.python-version` | Customize filename for local project versions.
 `PYTHON_BUILD_ARIA2_OPTS` | | Used to pass additional parameters to [`aria2`](https://aria2.github.io/).<br>If the `aria2c` binary is available on PATH, pyenv uses `aria2c` instead of `curl` or `wget` to download the Python Source code. If you have an unstable internet connection, you can use this variable to instruct `aria2` to accelerate the download.<br>In most cases, you will only need to use `-x 10 -k 1M` as value to `PYTHON_BUILD_ARIA2_OPTS` environment variable
 
 

--- a/libexec/pyenv-local
+++ b/libexec/pyenv-local
@@ -32,9 +32,9 @@ fi
 versions=("$@")
 
 if [ "$versions" = "--unset" ]; then
-  rm -f .python-version
+  rm -f "${PYENV_VERSION_FILENAME:-.python-version}"
 elif [ -n "$versions" ]; then
-  pyenv-version-file-write .python-version "${versions[@]}"
+  pyenv-version-file-write "${PYENV_VERSION_FILENAME:-.python-version}" "${versions[@]}"
 else
   if version_file="$(pyenv-version-file "$PWD")"; then
     IFS=: versions=($(pyenv-version-file-read "$version_file"))

--- a/libexec/pyenv-version-file
+++ b/libexec/pyenv-version-file
@@ -9,8 +9,8 @@ target_dir="$1"
 find_local_version_file() {
   local root="$1"
   while ! [[ "$root" =~ ^//[^/]*$ ]]; do
-    if [ -f "${root}/.python-version" ]; then
-      echo "${root}/.python-version"
+    if [ -f "${root}/${PYENV_VERSION_FILENAME:-.python-version}" ]; then
+      echo "${root}/${PYENV_VERSION_FILENAME:-.python-version}"
       return 0
     fi
     [ -n "$root" ] || break

--- a/test/local.bats
+++ b/test/local.bats
@@ -13,9 +13,23 @@ setup() {
   assert_failure "pyenv: no local version configured for this directory"
 }
 
+@test "no version with custom name" {
+  echo "9.9.9" > .python-version
+  assert [ ! -e "${PWD}/.python-version-custom" ]
+  PYENV_VERSION_FILENAME=.python-version-custom run pyenv-local
+  assert_failure "pyenv: no local version configured for this directory"
+}
+
 @test "local version" {
   echo "1.2.3" > .python-version
   run pyenv-local
+  assert_success "1.2.3"
+}
+
+@test "local version with custom name" {
+  echo "9.9.9" > .python-version
+  echo "1.2.3" > .python-version-custom
+  PYENV_VERSION_FILENAME=.python-version-custom run pyenv-local
   assert_success "1.2.3"
 }
 
@@ -23,6 +37,14 @@ setup() {
   echo "1.2.3" > .python-version
   mkdir -p "subdir" && cd "subdir"
   run pyenv-local
+  assert_success "1.2.3"
+}
+
+@test "discovers version file in parent directory with custom name" {
+  echo "9.9.9" > .python-version
+  echo "1.2.3" > .python-version-custom
+  mkdir -p "subdir" && cd "subdir"
+  PYENV_VERSION_FILENAME=.python-version-custom run pyenv-local
   assert_success "1.2.3"
 }
 
@@ -41,6 +63,14 @@ setup() {
   assert [ "$(cat .python-version)" = "1.2.3" ]
 }
 
+@test "sets local version with custom name" {
+  mkdir -p "${PYENV_ROOT}/versions/1.2.3"
+  PYENV_VERSION_FILENAME=.python-version-custom run pyenv-local 1.2.3
+  assert_success ""
+  assert [ "$(cat .python-version-custom)" = "1.2.3" ]
+  assert [ ! -e "${PWD}/.python-version" ]
+}
+
 @test "changes local version" {
   echo "1.0-pre" > .python-version
   mkdir -p "${PYENV_ROOT}/versions/1.2.3"
@@ -51,9 +81,29 @@ setup() {
   assert [ "$(cat .python-version)" = "1.2.3" ]
 }
 
+@test "changes local version with custom name" {
+  echo "1.0-pre" > .python-version-custom
+  mkdir -p "${PYENV_ROOT}/versions/1.2.3"
+  PYENV_VERSION_FILENAME=.python-version-custom run pyenv-local
+  assert_success "1.0-pre"
+  PYENV_VERSION_FILENAME=.python-version-custom run pyenv-local 1.2.3
+  assert_success ""
+  assert [ "$(cat .python-version-custom)" = "1.2.3" ]
+  assert [ ! -e "${PWD}/.python-version" ]
+}
+
 @test "unsets local version" {
   touch .python-version
   run pyenv-local --unset
   assert_success ""
   assert [ ! -e .python-version ]
+}
+
+@test "unsets local version with custom name" {
+  touch .python-version
+  touch .python-version-custom
+  PYENV_VERSION_FILENAME=.python-version-custom run pyenv-local --unset
+  assert_success ""
+  assert [ ! -e .python-version-custom ]
+  assert [ -e .python-version ]
 }

--- a/test/version-file.bats
+++ b/test/version-file.bats
@@ -31,12 +31,28 @@ create_file() {
   assert_success "${PYENV_TEST_DIR}/.python-version"
 }
 
+@test "in current directory with custom name" {
+  create_file ".python-version-custom"
+  create_file ".python-version"
+  PYENV_VERSION_FILENAME=.python-version-custom run pyenv-version-file
+  assert_success "${PYENV_TEST_DIR}/.python-version-custom"
+}
+
 @test "in parent directory" {
   create_file ".python-version"
   mkdir -p project
   cd project
   run pyenv-version-file
   assert_success "${PYENV_TEST_DIR}/.python-version"
+}
+
+@test "in parent directory with custom name" {
+  create_file ".python-version-custom"
+  create_file ".python-version"
+  mkdir -p project
+  cd project
+  PYENV_VERSION_FILENAME=.python-version-custom run pyenv-version-file
+  assert_success "${PYENV_TEST_DIR}/.python-version-custom"
 }
 
 @test "topmost file has precedence" {


### PR DESCRIPTION
### Description

[22K+ projects](https://github.com/search?l=&q=filename%3A.python-version&type=Code) define their own `.python-version` files in their source code, version-controlled.

This file supposed to be an environment configuration, which is individual to every developer and their habits/preferences. A strict Python version to be used in a project can be opinionated. For actual code restrictions, `python_requires="==3.8.1"` of `setup.py` should be used.

This also breaks workflows when plugins like `pyenv-virtualenv` are used, with their own named versions instead of numeric Pythons. Having a fixed numeric Python version in a project assumes that all dependencies will be installed into that binary Python build instead of virtualenvs — for all projects that rely on this Python version.

With this PR, the developers will have an option to ignore the recommended Python versions in `.python-version` file of every project, and configure their own dot-file name to use by setting `PYENV_VERSION_FILENAME` on their workstations.

_The variable name looks not so good, can be discussed._


### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

- [ ] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)
