### PR TITLE
Making instructions for installation more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,13 +228,26 @@ easy to fork and contribute any changes back upstream.
 3. **Add `pyenv init` to your shell** to enable shims and autocompletion.
    Please make sure `eval "$(pyenv init -)"` is placed toward the end of the shell
    configuration file since it manipulates `PATH` during the initialization.
-    ```sh
-    $ echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
-    ```
-    - **Zsh note**: Modify your `~/.zshrc` file instead of `~/.bash_profile`.
-    - **fish note**: Use `pyenv init - | source` instead of `eval (pyenv init -)`.
-    - **Ubuntu and Fedora note**: Modify your `~/.bashrc` file instead of `~/.bash_profile`.
-
+   - For **bash**:
+     ~~~ bash
+     $ echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
+     ~~~
+   
+   - For **Ubuntu and Fedora**:
+     ~~~ bash
+     $ echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  pyenv init - | source"\nfi' >> ~/.bashrc
+     ~~~
+   
+   - For **Zsh**:
+     ~~~ bash
+     $ echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
+     ~~~
+     
+   - For **Fish**:
+     ~~~ bash
+     $ echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  pyenv init - | source"\nfi' >> ~/.zshrc
+     ~~~
+    
     **General warning**: There are some systems where the `BASH_ENV` variable is configured
     to point to `.bashrc`. On such systems you should almost certainly put the above mentioned line
     `eval "$(pyenv init -)"` into `.bash_profile`, and **not** into `.bashrc`. Otherwise you

--- a/README.md
+++ b/README.md
@@ -244,8 +244,9 @@ easy to fork and contribute any changes back upstream.
      ~~~
      
    - For **Fish**:
-     ~~~ bash
-     $ echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  pyenv init - | source"\nfi' >> ~/.zshrc
+     ~~~ fish
+     $ status --is-interactive; and . (pyenv init -|psub)
+     $ status --is-interactive; and . (pyenv virtualenv-init -|psub)
      ~~~
     
     **General warning**: There are some systems where the `BASH_ENV` variable is configured


### PR DESCRIPTION
Separating commands for each shell instead of notes to make instructions clearer.

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR
       Moving instruction notes to actual copy-paste shell commands.

### Tests
- [x] My PR adds the following unit tests (if any) - No tests needed

