### PR TITLE
fix grep-function detection

### DIFF
--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -59,7 +59,7 @@ usage() {
 
 definitions() {
   local query="$1"
-  python-build --definitions | $(type -p ggrep grep | head -1) -F "$query" || true
+  python-build --definitions | $(type -ap ggrep grep | head -1) -F "$query" || true
 }
 
 indent() {


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1662

### Description
Let the `type` cmd be more permissive in finding a suitable `ggrep`/`grep`.

### Tests
- [ ] My PR adds the following unit tests (if any)
