### PR TITLE
Avoid duplicate shims path in PATH

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -86,11 +86,19 @@ mkdir -p "${PYENV_ROOT}/"{shims,versions}
 
 case "$shell" in
 fish )
-  echo "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
+  echo "
+if not echo \$PATH | grep -q -E \"(^|\\s)${PYENV_ROOT}/shims(\\$|\\s)\"
+  set -gx PATH '${PYENV_ROOT}/shims' \$PATH
+end
+"
   echo "set -gx PYENV_SHELL $shell"
 ;;
 * )
-  echo 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
+  echo "
+if ! echo \$PATH | grep -q -E \"(^|:)${PYENV_ROOT}/shims(\$|:)\"; then
+  export PATH=\"${PYENV_ROOT}/shims:\${PATH}\"
+fi
+"
   echo "export PYENV_SHELL=$shell"
 ;;
 esac


### PR DESCRIPTION
Fixes: #1649

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1649

### Description

Update `pyenv-init` script. Add statements to check shims path in `PATH` before appending.

### Tests

No
