### PR TITLE
Match Python version prefix

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1880,8 +1880,18 @@ elif [ ! -f "$DEFINITION_PATH" ]; then
   done
 
   if [ ! -f "$DEFINITION_PATH" ]; then
-    echo "python-build: definition not found: ${DEFINITION_PATH}" >&2
-    exit 2
+    # Check if specified version is a prefix for a valid version
+    # Uses the latest version e.g. 3.7 will give 3.7.8
+    PYTHON_PREFIX_MATCH=$(ls $DEFINITION_DIR -hr | grep ^"${DEFINITION_PATH}" | grep -v "dev" | head -n 1)
+
+    # If match found, install, else print error
+    if [ -n "$PYTHON_PREFIX_MATCH" ]; then
+      echo "python-build: installing latest version $PYTHON_PREFIX_MATCH" >&2
+      DEFINITION_PATH="${DEFINITION_DIR}/${PYTHON_PREFIX_MATCH}"
+    else
+      echo "python-build: definition not found: ${DEFINITION_PATH}" >&2
+      exit 2
+    fi
   fi
 fi
 


### PR DESCRIPTION
### Description

This PR adds prefix matching when performing `install` operations so users can get away with specifying a prefix string rather than the complete string, making pyenv much more user friendly.

For example, running `pyenv install 3.7` will give the message `python-build: definition not found: 3.7`, but this PR will cause pyenv to install `3.7.8`, the latest version matching `3.7`.

Similary, `pyenv install anaconda3-20` will install `anaconda3-2020.02`.
