### PR TITLE
Remove build_package_ldflags_dirs() from python-build

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1486,21 +1486,6 @@ use_xcode_sdk_zlib() {
   fi
 }
 
-# Ensure that directories listed in LDFLAGS exist
-build_package_ldflags_dirs() {
-  local arg dir
-  set - $LDFLAGS
-  while [ $# -gt 0 ]; do
-    dir=""
-    case "$1" in
-    -L  ) dir="$2" ;;
-    -L* ) dir="${1#-L}" ;;
-    esac
-    [ -z "$dir" ] || mkdir -p "$dir"
-    shift 1
-  done
-}
-
 build_package_enable_shared() {
     package_option python configure --enable-shared
 }


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/732

### Description
- [x] Here are some details about my PR:
  * Currently build_package_ldflags_dirs() checks for the existence of directories set by the LDFLAGS variable and then attempts to create those directories in an area where it lacks permission. Per the comment by @chrahunt found [here](https://github.com/pyenv/pyenv/issues/732#issuecomment-464899679), this function was introduced to ruby-build for what seems like a Ruby-specific issue. I suggest removing this function entirely from python-build. If there is a good reason for keeping it, proper amendment should be made so it is functional for users utilizing LDFLAGS in their environment.
  * This currently fails to build because the removed function is referenced in the command loop/via each python build definition - these were apparently added to `suppress linker warnings` in [this commit](https://github.com/pyenv/pyenv/commit/8e02b93e3932a5439e9b21a80c5a67e59401cd94).
