### PR TITLE
"system" python - support cases where python3 is in PATH but not python

### DIFF
--- a/libexec/pyenv-prefix
+++ b/libexec/pyenv-prefix
@@ -30,7 +30,7 @@ OLDIFS="$IFS"
 { IFS=:
   for version in ${PYENV_VERSION}; do
     if [ "$version" = "system" ]; then
-      if PYTHON_PATH="$(PYENV_VERSION="${version}" pyenv-which python 2>/dev/null)"; then
+      if PYTHON_PATH="$(PYENV_VERSION="${version}" pyenv-which python 2>/dev/null)" || PYTHON_PATH="$(PYENV_VERSION="${version}" pyenv-which python3 2>/dev/null)"; then
         PYENV_PREFIX_PATH="${PYTHON_PATH%/bin/*}"
         PYENV_PREFIX_PATH="${PYENV_PREFIX_PATH:-/}"
       else

--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -102,7 +102,7 @@ print_version() {
 }
 
 # Include "system" in the non-bare output, if it exists
-if [ -n "$include_system" ] && PYENV_VERSION=system pyenv-which python >/dev/null 2>&1; then
+if [ -n "$include_system" ] && (PYENV_VERSION=system pyenv-which python >/dev/null 2>&1 || PYENV_VERSION=system pyenv-which python3 >/dev/null 2>&1); then
   print_version system
 fi
 


### PR DESCRIPTION
### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1366
  - https://github.com/pyenv/pyenv/issues/1628

### Description
- [x] Here are some details about my PR

Simple fixes such that a user who does not have a 'python' binary in their path, but does have a 'python3' binary see their system python in `pyenv versions` and does not receive warnings about no system python installations.

### Tests
- [x] My PR adds the following unit tests (if any)

N/A