### PR TITLE
pypy 7.3.1 support

### DIFF
--- a/plugins/python-build/share/python-build/pypy2.7-7.3.1
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.1
@@ -1,0 +1,39 @@
+VERSION='7.3.1'
+PYVER='2.7'
+
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux" )
+  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#cd155d06cd0956d9de4a16e8a6bdf0722cb45b5bc4bbf805825d393ebd6690ad" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux64" )
+  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#be74886547df7bf7094096a11fc0a48496779d0d1b71901797b0c816f92caca3" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux-aarch64" )
+  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#094f23ab262e666d8740bf27459a6b1215a628dad9b6c2a88f1ed5c793fab267" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"osx64" )
+  if require_osx_version "10.13"; then
+    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#dfd4651243441d2f8f1c348e9ecc09848642d0c31bb323aa8ac320e5b9f232f0" "pypy" "verify_py${PYVER//./}" ensurepip
+  else
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true), OS X < 10.13."
+      echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+      echo
+    } >&2
+    exit 1
+  fi
+  ;;
+"win32" )
+  install_zip "pypy${PYVER}-v${VERSION}-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-win32.zip#e3c0dfb385d9825dd7723f26576d55d43ed92f1178f2399ab39e9fa11621a47b" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/pypy2.7-7.3.1-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.1-src
@@ -1,0 +1,4 @@
+#require_gcc
+prefer_openssl11
+install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
+install_package "pypy2.7-v7.3.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.3.1-src.tar.bz2#fa3771514c8a354969be9bd3b26d65a489c30e28f91d350e4ad2f4081a9c9321" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.3.1
+++ b/plugins/python-build/share/python-build/pypy3.6-7.3.1
@@ -1,0 +1,39 @@
+VERSION='7.3.1'
+PYVER='3.6'
+
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux" )
+  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#2e7a818c67f3ac0708e4d8cdf1961f30cf9586b3f3ca2f215d93437c5ea4567b" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux64" )
+  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#f67cf1664a336a3e939b58b3cabfe47d893356bdc01f2e17bc912aaa6605db12" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux-aarch64" )
+  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#0069bc3c1570b935f1687f5e128cf050cd7229309e48fad2a2bf2140d43ffcee" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"osx64" )
+  if require_osx_version "10.13"; then
+    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#d9c1778cd1ba37e129b495ea0f35ccdd9b68f5cd9d33ef0ce24e955c16d8840b" "pypy" "verify_py${PYVER//./}" ensurepip
+  else
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true), OS X < 10.13."
+      echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+      echo
+    } >&2
+    exit 1
+  fi
+  ;;
+"win32" )
+  install_zip "pypy${PYVER}-v${VERSION}-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-win32.zip#752fbe8c4abee6468e5ce22af82818f821daded36faa65f3d69423f9c217007a" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/pypy3.6-7.3.1-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.3.1-src
@@ -1,0 +1,4 @@
+#require_gcc
+prefer_openssl11
+install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
+install_package "pypy3.6-v7.3.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.3.1-src.tar.bz2#0c2cc3229da36c6984baee128c8ff8bb4516d69df1d73275dc4622bf249afa83" "pypy_builder" verify_py36 ensurepip


### PR DESCRIPTION
Adds support for PyPy 7.3.1, in both source and binary forms, and in both 2.7 and 3.6 variations.  This was adapted directly from the 7.3.0 support scripts.
