### PR TITLE
pyenv-version-file-read: use POSIX character sets

### DIFF
--- a/libexec/pyenv-version-file-read
+++ b/libexec/pyenv-version-file-read
@@ -9,7 +9,7 @@ if [ -e "$VERSION_FILE" ]; then
   # Read the first non-whitespace word from the specified version file.
   # Be careful not to load it whole in case there's something crazy in it.
   IFS="${IFS}"$'\r'
-  words=($(cut -b 1-1024 "$VERSION_FILE" | sed 's/^\s*\(\S\+\).*/\1/'))
+  words=($(cut -b 1-1024 "$VERSION_FILE" | sed 's/[[:space:]]*\([^[:space:]^[:space:]]*\).*/\1/'))
   versions=("${words[@]}")
 
   if [ -n "$versions" ]; then


### PR DESCRIPTION
Fixes #623

Make sure you have checked all steps below.

### Prerequisite
* [ ] ~~Please consider implementing the feature as a hook script or plugin as a first step.~~
  * N/A
* [ ] ~~Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.~~
  * N/A rbenv's [version-file-read](https://github.com/rbenv/rbenv/blob/master/libexec/rbenv-version-file-read) doesn't use a sed regex
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/623

### Description
- [x] Here are some details about my PR
As reported in #623, there are two test failures when running `bats test` on macOS:

```
not ok 98 reads only the first word from file
# (from function `assert_equal' in file test/test_helper.bash, line 65,
#  from function `assert_output' in file test/test_helper.bash, line 74,
#  from function `assert_success' in file test/test_helper.bash, line 49,
#  in test file test/version-file-read.bats, line 41)
#   `assert_success "3.3.5"' failed
# expected: 3.3.5
# actual:   3.3.5:2.7.6:hi
not ok 99 loads *not* only the first line in file
# (from function `assert_equal' in file test/test_helper.bash, line 65,
#  from function `assert_output' in file test/test_helper.bash, line 74,
#  from function `assert_success' in file test/test_helper.bash, line 49,
#  in test file test/version-file-read.bats, line 50)
#   `assert_success "2.7.6:3.3.5"' failed
# expected: 2.7.6:3.3.5
# actual:   2.7.6:one:3.3.5:two
```

This is because of differences in GNU sed and BSD sed (below, `gsed` is GNU sed and `sed` is BSD sed):

```console
$ echo "2.7.17 3.8" | gsed 's/^\s*\(\S\+\).*/\1/'
2.7.17
$ echo "2.7.17 3.8" | sed 's/^\s*\(\S\+\).*/\1/'
2.7.17 3.8
```

The fix is to use POSIX character sets for whitespace/non-whitespace:

```console
$ echo "2.7.17 3.8" | gsed 's/[[:space:]]*\([^[:space:]^[:space:]]*\).*/\1/'
2.7.17
$ echo "2.7.17 3.8" | sed 's/[[:space:]]*\([^[:space:]^[:space:]]*\).*/\1/'
2.7.17
```
FYI, I found this reference to be the most useful guide for fixing this:
https://www.grymoire.com/Unix/Regular.html#uh-13

### Tests
- [ ] My PR adds the following unit tests (if any)
