### PR TITLE
Fix CI by pinning bats to the latest release (1.2.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
 before_install:
 - date +%Y-%m-%dT%H:%M:%S
 
-install: git clone --depth 1 https://github.com/bats-core/bats-core.git bats
+install: git clone --depth 1 --branch v1.2.0 https://github.com/bats-core/bats-core.git bats
 
 # Default for auto-generated jobs.
 script: make test-build

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ test-build:
 	$(PYTHON_BUILD_TEST_PREFIX)/bin/pip -V
 
 bats:
-	git clone --depth 1 https://github.com/bats-core/bats-core.git bats
+	git clone --depth 1 --branch v1.2.0 https://github.com/bats-core/bats-core.git bats


### PR DESCRIPTION
pyenv's Makefile currently runs bats from its master branch. Pin bats to its latest release (1.2.0 - 2020-04-25) instead. This fixes the following error when running `make test` in CI:

```
/src/bats/libexec/bats-core/bats-exec-file: line 192: bats-exec-test: command not found
```

The master branch of bats is currently at the following commit:

  bats-core/bats-core@b615ed8f750e45017b1ad070ef893d1e2552633a

Beyond this specific breakage, using the master branch of bats appears problematic: The master branch is inherently unstable. Also, pyenv's CI is more deterministic if it pins tools to a specific version.