### PR TITLE
Fix #1647 (Incorrect checksum for Python 3.7.8 gzip package)

### DIFF
--- a/plugins/python-build/share/python-build/3.7.8
+++ b/plugins/python-build/share/python-build/3.7.8
@@ -6,5 +6,5 @@ install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.
 if has_tar_xz_support; then
   install_package "Python-3.7.8" "https://www.python.org/ftp/python/3.7.8/Python-3.7.8.tar.xz#43a543404b363f0037f89df8478f19db2dbc0d6f3ffee310bc2997fa71854a63" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.8" "https://www.python.org/ftp/python/3.7.8/Python-3.7.8.tgz#8c8be91cd2648a1a0c251f04ea0bb4c2a5570feb9c45eaaa2241c785585b475a" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.8" "https://www.python.org/ftp/python/3.7.8/Python-3.7.8.tgz#0e25835614dc221e3ecea5831b38fa90788b5389b99b675a751414c858789ab0" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
 fi


### PR DESCRIPTION
This is a minor copy/paste issue where checksum for the file was not bumped up for the given version (and only for tgz archive).

Closes #1647