### PR TITLE
Fix has_tar_xz_support function on FreeBSD.

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -504,7 +504,7 @@ download_tarball() {
 }
 
 has_tar_xz_support() {
-  tar Jc /dev/null 1>/dev/null 2>&1
+  tar Jcf - /dev/null 1>/dev/null 2>&1
 }
 
 fetch_git() {


### PR DESCRIPTION
While working on a fix for #1647 (PR #1651) I noticed that tgz archive was used even though my FreeBSDs tar is capable of operating with J flag handling xz archives. Reason for that is that the current implementation of the `has_tar_xz_support` function returns always 1 due to the following error:

```
~ tar Jc /dev/null
tar: Failed to open '/dev/sa0'
```

Easy fix that works universally on all(? I checked Linux, macOS and FreeBSD) platforms is in this PR.