### PR TITLE
Fix duplicate test in prefix.bats due to bad merge

### DIFF
--- a/test/prefix.bats
+++ b/test/prefix.bats
@@ -36,18 +36,6 @@ OUT
   rm -f "${BATS_TEST_DIRNAME}/libexec/pyenv-which"
 }
 
-@test "prefix for system in /" {
-  mkdir -p "${BATS_TEST_DIRNAME}/libexec"
-  cat >"${BATS_TEST_DIRNAME}/libexec/pyenv-which" <<OUT
-#!/bin/sh
-echo /bin/python
-OUT
-  chmod +x "${BATS_TEST_DIRNAME}/libexec/pyenv-which"
-  PYENV_VERSION="system" run pyenv-prefix
-  assert_success "/"
-  rm -f "${BATS_TEST_DIRNAME}/libexec/pyenv-which"
-}
-
 @test "prefix for invalid system" {
   PATH="$(path_without python)" run pyenv-prefix system
   assert_failure "pyenv: system version not found in PATH"


### PR DESCRIPTION
The test `"prefix for system in /"` is duplicated in [test/prefix.bats](test/prefix.bats). Both tests are completely identical. This commit removes the duplicate.

It appears that the culprit is this merge from `rbenv/master`, from 2016: cf1beda36248be9b0b0ff0913cca03a51d4572e5

With the current development version of bats, this leads to the following error when running `make test` (note that the development version is what pyenv's Makefile uses):

```
Error: Duplicate test name(s) in file "/home/travis/build/pyenv/pyenv/test/prefix.bats": test_prefix_for_system_in_-2f
```

With the latest release of bats, the duplication only leads to a warning:

```
bats warning: duplicate test name(s) in /src/test/prefix.bats: test_prefix_for_system_in_-2f
```

See also #1602 

Please note that the checks for this PR fail because of the issue addressed by #1602 