### PR TITLE
Add CPython v2.7.18.

### DIFF
--- a/plugins/python-build/share/python-build/2.7.18
+++ b/plugins/python-build/share/python-build/2.7.18
@@ -1,0 +1,8 @@
+#require_gcc
+install_package "openssl-1.0.2q" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-2.7.18" "https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tar.xz#b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+else
+  install_package "Python-2.7.18" "https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tgz#da3080e3b488f648a3d7a4560ddee895284c3380b11d6de75edb986526b9a814" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+fi


### PR DESCRIPTION
Adding the Python v2.7.18 release. Bats tests still pass, tested the install in an Ubuntu 19.10 VM.