### PR TITLE
Fix stackless-3.7.5 python-build script

### DIFF
--- a/plugins/python-build/share/python-build/stackless-3.7.5
+++ b/plugins/python-build/share/python-build/stackless-3.7.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-3.7.5-slp" "https://github.com/stackless-dev/stackless/archive/v3.7.5-slp.tar.gz#e2562a8d235adc19be5451c170837f53ef916aec4cd5cd17d9e0ab1f1b875d3f " ldflags_dirs standard verify_py37 ensurepip
+install_package "stackless-3.7.5-slp" "https://github.com/stackless-dev/stackless/archive/v3.7.5-slp.tar.gz#e2562a8d235adc19be5451c170837f53ef916aec4cd5cd17d9e0ab1f1b875d3f" ldflags_dirs standard verify_py37 ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)

### Description
- [x] Here are some details about my PR

Remove extra whitespace in quoted package_url#checksum string.

Prevent the following error:
```
$ pyenv install stackless-3.7.5
Downloading v3.7.5-slp.tar.gz...
-> https://github.com/stackless-dev/stackless/archive/v3.7.5-slp.tar.gz

BUILD FAILED (Ubuntu 18.04 using python-build 1.2.18-14-g5a96d9f)

Inspect or clean up the working tree at /tmp/python-build.20200517120717.3108
Results logged to /tmp/python-build.20200517120717.3108.log

Last 10 log lines:
/tmp/python-build.20200517120717.3108 ~

unexpected checksum length: 65 (e2562a8d235adc19be5451c170837f53ef916aec4cd5cd17d9e0ab1f1b875d3f )
expected 0 (no checksum), 32 (MD5), or 64 (SHA2-256)
```

### Tests
- [x] My PR adds the following unit tests (if any)
