### PR TITLE
Fixes missing double quote in README #1582

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ easy to fork and contribute any changes back upstream.
 
    - For **bash**:
      ~~~ bash
-     $ echo 'export PYENV_ROOT="$HOME/.pyenv' >> ~/.bash_profile
+     $ echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
      $ echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
      ~~~
 


### PR DESCRIPTION
Bash example had a missing quote for setting PYENV_ROOT path

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)

  - https://github.com/pyenv/pyenv/issues/1582

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
