### PR TITLE
Add 3.6.12 and 3.7.9 versions

### DIFF
--- a/plugins/python-build/share/python-build/3.6.12
+++ b/plugins/python-build/share/python-build/3.6.12
@@ -1,0 +1,9 @@
+#require_gcc
+prefer_openssl11
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-3.6.12" "https://www.python.org/ftp/python/3.6.12/Python-3.6.12.tar.xz#70953a9b5d6891d92e65d184c3512126a15814bee15e1eff2ddcce04334e9a99" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+else
+  install_package "Python-3.6.12" "https://www.python.org/ftp/python/3.6.12/Python-3.6.12.tgz#12dddbe52385a0f702fb8071e12dcc6b3cb2dde07cd8db3ed60e90d90ab78693" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+fi

--- a/plugins/python-build/share/python-build/3.7.9
+++ b/plugins/python-build/share/python-build/3.7.9
@@ -1,0 +1,10 @@
+#require_gcc
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-3.7.9" "https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tar.xz#91923007b05005b5f9bd46f3b9172248aea5abc1543e8a636d59e629c3331b01" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+else
+  install_package "Python-3.7.9" "https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tgz#39b018bc7d8a165e59aa827d9ae45c45901739b0bbb13721e4f973f3521c166a" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1679

### Description
Adds (cpython) 3.6.12 and 3.7.9

### Tests
I didn't add any tests. To make sure I got the shasums right, I downloaded from the tarballs from python.org, and checked that their md5 sums matched what was published on python.org. Then, I ran `shasum -a 256` on each file.

This is my first time contributing to this repo, so please let me know if there is anything else I should do.

Thanks for the awesome utility!
