### PR TITLE
Add ZPlug installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,19 @@ If you're on Windows, consider using @kirankotari's [`pyenv-win`](https://github
 Visit my other project:
 https://github.com/pyenv/pyenv-installer
 
+### via ZPlug plugin manager for Zsh
+
+Add the following line to your `.zshrc`:
+
+```zplug "RiverGlide/zsh-pyenv", from:gitlab```
+
+Then install the plugin
+~~~ zsh
+  $ source ~/.zshrc
+  $ zplug install
+~~~
+
+The ZPlug plugin will install and initialise `pyenv` and add `pyenv` and `pyenv-install` to your `PATH`
 
 ### Basic GitHub Checkout
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This project was forked from [rbenv](https://github.com/rbenv/rbenv) and
 * **[Installation](#installation)**
   * [The Automatic Installer](#the-automatic-installer)
   * [via ZPlug plugin manager for Zsh](#via-zplug-plugin-manager-for-zsh)
-    * [Upgrading via ZPlug](#upgrading via ZPlug)
+    * [Upgrading via ZPlug](#upgrading-via-zplug)
   * [Basic GitHub Checkout](#basic-github-checkout)
     * [Upgrading](#upgrading)
   * [Homebrew on macOS](#homebrew-on-macos)

--- a/README.md
+++ b/README.md
@@ -46,11 +46,14 @@ This project was forked from [rbenv](https://github.com/rbenv/rbenv) and
   * [Choosing the Python Version](#choosing-the-python-version)
   * [Locating the Python Installation](#locating-the-python-installation)
 * **[Installation](#installation)**
+  * [The Automatic Installer](#the-automatic-installer)
+  * [via ZPlug plugin manager for Zsh](#via-zplug-plugin-manager-for-zsh)
+    * [Upgrading via ZPlug](#upgrading via ZPlug)
   * [Basic GitHub Checkout](#basic-github-checkout)
     * [Upgrading](#upgrading)
-    * [Homebrew on macOS](#homebrew-on-macos)
-    * [Advanced Configuration](#advanced-configuration)
-    * [Uninstalling Python Versions](#uninstalling-python-versions)
+  * [Homebrew on macOS](#homebrew-on-macos)
+* [Advanced Configuration](#advanced-configuration)
+* [Uninstalling Python Versions](#uninstalling-python-versions)
 * **[Command Reference](#command-reference)**
 * **[Development](#development)**
   * [Version History](#version-history)
@@ -189,6 +192,13 @@ Then install the plugin
 ~~~
 
 The ZPlug plugin will install and initialise `pyenv` and add `pyenv` and `pyenv-install` to your `PATH`
+
+#### Upgrading via ZPlug
+To upgrade to the latest version of pyenv, update the ZPlug plugin:
+
+```sh
+$ zplug update RiverGlide/zsh-pyenv
+```
 
 ### Basic GitHub Checkout
 


### PR DESCRIPTION
### Description
This PR updates the documentation to include installation via ZPlug plugin.

The plugin at https://gitlab.com/RiverGlide/zsh-pyenv.git is pretty straightforward, and would be a good candidate for bringing under the pyenv organisation.
It uses git submodules to checkout pyenv, and the plugin file itself adds pyenv and pyenv-install to the path as well as calling `eval $(pyenv init -)`
