### PR TITLE
Update bats link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ The pyenv source code is [hosted on
 GitHub](https://github.com/pyenv/pyenv).  It's clean, modular,
 and easy to understand, even if you're not a shell hacker.
 
-Tests are executed using [Bats](https://github.com/sstephenson/bats):
+Tests are executed using [Bats](https://github.com/bats-core/bats-core):
 
     $ bats test
     $ bats/test/<file>.bats


### PR DESCRIPTION
Update the bats link to https://github.com/bats-core/bats-core (which is what pyenv is actually using on [Travis](https://github.com/pyenv/pyenv/blob/master/.travis.yml#L35))

Technically, the link is an artifact of upstream (rbenv), but rbenv is still using the the [old bats](https://github.com/rbenv/rbenv/blob/master/.github/workflows/ci.yml#L15), so without also updating rbenv to bats-core it wouldn't make sense to have this README update be PR against upstream.