### PR TITLE
Update 3.9-dev and add 3.10-dev

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1722,6 +1722,11 @@ build_package_verify_py39() {
   build_package_verify_py38 "$1" "${2:-3.9}"
 }
 
+# Post-install check for Python 3.10.x
+build_package_verify_py310() {
+  build_package_verify_py39 "$1" "${2:-3.10}"
+}
+
 # Copy Tools/gdb/libpython.py to pythonX.Y-gdb.py (#1190)
 build_package_copy_python_gdb() {
   if [ -e "$BUILD_PATH/$1/Tools/gdb/libpython.py" ]; then

--- a/plugins/python-build/share/python-build/3.10-dev
+++ b/plugins/python-build/share/python-build/3.10-dev
@@ -1,0 +1,6 @@
+#require_gcc
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+install_git "Python-3.10-dev" "https://github.com/python/cpython" master standard verify_py310 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.9-dev
+++ b/plugins/python-build/share/python-build/3.9-dev
@@ -3,4 +3,4 @@ prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_git "Python-3.9-dev" "https://github.com/python/cpython" master standard verify_py39 copy_python_gdb ensurepip
+install_git "Python-3.9-dev" "https://github.com/python/cpython" 3.9 standard verify_py39 copy_python_gdb ensurepip


### PR DESCRIPTION
### Description
After the beta release, `master` now points to `3.10`. `pyenv install 3.9-dev` is also failing because of a mismatch between the version number and the symlink (`python3.9`, I guess).

### Tests
No tests added ­— are they needed for this?