### PR TITLE
make zsh completion works no need source in zshrc.

### DIFF
--- a/completions/pyenv.zsh
+++ b/completions/pyenv.zsh
@@ -1,13 +1,28 @@
 #compdef pyenv
+if [[ ! -o interactive ]]; then
+    return
+fi
 
-_pyenv() {
-  local -a comples
-  if [ "${#words}" -eq 2 ]; then
-    comples=($(pyenv commands))
-  else
-    comples=($(pyenv completions ${words[2,-2]}))
-  fi
-  _describe -t comples 'comples' comples
-}
+local state line
+typeset -A opt_args
 
-_pyenv
+_arguments -C \
+    {--help,-h}'[Show help]' \
+    {--version,-v}'[Show pyenv version]' \
+    '(-): :->command' \
+    '*:: :->option-or-argument'
+
+case "$state" in
+    (command)
+        local -a commands
+        commands=(${(f)"$(pyenv commands)"})
+        _describe -t commands 'command' commands
+        ;;
+    (option-or-argument)
+        local -a args
+        args=(${(f)"$(pyenv completions ${line[1]})"})
+        _describe -t args 'arg' args
+        ;;
+esac
+
+return 0

--- a/completions/pyenv.zsh
+++ b/completions/pyenv.zsh
@@ -1,18 +1,13 @@
-if [[ ! -o interactive ]]; then
-    return
-fi
-
-compctl -K _pyenv pyenv
+#compdef pyenv
 
 _pyenv() {
-  local words completions
-  read -cA words
-
+  local -a comples
   if [ "${#words}" -eq 2 ]; then
-    completions="$(pyenv commands)"
+    comples=($(pyenv commands))
   else
-    completions="$(pyenv completions ${words[2,-2]})"
+    comples=($(pyenv completions ${words[2,-2]}))
   fi
-
-  reply=(${(ps:\n:)completions})
+  _describe -t comples 'comples' comples
 }
+
+_pyenv


### PR DESCRIPTION
Just put it on $fpath (Archlinux did it in default for pyenv).

By the way, this commit make pyenv zsh completion support [fzf-tab](https://github.com/Aloxaf/fzf-tab) @Aloxaf .

![image](https://user-images.githubusercontent.com/9500049/85985739-b911f080-ba1d-11ea-840b-15381ec9d92a.png)

### Description

This PR seems only involved to zsh completion.