### PR TITLE
Add support for PYTHON_BUILD_MIRROR_URL when checksums do not exist

### DIFF
--- a/plugins/python-build/README.md
+++ b/plugins/python-build/README.md
@@ -109,6 +109,8 @@ You can set certain environment variables to control the build process.
   downloaded package files.
 * `PYTHON_BUILD_MIRROR_URL` overrides the default mirror URL root to one of your
   choosing.
+* `PYTHON_BUILD_MIRROR_URL_SKIP_CHECKSUM`, if set, does not append the SHA2
+  checksum of the file to the mirror URL.
 * `PYTHON_BUILD_SKIP_MIRROR`, if set, forces python-build to download packages from
   their original source URLs instead of using a mirror.
 * `PYTHON_BUILD_ROOT` overrides the default location from where build definitions
@@ -181,6 +183,10 @@ You can point python-build to another mirror by specifying the
 `PYTHON_BUILD_MIRROR_URL` environment variable--useful if you'd like to run your
 own local mirror, for example. Package mirror URLs are constructed by joining
 this variable with the SHA2 checksum of the package file.
+
+If the mirror being used does not have the same checksum (*e.g.* with a
+pull-through cache like Artifactory), you can set the
+`PYTHON_BUILD_MIRROR_URL_SKIP_CHECKSUM` environment variable.
 
 If you don't have an SHA2 program installed, python-build will skip the download
 mirror and use official URLs instead. You can force python-build to bypass the

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -480,7 +480,12 @@ reuse_existing_tarball() {
 }
 
 download_tarball() {
-  local package_url="$1"
+  local official_source="www.python.org/ftp/python"
+  if [ -n "$PYTHON_BUILD_MIRROR_URL_SKIP_CHECKSUM" ]; then
+      local package_url="$(echo "$1" | sed -e "s|.*//${URL_BASE:-$official_source}|$PYTHON_BUILD_MIRROR_URL|g")"
+  else
+      local package_url="$1"
+  fi
   [ -n "$package_url" ] || return 1
 
   local package_filename="$2"
@@ -1948,7 +1953,11 @@ else
   PYTHON_BUILD_DEFAULT_MIRROR=
 fi
 
-if [ -n "$PYTHON_BUILD_SKIP_MIRROR" ] || ! has_checksum_support compute_sha2; then
+if [ -n "$PYTHON_BUILD_SKIP_MIRROR" ]; then
+  unset PYTHON_BUILD_MIRROR_URL
+fi
+
+if ! has_checksum_support compute_sha2 && ! [ -n "$PYTHON_BUILD_MIRROR_URL_SKIP_CHECKSUM" ] ; then
   unset PYTHON_BUILD_MIRROR_URL
 fi
 

--- a/plugins/python-build/test/mirror.bats
+++ b/plugins/python-build/test/mirror.bats
@@ -70,6 +70,26 @@ export PYTHON_BUILD_MIRROR_URL=http://mirror.example.com
   unstub shasum
 }
 
+@test "package is fetched from mirror when checksum is invalid if SKIP_CHECKSUM set" {
+  export PYTHON_BUILD_MIRROR_URL_SKIP_CHECKSUM=1
+  export PYTHON_BUILD_MIRROR_URL=https://custom.mirror.org
+  export URL_BASE=example.com
+  local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
+
+  stub shasum false
+  stub curl "-*I* : true" \
+    "-q -o * -*S* https://custom.mirror.org/* : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
+
+  install_fixture definitions/with-checksum
+
+  assert_success
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
+
+  unstub curl
+  unstub shasum
+  unset PYTHON_BUILD_MIRROR_URL_SKIP_CHECKSUM
+}
+
 
 @test "package is fetched from original URL if mirror download checksum is invalid" {
   local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [N/A] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [N/A] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/1473
  - Closes https://github.com/pyenv/pyenv/issues/1377
  - https://github.com/pyenv/pyenv/issues/1575
  - https://github.com/pyenv/pyenv/issues/803

### Description

Fixes an issue where `PYTHON_BUILD_MIRROR_URL` is not used if the mirror does not have the same checksum that is expected. In some cases, the mirror is not expected to have a matching checksum (as in the case of a corporate mirror behind a firewall), which causes errors.

By setting `PYTHON_BUILD_MIRROR_URL_SKIP_CHECKSUM`, the `PYTHON_BUILD_MIRROR_URL` will be used but will not attempt to match a checksum.

### Tests
- [x] My PR adds the following unit tests (if any)
  - package is fetched from mirror when checksum is invalid if SKIP_CHECKSUM set