### PR TITLE
Fix PyPy download links

### DIFF
--- a/plugins/python-build/share/python-build/pypy-1.6
+++ b/plugins/python-build/share/python-build/pypy-1.6
@@ -1,16 +1,16 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-1.6" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.6-linux.tar.bz2#1266c8b5918d84432b8649535fb5c84f6b977331c242bf45c5944033562ce0b2" "pypy" verify_py27 ensurepip
+  install_package "pypy-1.6" "https://downloads.python.org/pypy/pypy-1.6-linux.tar.bz2#1266c8b5918d84432b8649535fb5c84f6b977331c242bf45c5944033562ce0b2" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-1.6" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.6-linux64.tar.bz2#95b229c496339a51c4c1e9749bf8dbd11e4f698521803c089b52577be2cdbab8" "pypy" verify_py27 ensurepip
+  install_package "pypy-1.6" "https://downloads.python.org/pypy/pypy-1.6-linux64.tar.bz2#95b229c496339a51c4c1e9749bf8dbd11e4f698521803c089b52577be2cdbab8" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-1.6" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.6-osx64.tar.bz2#147a0e34b3d3a568d5c5926252a2c27e137677b3121cd8daab1d746df2d91e38" "pypy" verify_py27 ensurepip
+  install_package "pypy-1.6" "https://downloads.python.org/pypy/pypy-1.6-osx64.tar.bz2#147a0e34b3d3a568d5c5926252a2c27e137677b3121cd8daab1d746df2d91e38" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-1.6" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.6-win32-c.zip#75bf79f08e2d65fce51b14fb8fe0309f136ffc368f977017dc3029baf8426e53" "pypy" verify_py27 ensurepip
+  install_zip "pypy-1.6" "https://downloads.python.org/pypy/pypy-1.6-win32-c.zip#75bf79f08e2d65fce51b14fb8fe0309f136ffc368f977017dc3029baf8426e53" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-1.7
+++ b/plugins/python-build/share/python-build/pypy-1.7
@@ -1,16 +1,16 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-1.7" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.7-linux.tar.bz2#d8f6af52dd5c32ca65de8b1507ef49490188ec131d53a68db6f81201943b4227" "pypy" verify_py27 ensurepip
+  install_package "pypy-1.7" "https://downloads.python.org/pypy/pypy-1.7-linux.tar.bz2#d8f6af52dd5c32ca65de8b1507ef49490188ec131d53a68db6f81201943b4227" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-1.7" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.7-linux64.tar.bz2#cd7ff7a4beaaa78c3b9dbcd567fb0b2d672258051f837e727d4fd636788552ca" "pypy" verify_py27 ensurepip
+  install_package "pypy-1.7" "https://downloads.python.org/pypy/pypy-1.7-linux64.tar.bz2#cd7ff7a4beaaa78c3b9dbcd567fb0b2d672258051f837e727d4fd636788552ca" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-1.7" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.7-osx64.tar.bz2#9ad01f6e194b1a3d5f2fa82cd6760b4f9e8a791d5ca28cc156c5f03fe43a08ac" "pypy" verify_py27 ensurepip
+  install_package "pypy-1.7" "https://downloads.python.org/pypy/pypy-1.7-osx64.tar.bz2#9ad01f6e194b1a3d5f2fa82cd6760b4f9e8a791d5ca28cc156c5f03fe43a08ac" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-1.7" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.7-win32.zip#1d70faaed00f2f69c634dfbb61b54901df64f093d07d976e035578f812ed31ea" "pypy" verify_py27 ensurepip
+  install_zip "pypy-1.7" "https://downloads.python.org/pypy/pypy-1.7-win32.zip#1d70faaed00f2f69c634dfbb61b54901df64f093d07d976e035578f812ed31ea" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-1.8
+++ b/plugins/python-build/share/python-build/pypy-1.8
@@ -1,16 +1,16 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-1.8" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.8-linux.tar.bz2#9c293d8540780260718f8fd8dc433c97b614a31b115ccfe2d68df720ad7e55b1" "pypy" verify_py27 ensurepip
+  install_package "pypy-1.8" "https://downloads.python.org/pypy/pypy-1.8-linux.tar.bz2#9c293d8540780260718f8fd8dc433c97b614a31b115ccfe2d68df720ad7e55b1" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-1.8" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.8-linux64.tar.bz2#1045606cceb993844a016b76c55aa43a9924bcf526f91a0572fc97cee69b61dc" "pypy" verify_py27 ensurepip
+  install_package "pypy-1.8" "https://downloads.python.org/pypy/pypy-1.8-linux64.tar.bz2#1045606cceb993844a016b76c55aa43a9924bcf526f91a0572fc97cee69b61dc" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-1.8" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.8-osx64.tar.bz2#b823b6b919082cfb67861b8253313b877618672377164086c0364fa8eaa88b8a" "pypy" verify_py27 ensurepip
+  install_package "pypy-1.8" "https://downloads.python.org/pypy/pypy-1.8-osx64.tar.bz2#b823b6b919082cfb67861b8253313b877618672377164086c0364fa8eaa88b8a" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-1.8" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.8-win32.zip#a844f54551805d300beffd10b18684e0c08fa080c1b6f7be52bb7fbdfdf38292" "pypy" verify_py27 ensurepip
+  install_zip "pypy-1.8" "https://downloads.python.org/pypy/pypy-1.8-win32.zip#a844f54551805d300beffd10b18684e0c08fa080c1b6f7be52bb7fbdfdf38292" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-1.9
+++ b/plugins/python-build/share/python-build/pypy-1.9
@@ -1,16 +1,16 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-1.9" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.9-linux.tar.bz2#1e3f9c3d06f8bbfa0dcb1301b40c298096249a7d7c2b4594b3fb1c3e7b9888f2" "pypy" verify_py27 ensurepip
+  install_package "pypy-1.9" "https://downloads.python.org/pypy/pypy-1.9-linux.tar.bz2#1e3f9c3d06f8bbfa0dcb1301b40c298096249a7d7c2b4594b3fb1c3e7b9888f2" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-1.9" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.9-linux64.tar.bz2#4298252515e78c96f4ecd9f25be957411c060ece02d9213eef8d781cf528d18f" "pypy" verify_py27 ensurepip
+  install_package "pypy-1.9" "https://downloads.python.org/pypy/pypy-1.9-linux64.tar.bz2#4298252515e78c96f4ecd9f25be957411c060ece02d9213eef8d781cf528d18f" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-1.9" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.9-osx64.tar.bz2#4858f200e32c1070c77c1234ea0e9473eeda98bcd3832c4231f3e46e4e3b74b1" "pypy" verify_py27 ensurepip
+  install_package "pypy-1.9" "https://downloads.python.org/pypy/pypy-1.9-osx64.tar.bz2#4858f200e32c1070c77c1234ea0e9473eeda98bcd3832c4231f3e46e4e3b74b1" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-1.9" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.9-win32.zip#54fafe8c69df390d2a460bab022145aaacd2c62c4a569873b22fdc7475f31581" "pypy" verify_py27 ensurepip
+  install_zip "pypy-1.9" "https://downloads.python.org/pypy/pypy-1.9-win32.zip#54fafe8c69df390d2a460bab022145aaacd2c62c4a569873b22fdc7475f31581" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.0
+++ b/plugins/python-build/share/python-build/pypy-2.0
@@ -1,26 +1,26 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   require_distro "Ubuntu 10.04" || true
-  install_package "pypy-2.0" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-linux.tar.bz2#275dbbee67eac527a1177403a0386b17d008740f83030544800d87994edd46b9" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.0" "https://downloads.python.org/pypy/pypy-2.0-linux.tar.bz2#275dbbee67eac527a1177403a0386b17d008740f83030544800d87994edd46b9" "pypy" verify_py27 ensurepip
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.0-alpha-arm" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-alpha-arm-armel.tar.bz2#2f8f252d43a15661602a98f93d3292e333423459c5facb43eb2de1bda8eb8495" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.0-alpha-arm" "https://downloads.python.org/pypy/pypy-2.0-alpha-arm-armel.tar.bz2#2f8f252d43a15661602a98f93d3292e333423459c5facb43eb2de1bda8eb8495" "pypy" verify_py27 ensurepip
     ;;
 "linux-armhf" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.0-alpha-arm" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-alpha-arm-armhf.tar.bz2#00e678e5a226be0692ee18438ace1c91d346256cfab8f32e34a24584d018ca34" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.0-alpha-arm" "https://downloads.python.org/pypy/pypy-2.0-alpha-arm-armhf.tar.bz2#00e678e5a226be0692ee18438ace1c91d346256cfab8f32e34a24584d018ca34" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.0" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-linux64.tar.bz2#14c716d53a507eece89606d547456b886dbdfc0ba6e3fb29062fafe86d1b6038" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.0" "https://downloads.python.org/pypy/pypy-2.0-linux64.tar.bz2#14c716d53a507eece89606d547456b886dbdfc0ba6e3fb29062fafe86d1b6038" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-2.0" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-osx64.tar.bz2#6d190f32c9dce9d36d4a2bb91faed581a50fb7fa6249eee201dbf5dbc3e3c7d7" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.0" "https://downloads.python.org/pypy/pypy-2.0-osx64.tar.bz2#6d190f32c9dce9d36d4a2bb91faed581a50fb7fa6249eee201dbf5dbc3e3c7d7" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.0" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-win32.zip#2f1d5a0d2cb2fa61902eba5479b100d6d26aab211149b06d5acf64089dd20fe1" "pypy" verify_py27 ensurepip
+  install_zip "pypy-2.0" "https://downloads.python.org/pypy/pypy-2.0-win32.zip#2f1d5a0d2cb2fa61902eba5479b100d6d26aab211149b06d5acf64089dd20fe1" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-2.0-src" "https://downloads.python.org/pypy/pypy-2.0-src.tar.bz2#d92dfd418beac915d3efc28f8a2090f3c13a89ec653419deff3d7112c5c111f3" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-2.0-src" "https://downloads.python.org/pypy/pypy-2.0-src.tar.bz2#d92dfd418beac915d3efc28f8a2090f3c13a89ec653419deff3d7112c5c111f3" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-2.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-src.tar.bz2#d92dfd418beac915d3efc28f8a2090f3c13a89ec653419deff3d7112c5c111f3" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-2.0-src" "https://downloads.python.org/pypy/pypy-2.0-src.tar.bz2#d92dfd418beac915d3efc28f8a2090f3c13a89ec653419deff3d7112c5c111f3" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.0.1
+++ b/plugins/python-build/share/python-build/pypy-2.0.1
@@ -1,18 +1,18 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   require_distro "Ubuntu 10.04" || true
-  install_package "pypy-2.0.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-linux.tar.bz2#548686c5b95b424c79586d9a303ed41fca8eba52bd35c1527f39f5cd8fa35ea9" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.0.1" "https://downloads.python.org/pypy/pypy-2.0.1-linux.tar.bz2#548686c5b95b424c79586d9a303ed41fca8eba52bd35c1527f39f5cd8fa35ea9" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.0.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-linux64.tar.bz2#0eb57e28f2bd5f2a4ad396df322de5adf711eb7d9a2bfeb8be2d9eb9e125c5cc" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.0.1" "https://downloads.python.org/pypy/pypy-2.0.1-linux64.tar.bz2#0eb57e28f2bd5f2a4ad396df322de5adf711eb7d9a2bfeb8be2d9eb9e125c5cc" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-2.0.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-osx64.tar.bz2#337f2fda672827f2d706fd98e3344a83a8b80675e21b83dd6933da38d110c857" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.0.1" "https://downloads.python.org/pypy/pypy-2.0.1-osx64.tar.bz2#337f2fda672827f2d706fd98e3344a83a8b80675e21b83dd6933da38d110c857" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.0.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-win32.zip#78fff168c10176a3a7f6a5b97d2048ed87f3cd9a6284b5afa86115baa19af946" "pypy" verify_py27 ensurepip
+  install_zip "pypy-2.0.1" "https://downloads.python.org/pypy/pypy-2.0.1-win32.zip#78fff168c10176a3a7f6a5b97d2048ed87f3cd9a6284b5afa86115baa19af946" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.0.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.0.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-2.0.1-src" "https://downloads.python.org/pypy/pypy-2.0.1-src.tar.bz2#d1327bc325545939236ac609ec509548a545f97b1c933dedbe42f2482a130aa0" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-2.0.1-src" "https://downloads.python.org/pypy/pypy-2.0.1-src.tar.bz2#d1327bc325545939236ac609ec509548a545f97b1c933dedbe42f2482a130aa0" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.0.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.0.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-2.0.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-src.tar.bz2#d1327bc325545939236ac609ec509548a545f97b1c933dedbe42f2482a130aa0" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-2.0.1-src" "https://downloads.python.org/pypy/pypy-2.0.1-src.tar.bz2#d1327bc325545939236ac609ec509548a545f97b1c933dedbe42f2482a130aa0" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.0.2
+++ b/plugins/python-build/share/python-build/pypy-2.0.2
@@ -1,18 +1,18 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   require_distro "Ubuntu 10.04" || true
-  install_package "pypy-2.0.2" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-linux.tar.bz2#3b43c1ac147f6bb11981dd7f8c5458b95d6bdcf1adceb8043c32ca5e8fcab4da" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.0.2" "https://downloads.python.org/pypy/pypy-2.0.2-linux.tar.bz2#3b43c1ac147f6bb11981dd7f8c5458b95d6bdcf1adceb8043c32ca5e8fcab4da" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.0.2" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-linux64.tar.bz2#3f9bc07959a2d6058a0c1b84da837e2ec457642fe03ac46123d145c419a7b5cd" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.0.2" "https://downloads.python.org/pypy/pypy-2.0.2-linux64.tar.bz2#3f9bc07959a2d6058a0c1b84da837e2ec457642fe03ac46123d145c419a7b5cd" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-2.0.2" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-osx64.tar.bz2#34f5a7bf22a8bca3b9d79ae3186016c34638669ab19b4af6e38412181c757761" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.0.2" "https://downloads.python.org/pypy/pypy-2.0.2-osx64.tar.bz2#34f5a7bf22a8bca3b9d79ae3186016c34638669ab19b4af6e38412181c757761" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.0.2" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-win32.zip#f3cfa54740076c59e6ef02e1411f62551230df5cd20a247e81b6e589478afe66" "pypy" verify_py27 ensurepip
+  install_zip "pypy-2.0.2" "https://downloads.python.org/pypy/pypy-2.0.2-win32.zip#f3cfa54740076c59e6ef02e1411f62551230df5cd20a247e81b6e589478afe66" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.0.2-src
+++ b/plugins/python-build/share/python-build/pypy-2.0.2-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-2.0.2-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-src.tar.bz2#1991c90d6b98e2408b3790d4b57b71ec1c69346328b8321505ce8f6ab4544c3c" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-2.0.2-src" "https://downloads.python.org/pypy/pypy-2.0.2-src.tar.bz2#1991c90d6b98e2408b3790d4b57b71ec1c69346328b8321505ce8f6ab4544c3c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.0.2-src
+++ b/plugins/python-build/share/python-build/pypy-2.0.2-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-2.0.2-src" "https://downloads.python.org/pypy/pypy-2.0.2-src.tar.bz2#1991c90d6b98e2408b3790d4b57b71ec1c69346328b8321505ce8f6ab4544c3c" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-2.0.2-src" "https://downloads.python.org/pypy/pypy-2.0.2-src.tar.bz2#1991c90d6b98e2408b3790d4b57b71ec1c69346328b8321505ce8f6ab4544c3c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.1
+++ b/plugins/python-build/share/python-build/pypy-2.1
@@ -1,30 +1,30 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   require_distro "Ubuntu 10.04" || true
-  install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-linux.tar.bz2#9c0a38a40d3b4e642a159e51abef2827b33e3f7a254365daa24eae85d840eaf5" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.1" "https://downloads.python.org/pypy/pypy-2.1-linux.tar.bz2#9c0a38a40d3b4e642a159e51abef2827b33e3f7a254365daa24eae85d840eaf5" "pypy" verify_py27 ensurepip
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-linux-armel.tar.bz2#15af2d7485c9e4363805ad5b63bf8a67cd9516e7e34c4abb822229a2a41aee1d" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.1" "https://downloads.python.org/pypy/pypy-2.1-linux-armel.tar.bz2#15af2d7485c9e4363805ad5b63bf8a67cd9516e7e34c4abb822229a2a41aee1d" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-linux-armhf-raspbian.tar.bz2#b11c27447051af00928fcc3d1f20f1441c285045a3acb8cfba8721c63ee90df3" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.1" "https://downloads.python.org/pypy/pypy-2.1-linux-armhf-raspbian.tar.bz2#b11c27447051af00928fcc3d1f20f1441c285045a3acb8cfba8721c63ee90df3" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-linux-armhf-raring.tar.bz2#fbab31154848f309ef72b6e845e289285907eda950f6b632963217c463b5d4de" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.1" "https://downloads.python.org/pypy/pypy-2.1-linux-armhf-raring.tar.bz2#fbab31154848f309ef72b6e845e289285907eda950f6b632963217c463b5d4de" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-linux64.tar.bz2#80f90bb473635a0249049e87c5cc7cf738e13537c1f1e2857b6345848a3e6d20" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.1" "https://downloads.python.org/pypy/pypy-2.1-linux64.tar.bz2#80f90bb473635a0249049e87c5cc7cf738e13537c1f1e2857b6345848a3e6d20" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-osx64.tar.bz2#d0d788c6d54bb866ace67a1740133cb5bc62357b5ca4783244097f1f648876f0" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.1" "https://downloads.python.org/pypy/pypy-2.1-osx64.tar.bz2#d0d788c6d54bb866ace67a1740133cb5bc62357b5ca4783244097f1f648876f0" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-win32.zip#c425a35a6c4938e314ad48014816e05c8e5246d770abe135e11a1f9821eecf53" "pypy" verify_py27 ensurepip
+  install_zip "pypy-2.1" "https://downloads.python.org/pypy/pypy-2.1-win32.zip#c425a35a6c4938e314ad48014816e05c8e5246d770abe135e11a1f9821eecf53" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.1
+++ b/plugins/python-build/share/python-build/pypy-2.1
@@ -9,10 +9,10 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-2.1" "https://downloads.python.org/pypy/pypy-2.1-linux-armhf-raspbian.tar.bz2#b11c27447051af00928fcc3d1f20f1441c285045a3acb8cfba8721c63ee90df3" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.1" "https://downloads.python.org/pypy/pypy-2.1-linux-armhf-raspbian.tar.bz2#b11c27447051af00928fcc3d1f20f1441c285045a3acb8cfba8721c63ee90df3" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-2.1" "https://downloads.python.org/pypy/pypy-2.1-linux-armhf-raring.tar.bz2#fbab31154848f309ef72b6e845e289285907eda950f6b632963217c463b5d4de" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.1" "https://downloads.python.org/pypy/pypy-2.1-linux-armhf-raring.tar.bz2#fbab31154848f309ef72b6e845e289285907eda950f6b632963217c463b5d4de" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )

--- a/plugins/python-build/share/python-build/pypy-2.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-2.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-src.tar.bz2#31b3066c9739b117d6bb1bdc485a919dc3b67370ec00437de1b74069943f7f17" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-2.1-src" "https://downloads.python.org/pypy/pypy-2.1-src.tar.bz2#31b3066c9739b117d6bb1bdc485a919dc3b67370ec00437de1b74069943f7f17" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-2.1-src" "https://downloads.python.org/pypy/pypy-2.1-src.tar.bz2#31b3066c9739b117d6bb1bdc485a919dc3b67370ec00437de1b74069943f7f17" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-2.1-src" "https://downloads.python.org/pypy/pypy-2.1-src.tar.bz2#31b3066c9739b117d6bb1bdc485a919dc3b67370ec00437de1b74069943f7f17" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.2
+++ b/plugins/python-build/share/python-build/pypy-2.2
@@ -9,10 +9,10 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-2.2-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.2-linux-armhf-raspbian.tar.bz2#4856151d9a6dda82edd9d74f872e97243df3676fc25bbf661f976982194caa47" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.2-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.2-linux-armhf-raspbian.tar.bz2#4856151d9a6dda82edd9d74f872e97243df3676fc25bbf661f976982194caa47" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-2.2-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.2-linux-armhf-raring.tar.bz2#d64eeeac0a73bd073d8f875210b0e85ed8f0d9655d3f3cc8abb68093a1eb7366" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.2-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.2-linux-armhf-raring.tar.bz2#d64eeeac0a73bd073d8f875210b0e85ed8f0d9655d3f3cc8abb68093a1eb7366" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )

--- a/plugins/python-build/share/python-build/pypy-2.2
+++ b/plugins/python-build/share/python-build/pypy-2.2
@@ -1,30 +1,30 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   require_distro "Ubuntu 10.04" || true
-  install_package "pypy-2.2-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux.tar.bz2#2bdab70106f6b6d0dd97e42535ce73711c987887fb81fb821801f6fdcd92cdc4" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.2-linux" "https://downloads.python.org/pypy/pypy-2.2-linux.tar.bz2#2bdab70106f6b6d0dd97e42535ce73711c987887fb81fb821801f6fdcd92cdc4" "pypy" verify_py27 ensurepip
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.2-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux-armel.tar.bz2#98bfc524f9cf4fd96225f9fc9b0a3a379b8a1a06231b058c51bb875b363f4d75" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.2-linux-armel" "https://downloads.python.org/pypy/pypy-2.2-linux-armel.tar.bz2#98bfc524f9cf4fd96225f9fc9b0a3a379b8a1a06231b058c51bb875b363f4d75" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.2-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux-armhf-raspbian.tar.bz2#4856151d9a6dda82edd9d74f872e97243df3676fc25bbf661f976982194caa47" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.2-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.2-linux-armhf-raspbian.tar.bz2#4856151d9a6dda82edd9d74f872e97243df3676fc25bbf661f976982194caa47" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.2-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux-armhf-raring.tar.bz2#d64eeeac0a73bd073d8f875210b0e85ed8f0d9655d3f3cc8abb68093a1eb7366" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.2-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.2-linux-armhf-raring.tar.bz2#d64eeeac0a73bd073d8f875210b0e85ed8f0d9655d3f3cc8abb68093a1eb7366" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.2-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux64.tar.bz2#1583af0122c6ccb0cb95f8c3732925551ce3ca6d5ea0657e21523f8bf97837a3" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.2-linux64" "https://downloads.python.org/pypy/pypy-2.2-linux64.tar.bz2#1583af0122c6ccb0cb95f8c3732925551ce3ca6d5ea0657e21523f8bf97837a3" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-2.2-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-osx64.tar.bz2#8aa943de7ec38f13fa836b6964dbf58b45142e4fe7b3fdd5fffe37fdcf974e01" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.2-osx64" "https://downloads.python.org/pypy/pypy-2.2-osx64.tar.bz2#8aa943de7ec38f13fa836b6964dbf58b45142e4fe7b3fdd5fffe37fdcf974e01" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.2-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-win32.zip#c7a6682cde9034835b337be95415aee21cb4de85049d65a4674efe15d214dfb9" "pypy" verify_py27 ensurepip
+  install_zip "pypy-2.2-win32" "https://downloads.python.org/pypy/pypy-2.2-win32.zip#c7a6682cde9034835b337be95415aee21cb4de85049d65a4674efe15d214dfb9" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.2-src
+++ b/plugins/python-build/share/python-build/pypy-2.2-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-2.2-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-src.tar.bz2#50fffcb86039e019530a63d656580bc53c173e5f19768bddd8699cd08448e04e" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-2.2-src" "https://downloads.python.org/pypy/pypy-2.2-src.tar.bz2#50fffcb86039e019530a63d656580bc53c173e5f19768bddd8699cd08448e04e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.2-src
+++ b/plugins/python-build/share/python-build/pypy-2.2-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-2.2-src" "https://downloads.python.org/pypy/pypy-2.2-src.tar.bz2#50fffcb86039e019530a63d656580bc53c173e5f19768bddd8699cd08448e04e" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-2.2-src" "https://downloads.python.org/pypy/pypy-2.2-src.tar.bz2#50fffcb86039e019530a63d656580bc53c173e5f19768bddd8699cd08448e04e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.2.1
+++ b/plugins/python-build/share/python-build/pypy-2.2.1
@@ -9,10 +9,10 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-2.2.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.2.1-linux-armhf-raspbian.tar.bz2#31d921a8139ec6accf9749df2baff4aed844f6f46eeb37184119ff9c7d6fca55" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.2.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.2.1-linux-armhf-raspbian.tar.bz2#31d921a8139ec6accf9749df2baff4aed844f6f46eeb37184119ff9c7d6fca55" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-2.2.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.2.1-linux-armhf-raring.tar.bz2#6f5fe3285a32d1ea8fe148265467f870c6863ae00bc2e279b31b94d2d7f80102" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.2.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.2.1-linux-armhf-raring.tar.bz2#6f5fe3285a32d1ea8fe148265467f870c6863ae00bc2e279b31b94d2d7f80102" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )

--- a/plugins/python-build/share/python-build/pypy-2.2.1
+++ b/plugins/python-build/share/python-build/pypy-2.2.1
@@ -1,30 +1,30 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   require_distro "Ubuntu 10.04" || true
-  install_package "pypy-2.2.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux.tar.bz2#4d13483a0e13fc617a7b3d36918ed0e63cf07a7d2827c0a08132b80bc401a55a" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.2.1-linux" "https://downloads.python.org/pypy/pypy-2.2.1-linux.tar.bz2#4d13483a0e13fc617a7b3d36918ed0e63cf07a7d2827c0a08132b80bc401a55a" "pypy" verify_py27 ensurepip
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.2.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux-armel.tar.bz2#f0a15c7f4d66f152c58d73475314b906dcd3052fc422a8bb8cf88ae1ca0a8b19" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.2.1-linux-armel" "https://downloads.python.org/pypy/pypy-2.2.1-linux-armel.tar.bz2#f0a15c7f4d66f152c58d73475314b906dcd3052fc422a8bb8cf88ae1ca0a8b19" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.2.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux-armhf-raspbian.tar.bz2#31d921a8139ec6accf9749df2baff4aed844f6f46eeb37184119ff9c7d6fca55" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.2.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.2.1-linux-armhf-raspbian.tar.bz2#31d921a8139ec6accf9749df2baff4aed844f6f46eeb37184119ff9c7d6fca55" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.2.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux-armhf-raring.tar.bz2#6f5fe3285a32d1ea8fe148265467f870c6863ae00bc2e279b31b94d2d7f80102" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.2.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.2.1-linux-armhf-raring.tar.bz2#6f5fe3285a32d1ea8fe148265467f870c6863ae00bc2e279b31b94d2d7f80102" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.2.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux64.tar.bz2#022d611ac62a276890d3e262f4f7cc839fcf9f5e1416df01dcd83ba335eacb16" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.2.1-linux64" "https://downloads.python.org/pypy/pypy-2.2.1-linux64.tar.bz2#022d611ac62a276890d3e262f4f7cc839fcf9f5e1416df01dcd83ba335eacb16" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-2.2.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-osx64.tar.bz2#93e215dcffc9073acf41c63518f47fb59de60386aca4416cfe32190c7a096f29" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.2.1-osx64" "https://downloads.python.org/pypy/pypy-2.2.1-osx64.tar.bz2#93e215dcffc9073acf41c63518f47fb59de60386aca4416cfe32190c7a096f29" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.2.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-win32.zip#d36f4f1b4f146b3a0a623abef9b5a837c08f66e67c90023c724dfdcd8e0133bb" "pypy" verify_py27 ensurepip
+  install_zip "pypy-2.2.1-win32" "https://downloads.python.org/pypy/pypy-2.2.1-win32.zip#d36f4f1b4f146b3a0a623abef9b5a837c08f66e67c90023c724dfdcd8e0133bb" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.2.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.2.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-2.2.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-src.tar.bz2#252045187e443656a2beb412dadac9296e8fe8db0f75a66ed5265db58c35035f" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-2.2.1-src" "https://downloads.python.org/pypy/pypy-2.2.1-src.tar.bz2#252045187e443656a2beb412dadac9296e8fe8db0f75a66ed5265db58c35035f" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.2.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.2.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-2.2.1-src" "https://downloads.python.org/pypy/pypy-2.2.1-src.tar.bz2#252045187e443656a2beb412dadac9296e8fe8db0f75a66ed5265db58c35035f" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-2.2.1-src" "https://downloads.python.org/pypy/pypy-2.2.1-src.tar.bz2#252045187e443656a2beb412dadac9296e8fe8db0f75a66ed5265db58c35035f" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.3
+++ b/plugins/python-build/share/python-build/pypy-2.3
@@ -9,10 +9,10 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-2.3-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.3-linux-armhf-raspbian.tar.bz2#92584cfccde188b6a3a850ecf226daa9924788a1da8574c57c10a7551fb127d4" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.3-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.3-linux-armhf-raspbian.tar.bz2#92584cfccde188b6a3a850ecf226daa9924788a1da8574c57c10a7551fb127d4" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-2.3-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.3-linux-armhf-raring.tar.bz2#c8c4a4da406db8ea6dfec074951e1ac150619b0709317ceaafb6bdd837acf96e" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.3-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.3-linux-armhf-raring.tar.bz2#c8c4a4da406db8ea6dfec074951e1ac150619b0709317ceaafb6bdd837acf96e" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )

--- a/plugins/python-build/share/python-build/pypy-2.3
+++ b/plugins/python-build/share/python-build/pypy-2.3
@@ -1,30 +1,30 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   require_distro "Ubuntu 10.04" || true
-  install_package "pypy-2.3-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux.tar.bz2#9071072d42344fb37cc588429864b00fff447bd5d33d51008641fe6822823f1b" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.3-linux" "https://downloads.python.org/pypy/pypy-2.3-linux.tar.bz2#9071072d42344fb37cc588429864b00fff447bd5d33d51008641fe6822823f1b" "pypy" verify_py27 ensurepip
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.3-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux-armel.tar.bz2#18394acc9ce356d109cbd92224a9d724a7eb53a0505ce0ec5de36ee20b288a07" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.3-linux-armel" "https://downloads.python.org/pypy/pypy-2.3-linux-armel.tar.bz2#18394acc9ce356d109cbd92224a9d724a7eb53a0505ce0ec5de36ee20b288a07" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.3-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux-armhf-raspbian.tar.bz2#92584cfccde188b6a3a850ecf226daa9924788a1da8574c57c10a7551fb127d4" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.3-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.3-linux-armhf-raspbian.tar.bz2#92584cfccde188b6a3a850ecf226daa9924788a1da8574c57c10a7551fb127d4" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.3-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux-armhf-raring.tar.bz2#c8c4a4da406db8ea6dfec074951e1ac150619b0709317ceaafb6bdd837acf96e" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.3-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.3-linux-armhf-raring.tar.bz2#c8c4a4da406db8ea6dfec074951e1ac150619b0709317ceaafb6bdd837acf96e" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.3-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux64.tar.bz2#777dbdd9c67ad1b8906288b01ae76bc9f7b80c95e967836f9a700a1679b80008" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.3-linux64" "https://downloads.python.org/pypy/pypy-2.3-linux64.tar.bz2#777dbdd9c67ad1b8906288b01ae76bc9f7b80c95e967836f9a700a1679b80008" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-2.3-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-osx64.tar.bz2#df7ca23ba6c8a63149d910b482be04f069b26dd1f7d0ca15e6342cac94e759d7" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.3-osx64" "https://downloads.python.org/pypy/pypy-2.3-osx64.tar.bz2#df7ca23ba6c8a63149d910b482be04f069b26dd1f7d0ca15e6342cac94e759d7" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.3-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-win32.zip#72f46afe69281147ad9abc88a7b39d1840e112e626a8be251a5f9f7308c559c7" "pypy" verify_py27 ensurepip
+  install_zip "pypy-2.3-win32" "https://downloads.python.org/pypy/pypy-2.3-win32.zip#72f46afe69281147ad9abc88a7b39d1840e112e626a8be251a5f9f7308c559c7" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.3-src
+++ b/plugins/python-build/share/python-build/pypy-2.3-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-pypy-394146e9bb67" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-src.tar.bz2#be2c271e7f9d7c0059a551ba1501713c00336e551e7f13107f0f34c721d95b0c" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-pypy-394146e9bb67" "https://downloads.python.org/pypy/pypy-2.3-src.tar.bz2#be2c271e7f9d7c0059a551ba1501713c00336e551e7f13107f0f34c721d95b0c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.3-src
+++ b/plugins/python-build/share/python-build/pypy-2.3-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-pypy-394146e9bb67" "https://downloads.python.org/pypy/pypy-2.3-src.tar.bz2#be2c271e7f9d7c0059a551ba1501713c00336e551e7f13107f0f34c721d95b0c" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-pypy-394146e9bb67" "https://downloads.python.org/pypy/pypy-2.3-src.tar.bz2#be2c271e7f9d7c0059a551ba1501713c00336e551e7f13107f0f34c721d95b0c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.3.1
+++ b/plugins/python-build/share/python-build/pypy-2.3.1
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
   install_package "pypy-2.3.1-linux" "https://downloads.python.org/pypy/pypy-2.3.1-linux.tar.bz2#3eed698e8533cca7cbd2c2c87fce39dc14baa7dec03f4b082d870131d2a470e4" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.3.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.3.1-linux_i686-portable.tar.bz2#d8784020f6b8a5812fd8b3f5e1df8afb176fd56c2a929d4408d28d4a925525fa" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.3.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.3.1-linux_i686-portable.tar.bz2#d8784020f6b8a5812fd8b3f5e1df8afb176fd56c2a929d4408d28d4a925525fa" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -22,7 +22,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
   install_package "pypy-2.3.1-linux64" "https://downloads.python.org/pypy/pypy-2.3.1-linux64.tar.bz2#dab7940496d96f1f255a8ef402fa96b94444775e373484e057d2fcabc3928b42" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.3.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.3.1-linux_x86_64-portable.tar.bz2#453bd1291f0372e25ceab6b37b7a8d1756bebd3e708fcce1379ef931ccf9f75a" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.3.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.3.1-linux_x86_64-portable.tar.bz2#453bd1291f0372e25ceab6b37b7a8d1756bebd3e708fcce1379ef931ccf9f75a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-2.3.1
+++ b/plugins/python-build/share/python-build/pypy-2.3.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-  install_package "pypy-2.3.1-linux" "https://downloads.python.org/pypy/pypy-2.3.1-linux.tar.bz2#3eed698e8533cca7cbd2c2c87fce39dc14baa7dec03f4b082d870131d2a470e4" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.3.1-linux" "https://downloads.python.org/pypy/pypy-2.3.1-linux.tar.bz2#3eed698e8533cca7cbd2c2c87fce39dc14baa7dec03f4b082d870131d2a470e4" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-2.3.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.3.1-linux_i686-portable.tar.bz2#d8784020f6b8a5812fd8b3f5e1df8afb176fd56c2a929d4408d28d4a925525fa" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.3.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.3.1-linux_i686-portable.tar.bz2#d8784020f6b8a5812fd8b3f5e1df8afb176fd56c2a929d4408d28d4a925525fa" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,17 +12,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-2.3.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.3.1-linux-armhf-raspbian.tar.bz2#74ac62f8cf6dfa0b2f04debd8bbedaed21a12a1a4d4da22856410d06dc0c971c" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.3.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.3.1-linux-armhf-raspbian.tar.bz2#74ac62f8cf6dfa0b2f04debd8bbedaed21a12a1a4d4da22856410d06dc0c971c" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-2.3.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.3.1-linux-armhf-raring.tar.bz2#f65ad31c364e8122f55d77388026cf4750c6a8774af361b79dc9942612c3a8c1" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.3.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.3.1-linux-armhf-raring.tar.bz2#f65ad31c364e8122f55d77388026cf4750c6a8774af361b79dc9942612c3a8c1" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
-  install_package "pypy-2.3.1-linux64" "https://downloads.python.org/pypy/pypy-2.3.1-linux64.tar.bz2#dab7940496d96f1f255a8ef402fa96b94444775e373484e057d2fcabc3928b42" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.3.1-linux64" "https://downloads.python.org/pypy/pypy-2.3.1-linux64.tar.bz2#dab7940496d96f1f255a8ef402fa96b94444775e373484e057d2fcabc3928b42" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-2.3.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.3.1-linux_x86_64-portable.tar.bz2#453bd1291f0372e25ceab6b37b7a8d1756bebd3e708fcce1379ef931ccf9f75a" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.3.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.3.1-linux_x86_64-portable.tar.bz2#453bd1291f0372e25ceab6b37b7a8d1756bebd3e708fcce1379ef931ccf9f75a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-2.3.1
+++ b/plugins/python-build/share/python-build/pypy-2.3.1
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.3.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-linux.tar.bz2#3eed698e8533cca7cbd2c2c87fce39dc14baa7dec03f4b082d870131d2a470e4" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.3.1-linux" "https://downloads.python.org/pypy/pypy-2.3.1-linux.tar.bz2#3eed698e8533cca7cbd2c2c87fce39dc14baa7dec03f4b082d870131d2a470e4" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-2.3.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.3.1-linux_i686-portable.tar.bz2#d8784020f6b8a5812fd8b3f5e1df8afb176fd56c2a929d4408d28d4a925525fa" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.3.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-linux-armel.tar.bz2#4d71679597b4e971d7e566d9696851dd2ec1a90a04696184d2d0f6b5446d9706" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.3.1-linux-armel" "https://downloads.python.org/pypy/pypy-2.3.1-linux-armel.tar.bz2#4d71679597b4e971d7e566d9696851dd2ec1a90a04696184d2d0f6b5446d9706" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.3.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-linux-armhf-raspbian.tar.bz2#74ac62f8cf6dfa0b2f04debd8bbedaed21a12a1a4d4da22856410d06dc0c971c" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.3.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.3.1-linux-armhf-raspbian.tar.bz2#74ac62f8cf6dfa0b2f04debd8bbedaed21a12a1a4d4da22856410d06dc0c971c" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.3.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-linux-armhf-raring.tar.bz2#f65ad31c364e8122f55d77388026cf4750c6a8774af361b79dc9942612c3a8c1" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.3.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.3.1-linux-armhf-raring.tar.bz2#f65ad31c364e8122f55d77388026cf4750c6a8774af361b79dc9942612c3a8c1" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.3.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-linux64.tar.bz2#dab7940496d96f1f255a8ef402fa96b94444775e373484e057d2fcabc3928b42" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.3.1-linux64" "https://downloads.python.org/pypy/pypy-2.3.1-linux64.tar.bz2#dab7940496d96f1f255a8ef402fa96b94444775e373484e057d2fcabc3928b42" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-2.3.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.3.1-linux_x86_64-portable.tar.bz2#453bd1291f0372e25ceab6b37b7a8d1756bebd3e708fcce1379ef931ccf9f75a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-2.3.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-osx64.tar.bz2#12e363bf5ea3a508600e043b68c47d4148359ca3d999ee207665bb139f8fbf37" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.3.1-osx64" "https://downloads.python.org/pypy/pypy-2.3.1-osx64.tar.bz2#12e363bf5ea3a508600e043b68c47d4148359ca3d999ee207665bb139f8fbf37" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.3.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-win32.zip#c8db46d0e5199420dae583f6d2901eb4d4023ced75f035a6e26c232f229f8e0a" "pypy" verify_py27 ensurepip
+  install_zip "pypy-2.3.1-win32" "https://downloads.python.org/pypy/pypy-2.3.1-win32.zip#c8db46d0e5199420dae583f6d2901eb4d4023ced75f035a6e26c232f229f8e0a" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.4.0
+++ b/plugins/python-build/share/python-build/pypy-2.4.0
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.4.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux.tar.bz2#a24adb366f87ac0eba829d7188a156a7d897e71893689fab06502c3f4152ac0e" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.4.0-linux" "https://downloads.python.org/pypy/pypy-2.4.0-linux.tar.bz2#a24adb366f87ac0eba829d7188a156a7d897e71893689fab06502c3f4152ac0e" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-2.4-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.4-linux_i686-portable.tar.bz2#2a330bbeae038c143366982f2104bf4096752f1ec7520fc5608f0527c124b0c2" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.4.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux-armel.tar.bz2#8362d634bf86fbfb3b99b578b13c0a9fd673b2b7580d6d65b4a181934c659ccd" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.4.0-linux-armel" "https://downloads.python.org/pypy/pypy-2.4.0-linux-armel.tar.bz2#8362d634bf86fbfb3b99b578b13c0a9fd673b2b7580d6d65b4a181934c659ccd" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.4.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux-armhf-raspbian.tar.bz2#5e0ba69b28ffbd5b61b0b6be2a130ab0c80e7d2da289d9530b0b6eac4302d5fa" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.4.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.4.0-linux-armhf-raspbian.tar.bz2#5e0ba69b28ffbd5b61b0b6be2a130ab0c80e7d2da289d9530b0b6eac4302d5fa" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.4.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux-armhf-raring.tar.bz2#ddbdd6207c41cf82d8c96d52a2a204a2cdada9301cb577f9b323f22394bb1f0a" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.4.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.4.0-linux-armhf-raring.tar.bz2#ddbdd6207c41cf82d8c96d52a2a204a2cdada9301cb577f9b323f22394bb1f0a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.4.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux64.tar.bz2#27cdc0d6e8bce2637678f6d076fc780877dffe1bf9aec9e253f95219af9ed099" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.4.0-linux64" "https://downloads.python.org/pypy/pypy-2.4.0-linux64.tar.bz2#27cdc0d6e8bce2637678f6d076fc780877dffe1bf9aec9e253f95219af9ed099" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-2.4-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.4-linux_x86_64-portable.tar.bz2#b6ed31aff0ebcc9b40554576b1ce789fe4e8c93f7a34cd3983515e1a9a8a45b6" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-2.4.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-osx64.tar.bz2#3eb8afdfa42bc9b08b4d3058e21d4ce978a52722fdcfdc67d6c3ee5013a51aaa" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.4.0-osx64" "https://downloads.python.org/pypy/pypy-2.4.0-osx64.tar.bz2#3eb8afdfa42bc9b08b4d3058e21d4ce978a52722fdcfdc67d6c3ee5013a51aaa" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.4.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-win32.zip#3eb8afdfa42bc9b08b4d3058e21d4ce978a52722fdcfdc67d6c3ee5013a51aaa" "pypy" verify_py27 ensurepip
+  install_zip "pypy-2.4.0-win32" "https://downloads.python.org/pypy/pypy-2.4.0-win32.zip#3eb8afdfa42bc9b08b4d3058e21d4ce978a52722fdcfdc67d6c3ee5013a51aaa" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.4.0
+++ b/plugins/python-build/share/python-build/pypy-2.4.0
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
   install_package "pypy-2.4.0-linux" "https://downloads.python.org/pypy/pypy-2.4.0-linux.tar.bz2#a24adb366f87ac0eba829d7188a156a7d897e71893689fab06502c3f4152ac0e" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.4-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.4-linux_i686-portable.tar.bz2#2a330bbeae038c143366982f2104bf4096752f1ec7520fc5608f0527c124b0c2" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.4-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.4-linux_i686-portable.tar.bz2#2a330bbeae038c143366982f2104bf4096752f1ec7520fc5608f0527c124b0c2" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -22,7 +22,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
   install_package "pypy-2.4.0-linux64" "https://downloads.python.org/pypy/pypy-2.4.0-linux64.tar.bz2#27cdc0d6e8bce2637678f6d076fc780877dffe1bf9aec9e253f95219af9ed099" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.4-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.4-linux_x86_64-portable.tar.bz2#b6ed31aff0ebcc9b40554576b1ce789fe4e8c93f7a34cd3983515e1a9a8a45b6" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.4-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.4-linux_x86_64-portable.tar.bz2#b6ed31aff0ebcc9b40554576b1ce789fe4e8c93f7a34cd3983515e1a9a8a45b6" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-2.4.0
+++ b/plugins/python-build/share/python-build/pypy-2.4.0
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-  install_package "pypy-2.4.0-linux" "https://downloads.python.org/pypy/pypy-2.4.0-linux.tar.bz2#a24adb366f87ac0eba829d7188a156a7d897e71893689fab06502c3f4152ac0e" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.4.0-linux" "https://downloads.python.org/pypy/pypy-2.4.0-linux.tar.bz2#a24adb366f87ac0eba829d7188a156a7d897e71893689fab06502c3f4152ac0e" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-2.4-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.4-linux_i686-portable.tar.bz2#2a330bbeae038c143366982f2104bf4096752f1ec7520fc5608f0527c124b0c2" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.4-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.4-linux_i686-portable.tar.bz2#2a330bbeae038c143366982f2104bf4096752f1ec7520fc5608f0527c124b0c2" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,17 +12,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-2.4.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.4.0-linux-armhf-raspbian.tar.bz2#5e0ba69b28ffbd5b61b0b6be2a130ab0c80e7d2da289d9530b0b6eac4302d5fa" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.4.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.4.0-linux-armhf-raspbian.tar.bz2#5e0ba69b28ffbd5b61b0b6be2a130ab0c80e7d2da289d9530b0b6eac4302d5fa" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-2.4.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.4.0-linux-armhf-raring.tar.bz2#ddbdd6207c41cf82d8c96d52a2a204a2cdada9301cb577f9b323f22394bb1f0a" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.4.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.4.0-linux-armhf-raring.tar.bz2#ddbdd6207c41cf82d8c96d52a2a204a2cdada9301cb577f9b323f22394bb1f0a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
-  install_package "pypy-2.4.0-linux64" "https://downloads.python.org/pypy/pypy-2.4.0-linux64.tar.bz2#27cdc0d6e8bce2637678f6d076fc780877dffe1bf9aec9e253f95219af9ed099" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.4.0-linux64" "https://downloads.python.org/pypy/pypy-2.4.0-linux64.tar.bz2#27cdc0d6e8bce2637678f6d076fc780877dffe1bf9aec9e253f95219af9ed099" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-2.4-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.4-linux_x86_64-portable.tar.bz2#b6ed31aff0ebcc9b40554576b1ce789fe4e8c93f7a34cd3983515e1a9a8a45b6" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.4-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.4-linux_x86_64-portable.tar.bz2#b6ed31aff0ebcc9b40554576b1ce789fe4e8c93f7a34cd3983515e1a9a8a45b6" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-2.5.0
+++ b/plugins/python-build/share/python-build/pypy-2.5.0
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.5.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux.tar.bz2#3dfd56a986d25929b4ed9f40a5484f72f1d513cd816cf8aaa683106c3391247c" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5.0-linux" "https://downloads.python.org/pypy/pypy-2.5.0-linux.tar.bz2#3dfd56a986d25929b4ed9f40a5484f72f1d513cd816cf8aaa683106c3391247c" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-2.5-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5-linux_i686-portable.tar.bz2#6cbe3e1a48900f22c8e4412f82906fba92dd4a165bac5fe6866a2a26383fe3b8" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.5.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux-armel.tar.bz2#277fa6c61d63af96893dafd19e1ffea7b988397c6a0fd66cd99dc0db1029be56" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5.0-linux-armel" "https://downloads.python.org/pypy/pypy-2.5.0-linux-armel.tar.bz2#277fa6c61d63af96893dafd19e1ffea7b988397c6a0fd66cd99dc0db1029be56" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.5.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux-armhf-raspbian.tar.bz2#6c975e39f0e7d57176b49a987a08862a3cbd9aeb52f47eb4ab148ea334e747fd" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.5.0-linux-armhf-raspbian.tar.bz2#6c975e39f0e7d57176b49a987a08862a3cbd9aeb52f47eb4ab148ea334e747fd" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.5.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux-armhf-raring.tar.bz2#1866bf2b8a8144c68d64f2ba982c6c545849913167b4602b762716332ec1fa0b" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.5.0-linux-armhf-raring.tar.bz2#1866bf2b8a8144c68d64f2ba982c6c545849913167b4602b762716332ec1fa0b" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.5.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux64.tar.bz2#7764fb6b662407f8709eaa334c542aac9cb6bfe3291ac198dad0980ca129f3c2" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5.0-linux64" "https://downloads.python.org/pypy/pypy-2.5.0-linux64.tar.bz2#7764fb6b662407f8709eaa334c542aac9cb6bfe3291ac198dad0980ca129f3c2" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-2.5-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5-linux_x86_64-portable.tar.bz2#26c5a0964b32b09be0282766c27937c843a12b6820ff2d440c6d47a6092837e0" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-2.5.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-osx64.tar.bz2#30b392b969b54cde281b07f5c10865a7f2e11a229c46b8af384ca1d3fe8d4e6e" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5.0-osx64" "https://downloads.python.org/pypy/pypy-2.5.0-osx64.tar.bz2#30b392b969b54cde281b07f5c10865a7f2e11a229c46b8af384ca1d3fe8d4e6e" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.5.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-win32.zip#692391434cf14016d74c6b8bda8f93135ef026f48c8327f3195bfa24d314317d" "pypy" verify_py27 ensurepip
+  install_zip "pypy-2.5.0-win32" "https://downloads.python.org/pypy/pypy-2.5.0-win32.zip#692391434cf14016d74c6b8bda8f93135ef026f48c8327f3195bfa24d314317d" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.5.0
+++ b/plugins/python-build/share/python-build/pypy-2.5.0
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
   install_package "pypy-2.5.0-linux" "https://downloads.python.org/pypy/pypy-2.5.0-linux.tar.bz2#3dfd56a986d25929b4ed9f40a5484f72f1d513cd816cf8aaa683106c3391247c" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.5-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5-linux_i686-portable.tar.bz2#6cbe3e1a48900f22c8e4412f82906fba92dd4a165bac5fe6866a2a26383fe3b8" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.5-linux_i686-portable.tar.bz2#6cbe3e1a48900f22c8e4412f82906fba92dd4a165bac5fe6866a2a26383fe3b8" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -22,7 +22,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy-2.5.0-linux64" "https://downloads.python.org/pypy/pypy-2.5.0-linux64.tar.bz2#7764fb6b662407f8709eaa334c542aac9cb6bfe3291ac198dad0980ca129f3c2" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.5-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5-linux_x86_64-portable.tar.bz2#26c5a0964b32b09be0282766c27937c843a12b6820ff2d440c6d47a6092837e0" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.5-linux_x86_64-portable.tar.bz2#26c5a0964b32b09be0282766c27937c843a12b6820ff2d440c6d47a6092837e0" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-2.5.0
+++ b/plugins/python-build/share/python-build/pypy-2.5.0
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-  install_package "pypy-2.5.0-linux" "https://downloads.python.org/pypy/pypy-2.5.0-linux.tar.bz2#3dfd56a986d25929b4ed9f40a5484f72f1d513cd816cf8aaa683106c3391247c" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.5.0-linux" "https://downloads.python.org/pypy/pypy-2.5.0-linux.tar.bz2#3dfd56a986d25929b4ed9f40a5484f72f1d513cd816cf8aaa683106c3391247c" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-2.5-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.5-linux_i686-portable.tar.bz2#6cbe3e1a48900f22c8e4412f82906fba92dd4a165bac5fe6866a2a26383fe3b8" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.5-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.5-linux_i686-portable.tar.bz2#6cbe3e1a48900f22c8e4412f82906fba92dd4a165bac5fe6866a2a26383fe3b8" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,17 +12,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-2.5.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.5.0-linux-armhf-raspbian.tar.bz2#6c975e39f0e7d57176b49a987a08862a3cbd9aeb52f47eb4ab148ea334e747fd" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.5.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.5.0-linux-armhf-raspbian.tar.bz2#6c975e39f0e7d57176b49a987a08862a3cbd9aeb52f47eb4ab148ea334e747fd" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-2.5.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.5.0-linux-armhf-raring.tar.bz2#1866bf2b8a8144c68d64f2ba982c6c545849913167b4602b762716332ec1fa0b" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.5.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.5.0-linux-armhf-raring.tar.bz2#1866bf2b8a8144c68d64f2ba982c6c545849913167b4602b762716332ec1fa0b" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy-2.5.0-linux64" "https://downloads.python.org/pypy/pypy-2.5.0-linux64.tar.bz2#7764fb6b662407f8709eaa334c542aac9cb6bfe3291ac198dad0980ca129f3c2" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.5.0-linux64" "https://downloads.python.org/pypy/pypy-2.5.0-linux64.tar.bz2#7764fb6b662407f8709eaa334c542aac9cb6bfe3291ac198dad0980ca129f3c2" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-2.5-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.5-linux_x86_64-portable.tar.bz2#26c5a0964b32b09be0282766c27937c843a12b6820ff2d440c6d47a6092837e0" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.5-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.5-linux_x86_64-portable.tar.bz2#26c5a0964b32b09be0282766c27937c843a12b6820ff2d440c6d47a6092837e0" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-2.5.1
+++ b/plugins/python-build/share/python-build/pypy-2.5.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-  install_package "pypy-2.5.1-linux" "https://downloads.python.org/pypy/pypy-2.5.1-linux.tar.bz2#c0035a2650cafcb384050a8c476ddc41c9fd40b0c3677fab68026f57c715907a" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.5.1-linux" "https://downloads.python.org/pypy/pypy-2.5.1-linux.tar.bz2#c0035a2650cafcb384050a8c476ddc41c9fd40b0c3677fab68026f57c715907a" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-2.5.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.5.1-linux_i686-portable.tar.bz2#ed532ddde3332d10faa59af49854cacbca458c597889352e619a87ab22363063" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.5.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.5.1-linux_i686-portable.tar.bz2#ed532ddde3332d10faa59af49854cacbca458c597889352e619a87ab22363063" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,17 +12,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-2.5.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.5.1-linux-armhf-raspbian.tar.bz2#2b730f86b56fcc72f5bfcfe6a38b5a6fe27654f73b2256e10297373af169a69e" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.5.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.5.1-linux-armhf-raspbian.tar.bz2#2b730f86b56fcc72f5bfcfe6a38b5a6fe27654f73b2256e10297373af169a69e" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-2.5.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.5.1-linux-armhf-raring.tar.bz2#0a5648c18cc604b0a8eaa559549cb332d18358fc551865e9b7ef051b796e4ec7" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.5.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.5.1-linux-armhf-raring.tar.bz2#0a5648c18cc604b0a8eaa559549cb332d18358fc551865e9b7ef051b796e4ec7" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy-2.5.1-linux64" "https://downloads.python.org/pypy/pypy-2.5.1-linux64.tar.bz2#68e0955dbc80a0d51dfa9a8a76d8623f34920ece1bcbc6d910c2be019a653ba8" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.5.1-linux64" "https://downloads.python.org/pypy/pypy-2.5.1-linux64.tar.bz2#68e0955dbc80a0d51dfa9a8a76d8623f34920ece1bcbc6d910c2be019a653ba8" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-2.5.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.5.1-linux_x86_64-portable.tar.bz2#157bee6349878cf0ef575b0d7bfd6cbb837c00e83b2872c924580ef7bc32c0d7" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.5.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.5.1-linux_x86_64-portable.tar.bz2#157bee6349878cf0ef575b0d7bfd6cbb837c00e83b2872c924580ef7bc32c0d7" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-2.5.1
+++ b/plugins/python-build/share/python-build/pypy-2.5.1
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.5.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux.tar.bz2#c0035a2650cafcb384050a8c476ddc41c9fd40b0c3677fab68026f57c715907a" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5.1-linux" "https://downloads.python.org/pypy/pypy-2.5.1-linux.tar.bz2#c0035a2650cafcb384050a8c476ddc41c9fd40b0c3677fab68026f57c715907a" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-2.5.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5.1-linux_i686-portable.tar.bz2#ed532ddde3332d10faa59af49854cacbca458c597889352e619a87ab22363063" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.5.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux-armel.tar.bz2#91d68551b6e738c1e47aaed869a6df8208abb8c60194a1647c6aa13c7363a61d" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5.1-linux-armel" "https://downloads.python.org/pypy/pypy-2.5.1-linux-armel.tar.bz2#91d68551b6e738c1e47aaed869a6df8208abb8c60194a1647c6aa13c7363a61d" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.5.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux-armhf-raspbian.tar.bz2#2b730f86b56fcc72f5bfcfe6a38b5a6fe27654f73b2256e10297373af169a69e" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.5.1-linux-armhf-raspbian.tar.bz2#2b730f86b56fcc72f5bfcfe6a38b5a6fe27654f73b2256e10297373af169a69e" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.5.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux-armhf-raring.tar.bz2#0a5648c18cc604b0a8eaa559549cb332d18358fc551865e9b7ef051b796e4ec7" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.5.1-linux-armhf-raring.tar.bz2#0a5648c18cc604b0a8eaa559549cb332d18358fc551865e9b7ef051b796e4ec7" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.5.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux64.tar.bz2#68e0955dbc80a0d51dfa9a8a76d8623f34920ece1bcbc6d910c2be019a653ba8" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5.1-linux64" "https://downloads.python.org/pypy/pypy-2.5.1-linux64.tar.bz2#68e0955dbc80a0d51dfa9a8a76d8623f34920ece1bcbc6d910c2be019a653ba8" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-2.5.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5.1-linux_x86_64-portable.tar.bz2#157bee6349878cf0ef575b0d7bfd6cbb837c00e83b2872c924580ef7bc32c0d7" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-2.5.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-osx64.tar.bz2#db40dc8b5e95ef9c3322bd9897099e91555ef34188cf1c3852a92b081142d183" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5.1-osx64" "https://downloads.python.org/pypy/pypy-2.5.1-osx64.tar.bz2#db40dc8b5e95ef9c3322bd9897099e91555ef34188cf1c3852a92b081142d183" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.5.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-win32.zip#0dbf90c30e848a91611bea99968a215244db02cf5f649114f10269cf1a15d607" "pypy" verify_py27 ensurepip
+  install_zip "pypy-2.5.1-win32" "https://downloads.python.org/pypy/pypy-2.5.1-win32.zip#0dbf90c30e848a91611bea99968a215244db02cf5f649114f10269cf1a15d607" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.5.1
+++ b/plugins/python-build/share/python-build/pypy-2.5.1
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
   install_package "pypy-2.5.1-linux" "https://downloads.python.org/pypy/pypy-2.5.1-linux.tar.bz2#c0035a2650cafcb384050a8c476ddc41c9fd40b0c3677fab68026f57c715907a" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.5.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5.1-linux_i686-portable.tar.bz2#ed532ddde3332d10faa59af49854cacbca458c597889352e619a87ab22363063" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.5.1-linux_i686-portable.tar.bz2#ed532ddde3332d10faa59af49854cacbca458c597889352e619a87ab22363063" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -22,7 +22,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy-2.5.1-linux64" "https://downloads.python.org/pypy/pypy-2.5.1-linux64.tar.bz2#68e0955dbc80a0d51dfa9a8a76d8623f34920ece1bcbc6d910c2be019a653ba8" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.5.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5.1-linux_x86_64-portable.tar.bz2#157bee6349878cf0ef575b0d7bfd6cbb837c00e83b2872c924580ef7bc32c0d7" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.5.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.5.1-linux_x86_64-portable.tar.bz2#157bee6349878cf0ef575b0d7bfd6cbb837c00e83b2872c924580ef7bc32c0d7" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-2.5.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.5.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-2.5.1-src" "https://downloads.python.org/pypy/pypy-2.5.1-src.tar.bz2#ddb3a580b1ee99c5a699172d74be91c36dda9a38946d4731d8c6a63120a3ba2a" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-2.5.1-src" "https://downloads.python.org/pypy/pypy-2.5.1-src.tar.bz2#ddb3a580b1ee99c5a699172d74be91c36dda9a38946d4731d8c6a63120a3ba2a" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.5.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.5.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-2.5.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-src.tar.bz2#ddb3a580b1ee99c5a699172d74be91c36dda9a38946d4731d8c6a63120a3ba2a" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-2.5.1-src" "https://downloads.python.org/pypy/pypy-2.5.1-src.tar.bz2#ddb3a580b1ee99c5a699172d74be91c36dda9a38946d4731d8c6a63120a3ba2a" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.6.0
+++ b/plugins/python-build/share/python-build/pypy-2.6.0
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.6.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-linux.tar.bz2#6e0b052c40a59bf5a85ee239980bbcab8b031b4c2bc33b99efe1b072977d9910" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6.0-linux" "https://downloads.python.org/pypy/pypy-2.6.0-linux.tar.bz2#6e0b052c40a59bf5a85ee239980bbcab8b031b4c2bc33b99efe1b072977d9910" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-2.6-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6-linux_i686-portable.tar.bz2#e01db0984f7fecd80dadfb1d5f65118e596e3984d12643b4d552e83f92bff549" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.6.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-linux-armel.tar.bz2#9d0cb9b15283f9c15f83c05293f8bd41d302c96090fd89b778f359df9bc8e619" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6.0-linux-armel" "https://downloads.python.org/pypy/pypy-2.6.0-linux-armel.tar.bz2#9d0cb9b15283f9c15f83c05293f8bd41d302c96090fd89b778f359df9bc8e619" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.6.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-linux-armhf-raspbian.tar.bz2#e9f6a16c3e21f38bd571adb33757649ceef3f2ebfdd6d37eea923ce26ea6728c" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.6.0-linux-armhf-raspbian.tar.bz2#e9f6a16c3e21f38bd571adb33757649ceef3f2ebfdd6d37eea923ce26ea6728c" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.6.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-linux-armhf-raring.tar.bz2#ccb37a6d861b6dd69cd038337664885dcf91852a2ab6aef480dd7cfbda8de502" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.6.0-linux-armhf-raring.tar.bz2#ccb37a6d861b6dd69cd038337664885dcf91852a2ab6aef480dd7cfbda8de502" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.6.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-linux64.tar.bz2#f5d2b0e3594cec57e32d3e43a951041ec330e1e962a836be470d591633e51388" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6.0-linux64" "https://downloads.python.org/pypy/pypy-2.6.0-linux64.tar.bz2#f5d2b0e3594cec57e32d3e43a951041ec330e1e962a836be470d591633e51388" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-2.6-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6-linux_x86_64-portable.tar.bz2#97284b66476c5d1b17a62f5017569a0073730928e19f95b49d78d6bc60b69495" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-2.6.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-osx64.tar.bz2#77f1d056484e40e0a8e2e2b2b489eedfe785605ef36b144ffce05f7b748f6acd" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6.0-osx64" "https://downloads.python.org/pypy/pypy-2.6.0-osx64.tar.bz2#77f1d056484e40e0a8e2e2b2b489eedfe785605ef36b144ffce05f7b748f6acd" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.6.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-win32.zip#de907e7fef7b9b6ceccfc8aa5f4781ee3bc4a49b119d4b22ab5e25eab21c6e8d" "pypy" verify_py27 ensurepip
+  install_zip "pypy-2.6.0-win32" "https://downloads.python.org/pypy/pypy-2.6.0-win32.zip#de907e7fef7b9b6ceccfc8aa5f4781ee3bc4a49b119d4b22ab5e25eab21c6e8d" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.6.0
+++ b/plugins/python-build/share/python-build/pypy-2.6.0
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-  install_package "pypy-2.6.0-linux" "https://downloads.python.org/pypy/pypy-2.6.0-linux.tar.bz2#6e0b052c40a59bf5a85ee239980bbcab8b031b4c2bc33b99efe1b072977d9910" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.6.0-linux" "https://downloads.python.org/pypy/pypy-2.6.0-linux.tar.bz2#6e0b052c40a59bf5a85ee239980bbcab8b031b4c2bc33b99efe1b072977d9910" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-2.6-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.6-linux_i686-portable.tar.bz2#e01db0984f7fecd80dadfb1d5f65118e596e3984d12643b4d552e83f92bff549" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.6-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.6-linux_i686-portable.tar.bz2#e01db0984f7fecd80dadfb1d5f65118e596e3984d12643b4d552e83f92bff549" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,17 +12,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-2.6.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.6.0-linux-armhf-raspbian.tar.bz2#e9f6a16c3e21f38bd571adb33757649ceef3f2ebfdd6d37eea923ce26ea6728c" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.6.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.6.0-linux-armhf-raspbian.tar.bz2#e9f6a16c3e21f38bd571adb33757649ceef3f2ebfdd6d37eea923ce26ea6728c" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-2.6.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.6.0-linux-armhf-raring.tar.bz2#ccb37a6d861b6dd69cd038337664885dcf91852a2ab6aef480dd7cfbda8de502" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.6.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.6.0-linux-armhf-raring.tar.bz2#ccb37a6d861b6dd69cd038337664885dcf91852a2ab6aef480dd7cfbda8de502" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy-2.6.0-linux64" "https://downloads.python.org/pypy/pypy-2.6.0-linux64.tar.bz2#f5d2b0e3594cec57e32d3e43a951041ec330e1e962a836be470d591633e51388" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.6.0-linux64" "https://downloads.python.org/pypy/pypy-2.6.0-linux64.tar.bz2#f5d2b0e3594cec57e32d3e43a951041ec330e1e962a836be470d591633e51388" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-2.6-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.6-linux_x86_64-portable.tar.bz2#97284b66476c5d1b17a62f5017569a0073730928e19f95b49d78d6bc60b69495" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.6-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.6-linux_x86_64-portable.tar.bz2#97284b66476c5d1b17a62f5017569a0073730928e19f95b49d78d6bc60b69495" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-2.6.0
+++ b/plugins/python-build/share/python-build/pypy-2.6.0
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
   install_package "pypy-2.6.0-linux" "https://downloads.python.org/pypy/pypy-2.6.0-linux.tar.bz2#6e0b052c40a59bf5a85ee239980bbcab8b031b4c2bc33b99efe1b072977d9910" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.6-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6-linux_i686-portable.tar.bz2#e01db0984f7fecd80dadfb1d5f65118e596e3984d12643b4d552e83f92bff549" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.6-linux_i686-portable.tar.bz2#e01db0984f7fecd80dadfb1d5f65118e596e3984d12643b4d552e83f92bff549" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -22,7 +22,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy-2.6.0-linux64" "https://downloads.python.org/pypy/pypy-2.6.0-linux64.tar.bz2#f5d2b0e3594cec57e32d3e43a951041ec330e1e962a836be470d591633e51388" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.6-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6-linux_x86_64-portable.tar.bz2#97284b66476c5d1b17a62f5017569a0073730928e19f95b49d78d6bc60b69495" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.6-linux_x86_64-portable.tar.bz2#97284b66476c5d1b17a62f5017569a0073730928e19f95b49d78d6bc60b69495" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-2.6.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.6.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-2.6.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-src.tar.bz2#9bf353f22d25e97a85a6d3766619966055edea1ea1b2218445d683a8ad0399d9" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-2.6.0-src" "https://downloads.python.org/pypy/pypy-2.6.0-src.tar.bz2#9bf353f22d25e97a85a6d3766619966055edea1ea1b2218445d683a8ad0399d9" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.6.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.6.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-2.6.0-src" "https://downloads.python.org/pypy/pypy-2.6.0-src.tar.bz2#9bf353f22d25e97a85a6d3766619966055edea1ea1b2218445d683a8ad0399d9" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-2.6.0-src" "https://downloads.python.org/pypy/pypy-2.6.0-src.tar.bz2#9bf353f22d25e97a85a6d3766619966055edea1ea1b2218445d683a8ad0399d9" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.6.1
+++ b/plugins/python-build/share/python-build/pypy-2.6.1
@@ -1,39 +1,39 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "freebsd64" )
-  install_package "pypy-2.6.1-freebsd64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-freebsd64.tar.bz2#58118e88ce01c1d48b31d293db40687efbdeba54334eb55ba96de9ecf3c39055" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6.1-freebsd64" "https://downloads.python.org/pypy/pypy-2.6.1-freebsd64.tar.bz2#58118e88ce01c1d48b31d293db40687efbdeba54334eb55ba96de9ecf3c39055" "pypy" verify_py27 ensurepip
   ;;
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.6.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-linux.tar.bz2#d010b1f1aafdb01beb107f16843985508ce81698260ce830690686d9b2768c88" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6.1-linux" "https://downloads.python.org/pypy/pypy-2.6.1-linux.tar.bz2#d010b1f1aafdb01beb107f16843985508ce81698260ce830690686d9b2768c88" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-2.6.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6.1-linux_i686-portable.tar.bz2#af8f05790fe21bffdb0619d39f2890e2ecabe47bbd3b21c2c97b9778e4cdb378" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.6.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-linux-armel.tar.bz2#0ca15d289e78a82f927b375a016b7c3246accac5d7eebded4e32a496fb3245ab" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6.1-linux-armel" "https://downloads.python.org/pypy/pypy-2.6.1-linux-armel.tar.bz2#0ca15d289e78a82f927b375a016b7c3246accac5d7eebded4e32a496fb3245ab" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.6.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-linux-armhf-raspbian.tar.bz2#13d983805ebc6d9a3627dea3c34898375a4e4e7b6f0171cfbde463c1c04a92aa" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.6.1-linux-armhf-raspbian.tar.bz2#13d983805ebc6d9a3627dea3c34898375a4e4e7b6f0171cfbde463c1c04a92aa" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.6.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-linux-armhf-raring.tar.bz2#4caa7c1922a212cca4690bfa181cd368760a23b50163b3cbbd6d28401dd5cef5" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.6.1-linux-armhf-raring.tar.bz2#4caa7c1922a212cca4690bfa181cd368760a23b50163b3cbbd6d28401dd5cef5" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.6.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-linux64.tar.bz2#78a48490d1b2dba8571156c2bf822324ca7dae6f6a56a4bbb96d3e8e8885367b" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6.1-linux64" "https://downloads.python.org/pypy/pypy-2.6.1-linux64.tar.bz2#78a48490d1b2dba8571156c2bf822324ca7dae6f6a56a4bbb96d3e8e8885367b" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-2.6.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6.1-linux_x86_64-portable.tar.bz2#ed6a35dee4c982123af716e62975039e18920b599afc4f6a2f3c7c89d0403389" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-2.6.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-osx64.tar.bz2#4a78ef76ec38a49a9de40225c337e89486fa09938c600df2bd2dd60110066f65" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6.1-osx64" "https://downloads.python.org/pypy/pypy-2.6.1-osx64.tar.bz2#4a78ef76ec38a49a9de40225c337e89486fa09938c600df2bd2dd60110066f65" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.6.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-win32.zip#ccea3940fdedc03e2fcb5acf6badfe6d9c1ae876d5faf0a004e1d94edd7fd856" "pypy" verify_py27 ensurepip
+  install_zip "pypy-2.6.1-win32" "https://downloads.python.org/pypy/pypy-2.6.1-win32.zip#ccea3940fdedc03e2fcb5acf6badfe6d9c1ae876d5faf0a004e1d94edd7fd856" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.6.1
+++ b/plugins/python-build/share/python-build/pypy-2.6.1
@@ -4,9 +4,9 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-  install_package "pypy-2.6.1-linux" "https://downloads.python.org/pypy/pypy-2.6.1-linux.tar.bz2#d010b1f1aafdb01beb107f16843985508ce81698260ce830690686d9b2768c88" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.6.1-linux" "https://downloads.python.org/pypy/pypy-2.6.1-linux.tar.bz2#d010b1f1aafdb01beb107f16843985508ce81698260ce830690686d9b2768c88" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-2.6.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.6.1-linux_i686-portable.tar.bz2#af8f05790fe21bffdb0619d39f2890e2ecabe47bbd3b21c2c97b9778e4cdb378" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.6.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.6.1-linux_i686-portable.tar.bz2#af8f05790fe21bffdb0619d39f2890e2ecabe47bbd3b21c2c97b9778e4cdb378" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -15,17 +15,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-2.6.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.6.1-linux-armhf-raspbian.tar.bz2#13d983805ebc6d9a3627dea3c34898375a4e4e7b6f0171cfbde463c1c04a92aa" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.6.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-2.6.1-linux-armhf-raspbian.tar.bz2#13d983805ebc6d9a3627dea3c34898375a4e4e7b6f0171cfbde463c1c04a92aa" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-2.6.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.6.1-linux-armhf-raring.tar.bz2#4caa7c1922a212cca4690bfa181cd368760a23b50163b3cbbd6d28401dd5cef5" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.6.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-2.6.1-linux-armhf-raring.tar.bz2#4caa7c1922a212cca4690bfa181cd368760a23b50163b3cbbd6d28401dd5cef5" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy-2.6.1-linux64" "https://downloads.python.org/pypy/pypy-2.6.1-linux64.tar.bz2#78a48490d1b2dba8571156c2bf822324ca7dae6f6a56a4bbb96d3e8e8885367b" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.6.1-linux64" "https://downloads.python.org/pypy/pypy-2.6.1-linux64.tar.bz2#78a48490d1b2dba8571156c2bf822324ca7dae6f6a56a4bbb96d3e8e8885367b" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-2.6.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.6.1-linux_x86_64-portable.tar.bz2#ed6a35dee4c982123af716e62975039e18920b599afc4f6a2f3c7c89d0403389" "pypy" verify_py27 ensurepip
+    install_package "pypy-2.6.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.6.1-linux_x86_64-portable.tar.bz2#ed6a35dee4c982123af716e62975039e18920b599afc4f6a2f3c7c89d0403389" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-2.6.1
+++ b/plugins/python-build/share/python-build/pypy-2.6.1
@@ -6,7 +6,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
   install_package "pypy-2.6.1-linux" "https://downloads.python.org/pypy/pypy-2.6.1-linux.tar.bz2#d010b1f1aafdb01beb107f16843985508ce81698260ce830690686d9b2768c88" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.6.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6.1-linux_i686-portable.tar.bz2#af8f05790fe21bffdb0619d39f2890e2ecabe47bbd3b21c2c97b9778e4cdb378" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.6.1-linux_i686-portable.tar.bz2#af8f05790fe21bffdb0619d39f2890e2ecabe47bbd3b21c2c97b9778e4cdb378" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -25,7 +25,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy-2.6.1-linux64" "https://downloads.python.org/pypy/pypy-2.6.1-linux64.tar.bz2#78a48490d1b2dba8571156c2bf822324ca7dae6f6a56a4bbb96d3e8e8885367b" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.6.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6.1-linux_x86_64-portable.tar.bz2#ed6a35dee4c982123af716e62975039e18920b599afc4f6a2f3c7c89d0403389" "pypy" verify_py27 ensurepip
+  install_package "pypy-2.6.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-2.6.1-linux_x86_64-portable.tar.bz2#ed6a35dee4c982123af716e62975039e18920b599afc4f6a2f3c7c89d0403389" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-2.6.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.6.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-2.6.1-src" "https://downloads.python.org/pypy/pypy-2.6.1-src.tar.bz2#7fddd414c9348c2f899f79ad86adc3fc2b19443855b5243f58487e1f0ac46560" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-2.6.1-src" "https://downloads.python.org/pypy/pypy-2.6.1-src.tar.bz2#7fddd414c9348c2f899f79ad86adc3fc2b19443855b5243f58487e1f0ac46560" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.6.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.6.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-2.6.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-src.tar.bz2#7fddd414c9348c2f899f79ad86adc3fc2b19443855b5243f58487e1f0ac46560" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-2.6.1-src" "https://downloads.python.org/pypy/pypy-2.6.1-src.tar.bz2#7fddd414c9348c2f899f79ad86adc3fc2b19443855b5243f58487e1f0ac46560" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-4.0.0
+++ b/plugins/python-build/share/python-build/pypy-4.0.0
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
   install_package "pypy-4.0.0-linux" "https://downloads.python.org/pypy/pypy-4.0.0-linux.tar.bz2#365600947775bc73a902a5b1d11f8b96cf49f07cdbbab28bb47240097b4bb4c5" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-4.0-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0-linux_i686-portable.tar.bz2#8d6b775a1fdc79db453f80e6b50cd9979d89be3714cd71d3af21bf9f56745610" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-4.0-linux_i686-portable.tar.bz2#8d6b775a1fdc79db453f80e6b50cd9979d89be3714cd71d3af21bf9f56745610" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )

--- a/plugins/python-build/share/python-build/pypy-4.0.0
+++ b/plugins/python-build/share/python-build/pypy-4.0.0
@@ -1,44 +1,44 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-4.0.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-linux.tar.bz2#365600947775bc73a902a5b1d11f8b96cf49f07cdbbab28bb47240097b4bb4c5" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0.0-linux" "https://downloads.python.org/pypy/pypy-4.0.0-linux.tar.bz2#365600947775bc73a902a5b1d11f8b96cf49f07cdbbab28bb47240097b4bb4c5" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-4.0-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0-linux_i686-portable.tar.bz2#8d6b775a1fdc79db453f80e6b50cd9979d89be3714cd71d3af21bf9f56745610" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-4.0.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-linux-armel.tar.bz2#612df41fa21c5bc95d8d3575e0d8c09f605de6f0684109222afa561672dd9c7b" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0.0-linux-armel" "https://downloads.python.org/pypy/pypy-4.0.0-linux-armel.tar.bz2#612df41fa21c5bc95d8d3575e0d8c09f605de6f0684109222afa561672dd9c7b" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-4.0.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-linux-armhf-raspbian.tar.bz2#fccd9d8436781cbeb8c94e2b37e590303c52e63bc50ed30c4a99a46f022c44bb" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-4.0.0-linux-armhf-raspbian.tar.bz2#fccd9d8436781cbeb8c94e2b37e590303c52e63bc50ed30c4a99a46f022c44bb" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-4.0.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-linux-armhf-raring.tar.bz2#9586d9accdb8faa488a313132047e0dad73c8facc222201380d4935a2ba429b8" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-4.0.0-linux-armhf-raring.tar.bz2#9586d9accdb8faa488a313132047e0dad73c8facc222201380d4935a2ba429b8" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-ppc64" )
   require_distro "Fedora 20" || true
-  install_package "pypy-4.0.0-ppc64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-ppc64.tar.bz2#729eab7fa84289a094d69fe1607ef97c8e7acc08588db5cd410c9dd26bdd4110" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0.0-ppc64" "https://downloads.python.org/pypy/pypy-4.0.0-ppc64.tar.bz2#729eab7fa84289a094d69fe1607ef97c8e7acc08588db5cd410c9dd26bdd4110" "pypy" verify_py27 ensurepip
   ;;
 "linux-ppc64le" )
   require_distro "Fedora 21" || true
-  install_package "pypy-4.0.0-ppc64le" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-ppc64le.tar.bz2#0ba3c313afb48cba2798c9b46e9a27e24a597f90e092b649b6ac9cd8af4f7765" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0.0-ppc64le" "https://downloads.python.org/pypy/pypy-4.0.0-ppc64le.tar.bz2#0ba3c313afb48cba2798c9b46e9a27e24a597f90e092b649b6ac9cd8af4f7765" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-4.0.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-linux64.tar.bz2#30365cf4fa6cd8e9ff44126f06dcaebefda35c2543ddcf9b9e8516c29cabe726" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0.0-linux64" "https://downloads.python.org/pypy/pypy-4.0.0-linux64.tar.bz2#30365cf4fa6cd8e9ff44126f06dcaebefda35c2543ddcf9b9e8516c29cabe726" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-4.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0-linux_x86_64-portable.tar.bz2#61fb04eaa823763b8de777e16edc02b09116985586f53c14c6e85d531072a38f" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-4.0.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-osx64.tar.bz2#d9e590fe5b9461bbdff56c76636e844ef90a297f82d0d2e204866c8a21759a50" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0.0-osx64" "https://downloads.python.org/pypy/pypy-4.0.0-osx64.tar.bz2#d9e590fe5b9461bbdff56c76636e844ef90a297f82d0d2e204866c8a21759a50" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-4.0.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-win32.zip#d906ffa98b120496cbbc1623d0fd08662c3a589340ae7071c669432eccf26e00" "pypy" verify_py27 ensurepip
+  install_zip "pypy-4.0.0-win32" "https://downloads.python.org/pypy/pypy-4.0.0-win32.zip#d906ffa98b120496cbbc1623d0fd08662c3a589340ae7071c669432eccf26e00" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-4.0.0
+++ b/plugins/python-build/share/python-build/pypy-4.0.0
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-  install_package "pypy-4.0.0-linux" "https://downloads.python.org/pypy/pypy-4.0.0-linux.tar.bz2#365600947775bc73a902a5b1d11f8b96cf49f07cdbbab28bb47240097b4bb4c5" "pypy" verify_py27 ensurepip
+    install_package "pypy-4.0.0-linux" "https://downloads.python.org/pypy/pypy-4.0.0-linux.tar.bz2#365600947775bc73a902a5b1d11f8b96cf49f07cdbbab28bb47240097b4bb4c5" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-4.0-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-4.0-linux_i686-portable.tar.bz2#8d6b775a1fdc79db453f80e6b50cd9979d89be3714cd71d3af21bf9f56745610" "pypy" verify_py27 ensurepip
+    install_package "pypy-4.0-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-4.0-linux_i686-portable.tar.bz2#8d6b775a1fdc79db453f80e6b50cd9979d89be3714cd71d3af21bf9f56745610" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,10 +12,10 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-4.0.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-4.0.0-linux-armhf-raspbian.tar.bz2#fccd9d8436781cbeb8c94e2b37e590303c52e63bc50ed30c4a99a46f022c44bb" "pypy" verify_py27 ensurepip
+    install_package "pypy-4.0.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-4.0.0-linux-armhf-raspbian.tar.bz2#fccd9d8436781cbeb8c94e2b37e590303c52e63bc50ed30c4a99a46f022c44bb" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-4.0.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-4.0.0-linux-armhf-raring.tar.bz2#9586d9accdb8faa488a313132047e0dad73c8facc222201380d4935a2ba429b8" "pypy" verify_py27 ensurepip
+    install_package "pypy-4.0.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-4.0.0-linux-armhf-raring.tar.bz2#9586d9accdb8faa488a313132047e0dad73c8facc222201380d4935a2ba429b8" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-ppc64" )
@@ -28,7 +28,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy-4.0.0-linux64" "https://downloads.python.org/pypy/pypy-4.0.0-linux64.tar.bz2#30365cf4fa6cd8e9ff44126f06dcaebefda35c2543ddcf9b9e8516c29cabe726" "pypy" verify_py27 ensurepip
+    install_package "pypy-4.0.0-linux64" "https://downloads.python.org/pypy/pypy-4.0.0-linux64.tar.bz2#30365cf4fa6cd8e9ff44126f06dcaebefda35c2543ddcf9b9e8516c29cabe726" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-4.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0-linux_x86_64-portable.tar.bz2#61fb04eaa823763b8de777e16edc02b09116985586f53c14c6e85d531072a38f" "pypy" verify_py27 ensurepip
   fi

--- a/plugins/python-build/share/python-build/pypy-4.0.0-src
+++ b/plugins/python-build/share/python-build/pypy-4.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-4.0.0-src" "https://downloads.python.org/pypy/pypy-4.0.0-src.tar.bz2#acff480e44ce92acd057f2e786775af36dc3c2cd12e9efc60a1ac6a562ad7b4d" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-4.0.0-src" "https://downloads.python.org/pypy/pypy-4.0.0-src.tar.bz2#acff480e44ce92acd057f2e786775af36dc3c2cd12e9efc60a1ac6a562ad7b4d" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-4.0.0-src
+++ b/plugins/python-build/share/python-build/pypy-4.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-4.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-src.tar.bz2#acff480e44ce92acd057f2e786775af36dc3c2cd12e9efc60a1ac6a562ad7b4d" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-4.0.0-src" "https://downloads.python.org/pypy/pypy-4.0.0-src.tar.bz2#acff480e44ce92acd057f2e786775af36dc3c2cd12e9efc60a1ac6a562ad7b4d" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-4.0.1
+++ b/plugins/python-build/share/python-build/pypy-4.0.1
@@ -1,21 +1,21 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-4.0.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-linux.tar.bz2#721920fcbb6aefc9a98e868e32b7f4ea5fd68b7f9305d08d0a2595327c9c0611" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0.1-linux" "https://downloads.python.org/pypy/pypy-4.0.1-linux.tar.bz2#721920fcbb6aefc9a98e868e32b7f4ea5fd68b7f9305d08d0a2595327c9c0611" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-4.0.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0.1-linux_i686-portable.tar.bz2#2a1078bf36372b1c2919c11c418860dd7f0d44c92e6772bb36490eaf793b5c47" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-4.0.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-linux-armel.tar.bz2#d1acdd45ebd34580dd632c63c95211f6bae5e9a8f7a46ffa6f0443286ff9f61b" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0.1-linux-armel" "https://downloads.python.org/pypy/pypy-4.0.1-linux-armel.tar.bz2#d1acdd45ebd34580dd632c63c95211f6bae5e9a8f7a46ffa6f0443286ff9f61b" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-4.0.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-linux-armhf-raspbian.tar.bz2#52eef495f560af59a787b9935367cb5f8c83b48e32a80ec3e7060bffac011ecc" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-4.0.1-linux-armhf-raspbian.tar.bz2#52eef495f560af59a787b9935367cb5f8c83b48e32a80ec3e7060bffac011ecc" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-4.0.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-linux-armhf-raring.tar.bz2#e67278ce7423aa7bf99a95fd271cb76763eae3106930f4b7de1fba6a70a3f383" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-4.0.1-linux-armhf-raring.tar.bz2#e67278ce7423aa7bf99a95fd271cb76763eae3106930f4b7de1fba6a70a3f383" "pypy" verify_py27 ensurepip
   fi
   ;;
 #"linux-ppc64" )
@@ -28,17 +28,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
 #  ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-4.0.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-linux64.tar.bz2#0d6090cee59f4b9bab91ddbea76580d0c232b78dae65aaa9e8fa8d4449ba25b4" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0.1-linux64" "https://downloads.python.org/pypy/pypy-4.0.1-linux64.tar.bz2#0d6090cee59f4b9bab91ddbea76580d0c232b78dae65aaa9e8fa8d4449ba25b4" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-4.0.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0.1-linux_x86_64-portable.tar.bz2#b3803f6dd9bbb964f7d322aa4aeb93191ff0ebe573428c1d2014ea26da49ff53" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-4.0.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-osx64.tar.bz2#06be1299691f7ea558bf8e3bdf3d20debb8ba03cd7cadf04f2d6cbd5fd084430" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0.1-osx64" "https://downloads.python.org/pypy/pypy-4.0.1-osx64.tar.bz2#06be1299691f7ea558bf8e3bdf3d20debb8ba03cd7cadf04f2d6cbd5fd084430" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-4.0.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-win32.zip#9a350a5e6f9b86fb525c6f1300b0c97c021ea8b1e37bfd32a8c4bb7a415d5329" "pypy" verify_py27 ensurepip
+  install_zip "pypy-4.0.1-win32" "https://downloads.python.org/pypy/pypy-4.0.1-win32.zip#9a350a5e6f9b86fb525c6f1300b0c97c021ea8b1e37bfd32a8c4bb7a415d5329" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-4.0.1
+++ b/plugins/python-build/share/python-build/pypy-4.0.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-  install_package "pypy-4.0.1-linux" "https://downloads.python.org/pypy/pypy-4.0.1-linux.tar.bz2#721920fcbb6aefc9a98e868e32b7f4ea5fd68b7f9305d08d0a2595327c9c0611" "pypy" verify_py27 ensurepip
+    install_package "pypy-4.0.1-linux" "https://downloads.python.org/pypy/pypy-4.0.1-linux.tar.bz2#721920fcbb6aefc9a98e868e32b7f4ea5fd68b7f9305d08d0a2595327c9c0611" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-4.0.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-4.0.1-linux_i686-portable.tar.bz2#2a1078bf36372b1c2919c11c418860dd7f0d44c92e6772bb36490eaf793b5c47" "pypy" verify_py27 ensurepip
+    install_package "pypy-4.0.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-4.0.1-linux_i686-portable.tar.bz2#2a1078bf36372b1c2919c11c418860dd7f0d44c92e6772bb36490eaf793b5c47" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,10 +12,10 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-4.0.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-4.0.1-linux-armhf-raspbian.tar.bz2#52eef495f560af59a787b9935367cb5f8c83b48e32a80ec3e7060bffac011ecc" "pypy" verify_py27 ensurepip
+    install_package "pypy-4.0.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-4.0.1-linux-armhf-raspbian.tar.bz2#52eef495f560af59a787b9935367cb5f8c83b48e32a80ec3e7060bffac011ecc" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-4.0.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-4.0.1-linux-armhf-raring.tar.bz2#e67278ce7423aa7bf99a95fd271cb76763eae3106930f4b7de1fba6a70a3f383" "pypy" verify_py27 ensurepip
+    install_package "pypy-4.0.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-4.0.1-linux-armhf-raring.tar.bz2#e67278ce7423aa7bf99a95fd271cb76763eae3106930f4b7de1fba6a70a3f383" "pypy" verify_py27 ensurepip
   fi
   ;;
 #"linux-ppc64" )
@@ -28,7 +28,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
 #  ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy-4.0.1-linux64" "https://downloads.python.org/pypy/pypy-4.0.1-linux64.tar.bz2#0d6090cee59f4b9bab91ddbea76580d0c232b78dae65aaa9e8fa8d4449ba25b4" "pypy" verify_py27 ensurepip
+    install_package "pypy-4.0.1-linux64" "https://downloads.python.org/pypy/pypy-4.0.1-linux64.tar.bz2#0d6090cee59f4b9bab91ddbea76580d0c232b78dae65aaa9e8fa8d4449ba25b4" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-4.0.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0.1-linux_x86_64-portable.tar.bz2#b3803f6dd9bbb964f7d322aa4aeb93191ff0ebe573428c1d2014ea26da49ff53" "pypy" verify_py27 ensurepip
   fi

--- a/plugins/python-build/share/python-build/pypy-4.0.1
+++ b/plugins/python-build/share/python-build/pypy-4.0.1
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
   install_package "pypy-4.0.1-linux" "https://downloads.python.org/pypy/pypy-4.0.1-linux.tar.bz2#721920fcbb6aefc9a98e868e32b7f4ea5fd68b7f9305d08d0a2595327c9c0611" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-4.0.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0.1-linux_i686-portable.tar.bz2#2a1078bf36372b1c2919c11c418860dd7f0d44c92e6772bb36490eaf793b5c47" "pypy" verify_py27 ensurepip
+  install_package "pypy-4.0.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-4.0.1-linux_i686-portable.tar.bz2#2a1078bf36372b1c2919c11c418860dd7f0d44c92e6772bb36490eaf793b5c47" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )

--- a/plugins/python-build/share/python-build/pypy-4.0.1-src
+++ b/plugins/python-build/share/python-build/pypy-4.0.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-4.0.1-src" "https://downloads.python.org/pypy/pypy-4.0.1-src.tar.bz2#29f5aa6ba17b34fd980e85172dfeb4086fdc373ad392b1feff2677d2d8aea23c" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-4.0.1-src" "https://downloads.python.org/pypy/pypy-4.0.1-src.tar.bz2#29f5aa6ba17b34fd980e85172dfeb4086fdc373ad392b1feff2677d2d8aea23c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-4.0.1-src
+++ b/plugins/python-build/share/python-build/pypy-4.0.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-4.0.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-src.tar.bz2#29f5aa6ba17b34fd980e85172dfeb4086fdc373ad392b1feff2677d2d8aea23c" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-4.0.1-src" "https://downloads.python.org/pypy/pypy-4.0.1-src.tar.bz2#29f5aa6ba17b34fd980e85172dfeb4086fdc373ad392b1feff2677d2d8aea23c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.0.0
+++ b/plugins/python-build/share/python-build/pypy-5.0.0
@@ -1,44 +1,44 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.0.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux.tar.bz2#a9cc9afa94ff1cde811626a70081c477c9840e7816c0562d1903fd823d222ceb" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0.0-linux" "https://downloads.python.org/pypy/pypy-5.0.0-linux.tar.bz2#a9cc9afa94ff1cde811626a70081c477c9840e7816c0562d1903fd823d222ceb" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.0-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0-linux_i686-portable.tar.bz2#316e03afdd2f6212857789933c01f0d41a1665c80d28526c0fb4082b6d3f4f60" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-5.0.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux-armel.tar.bz2#87bd85441b16ecca0d45ba6e9c0e9d26bb7bd8867afbf79d80312cf79b032dc1" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0.0-linux-armel" "https://downloads.python.org/pypy/pypy-5.0.0-linux-armel.tar.bz2#87bd85441b16ecca0d45ba6e9c0e9d26bb7bd8867afbf79d80312cf79b032dc1" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-5.0.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux-armhf-raspbian.tar.bz2#8033c0cc39e9f6771688f2eda95c726595f5453b3e73e1cd5f7ebbe3dae1f685" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-5.0.0-linux-armhf-raspbian.tar.bz2#8033c0cc39e9f6771688f2eda95c726595f5453b3e73e1cd5f7ebbe3dae1f685" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-5.0.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux-armhf-raring.tar.bz2#5bb52cf5db4ae8497c4e03cd8a70e49867e6b93d9f29ad335d030fcd3a375769" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-5.0.0-linux-armhf-raring.tar.bz2#5bb52cf5db4ae8497c4e03cd8a70e49867e6b93d9f29ad335d030fcd3a375769" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-ppc64" )
  require_distro "Fedora 20" || true
- install_package "pypy-5.0.0-ppc64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-ppc64.tar.bz2#334a37e68cb543cf2cbcdd12379b9b770064bb70ba7fd104f1e451cfa10cdda5" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0.0-ppc64" "https://downloads.python.org/pypy/pypy-5.0.0-ppc64.tar.bz2#334a37e68cb543cf2cbcdd12379b9b770064bb70ba7fd104f1e451cfa10cdda5" "pypy" verify_py27 ensurepip
  ;;
 "linux-ppc64le" )
  require_distro "Fedora 21" || true
- install_package "pypy-5.0.0-ppc64le" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-ppc64le.tar.bz2#e72fe5c094186f79c997000ddbaa01616def652a8d1338b75a27dfa3755eb86c" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0.0-ppc64le" "https://downloads.python.org/pypy/pypy-5.0.0-ppc64le.tar.bz2#e72fe5c094186f79c997000ddbaa01616def652a8d1338b75a27dfa3755eb86c" "pypy" verify_py27 ensurepip
  ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.0.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux64.tar.bz2#b9c73be8e3c3b0835df83bdb86335712005240071cdd4dc245ac30b457063ae0" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0.0-linux64" "https://downloads.python.org/pypy/pypy-5.0.0-linux64.tar.bz2#b9c73be8e3c3b0835df83bdb86335712005240071cdd4dc245ac30b457063ae0" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0-linux_x86_64-portable.tar.bz2#57c9ea251bf1e7074e14aeecdd1ac8bb2fc53dbf3f90a9613d03e33076a7fa08" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-5.0.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-osx64.tar.bz2#45ed8bf799d0fd8eb051cbcc427173fba74dc9c2f6c309d7a3cc90f4917e6a10" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0.0-osx64" "https://downloads.python.org/pypy/pypy-5.0.0-osx64.tar.bz2#45ed8bf799d0fd8eb051cbcc427173fba74dc9c2f6c309d7a3cc90f4917e6a10" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-5.0.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-win32.zip#c53f0946703f5e4885484c7cde2554a0320537135bf8965e054757c214412438" "pypy" verify_py27 ensurepip
+  install_zip "pypy-5.0.0-win32" "https://downloads.python.org/pypy/pypy-5.0.0-win32.zip#c53f0946703f5e4885484c7cde2554a0320537135bf8965e054757c214412438" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-5.0.0
+++ b/plugins/python-build/share/python-build/pypy-5.0.0
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
   install_package "pypy-5.0.0-linux" "https://downloads.python.org/pypy/pypy-5.0.0-linux.tar.bz2#a9cc9afa94ff1cde811626a70081c477c9840e7816c0562d1903fd823d222ceb" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.0-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0-linux_i686-portable.tar.bz2#316e03afdd2f6212857789933c01f0d41a1665c80d28526c0fb4082b6d3f4f60" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.0-linux_i686-portable.tar.bz2#316e03afdd2f6212857789933c01f0d41a1665c80d28526c0fb4082b6d3f4f60" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -30,7 +30,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy-5.0.0-linux64" "https://downloads.python.org/pypy/pypy-5.0.0-linux64.tar.bz2#b9c73be8e3c3b0835df83bdb86335712005240071cdd4dc245ac30b457063ae0" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0-linux_x86_64-portable.tar.bz2#57c9ea251bf1e7074e14aeecdd1ac8bb2fc53dbf3f90a9613d03e33076a7fa08" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.0-linux_x86_64-portable.tar.bz2#57c9ea251bf1e7074e14aeecdd1ac8bb2fc53dbf3f90a9613d03e33076a7fa08" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-5.0.0
+++ b/plugins/python-build/share/python-build/pypy-5.0.0
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-  install_package "pypy-5.0.0-linux" "https://downloads.python.org/pypy/pypy-5.0.0-linux.tar.bz2#a9cc9afa94ff1cde811626a70081c477c9840e7816c0562d1903fd823d222ceb" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.0.0-linux" "https://downloads.python.org/pypy/pypy-5.0.0-linux.tar.bz2#a9cc9afa94ff1cde811626a70081c477c9840e7816c0562d1903fd823d222ceb" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.0-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.0-linux_i686-portable.tar.bz2#316e03afdd2f6212857789933c01f0d41a1665c80d28526c0fb4082b6d3f4f60" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.0-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.0-linux_i686-portable.tar.bz2#316e03afdd2f6212857789933c01f0d41a1665c80d28526c0fb4082b6d3f4f60" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,25 +12,25 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-5.0.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-5.0.0-linux-armhf-raspbian.tar.bz2#8033c0cc39e9f6771688f2eda95c726595f5453b3e73e1cd5f7ebbe3dae1f685" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.0.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-5.0.0-linux-armhf-raspbian.tar.bz2#8033c0cc39e9f6771688f2eda95c726595f5453b3e73e1cd5f7ebbe3dae1f685" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-5.0.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-5.0.0-linux-armhf-raring.tar.bz2#5bb52cf5db4ae8497c4e03cd8a70e49867e6b93d9f29ad335d030fcd3a375769" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.0.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-5.0.0-linux-armhf-raring.tar.bz2#5bb52cf5db4ae8497c4e03cd8a70e49867e6b93d9f29ad335d030fcd3a375769" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-ppc64" )
  require_distro "Fedora 20" || true
-  install_package "pypy-5.0.0-ppc64" "https://downloads.python.org/pypy/pypy-5.0.0-ppc64.tar.bz2#334a37e68cb543cf2cbcdd12379b9b770064bb70ba7fd104f1e451cfa10cdda5" "pypy" verify_py27 ensurepip
+ install_package "pypy-5.0.0-ppc64" "https://downloads.python.org/pypy/pypy-5.0.0-ppc64.tar.bz2#334a37e68cb543cf2cbcdd12379b9b770064bb70ba7fd104f1e451cfa10cdda5" "pypy" verify_py27 ensurepip
  ;;
 "linux-ppc64le" )
  require_distro "Fedora 21" || true
-  install_package "pypy-5.0.0-ppc64le" "https://downloads.python.org/pypy/pypy-5.0.0-ppc64le.tar.bz2#e72fe5c094186f79c997000ddbaa01616def652a8d1338b75a27dfa3755eb86c" "pypy" verify_py27 ensurepip
+ install_package "pypy-5.0.0-ppc64le" "https://downloads.python.org/pypy/pypy-5.0.0-ppc64le.tar.bz2#e72fe5c094186f79c997000ddbaa01616def652a8d1338b75a27dfa3755eb86c" "pypy" verify_py27 ensurepip
  ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy-5.0.0-linux64" "https://downloads.python.org/pypy/pypy-5.0.0-linux64.tar.bz2#b9c73be8e3c3b0835df83bdb86335712005240071cdd4dc245ac30b457063ae0" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.0.0-linux64" "https://downloads.python.org/pypy/pypy-5.0.0-linux64.tar.bz2#b9c73be8e3c3b0835df83bdb86335712005240071cdd4dc245ac30b457063ae0" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.0-linux_x86_64-portable.tar.bz2#57c9ea251bf1e7074e14aeecdd1ac8bb2fc53dbf3f90a9613d03e33076a7fa08" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.0-linux_x86_64-portable.tar.bz2#57c9ea251bf1e7074e14aeecdd1ac8bb2fc53dbf3f90a9613d03e33076a7fa08" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-5.0.0-src
+++ b/plugins/python-build/share/python-build/pypy-5.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-5.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-src.tar.bz2#89027b1b33553b53ff7733dc4838f0a76af23552c0d915d9f6de5875b8d7d4ab" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-5.0.0-src" "https://downloads.python.org/pypy/pypy-5.0.0-src.tar.bz2#89027b1b33553b53ff7733dc4838f0a76af23552c0d915d9f6de5875b8d7d4ab" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.0.0-src
+++ b/plugins/python-build/share/python-build/pypy-5.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-5.0.0-src" "https://downloads.python.org/pypy/pypy-5.0.0-src.tar.bz2#89027b1b33553b53ff7733dc4838f0a76af23552c0d915d9f6de5875b8d7d4ab" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-5.0.0-src" "https://downloads.python.org/pypy/pypy-5.0.0-src.tar.bz2#89027b1b33553b53ff7733dc4838f0a76af23552c0d915d9f6de5875b8d7d4ab" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.0.1
+++ b/plugins/python-build/share/python-build/pypy-5.0.1
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.0.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux.tar.bz2#4b9a294033f917a1674c9ddcb2e7e8d32c4f4351f8216fd1fe23f6d2ad2b1a36" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0.1-linux" "https://downloads.python.org/pypy/pypy-5.0.1-linux.tar.bz2#4b9a294033f917a1674c9ddcb2e7e8d32c4f4351f8216fd1fe23f6d2ad2b1a36" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.0.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0.1-linux_i686-portable.tar.bz2#96f1b487655c914a03f56747dfff9c20350175cae01e2911f19b1016442ed6b5" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-5.0.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux-armel.tar.bz2#17d55804b2253acd9de42276d756d4a08b7d1d2da09ef81dd325e14b18a1bcda" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0.1-linux-armel" "https://downloads.python.org/pypy/pypy-5.0.1-linux-armel.tar.bz2#17d55804b2253acd9de42276d756d4a08b7d1d2da09ef81dd325e14b18a1bcda" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-5.0.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux-armhf-raspbian.tar.bz2#338d1c32c1326e6321b222ae357711b38c4a0ffddf020c2a35536b5f69376e28" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-5.0.1-linux-armhf-raspbian.tar.bz2#338d1c32c1326e6321b222ae357711b38c4a0ffddf020c2a35536b5f69376e28" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-5.0.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux-armhf-raring.tar.bz2#1e9146978cc7e7bd30683a518f304a824db7b9b1c6fae5e866eb703684ba3c98" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-5.0.1-linux-armhf-raring.tar.bz2#1e9146978cc7e7bd30683a518f304a824db7b9b1c6fae5e866eb703684ba3c98" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.0.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux64.tar.bz2#1b1363a48edd1c1b31ca5e995987eda3d460a3404f36c3bb2dd9f52c93eecff5" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0.1-linux64" "https://downloads.python.org/pypy/pypy-5.0.1-linux64.tar.bz2#1b1363a48edd1c1b31ca5e995987eda3d460a3404f36c3bb2dd9f52c93eecff5" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.0.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0.1-linux_x86_64-portable.tar.bz2#14d65f84fe8228cfa2b8e924364cf4c71e2bc6b13649098fa340baf044606436" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-5.0.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-osx64.tar.bz2#6ebdb9d91203f053b38e3c21841c11a72f416dc185f7b3b7c908229df15e924a" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0.1-osx64" "https://downloads.python.org/pypy/pypy-5.0.1-osx64.tar.bz2#6ebdb9d91203f053b38e3c21841c11a72f416dc185f7b3b7c908229df15e924a" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-5.0.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-win32.zip#c12254d8b1747322736d26e014744a426c6900d232c1799140fbb43f44319730" "pypy" verify_py27 ensurepip
+  install_zip "pypy-5.0.1-win32" "https://downloads.python.org/pypy/pypy-5.0.1-win32.zip#c12254d8b1747322736d26e014744a426c6900d232c1799140fbb43f44319730" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-5.0.1
+++ b/plugins/python-build/share/python-build/pypy-5.0.1
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
   install_package "pypy-5.0.1-linux" "https://downloads.python.org/pypy/pypy-5.0.1-linux.tar.bz2#4b9a294033f917a1674c9ddcb2e7e8d32c4f4351f8216fd1fe23f6d2ad2b1a36" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.0.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0.1-linux_i686-portable.tar.bz2#96f1b487655c914a03f56747dfff9c20350175cae01e2911f19b1016442ed6b5" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.0.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.0.1-linux_i686-portable.tar.bz2#96f1b487655c914a03f56747dfff9c20350175cae01e2911f19b1016442ed6b5" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )

--- a/plugins/python-build/share/python-build/pypy-5.0.1
+++ b/plugins/python-build/share/python-build/pypy-5.0.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-  install_package "pypy-5.0.1-linux" "https://downloads.python.org/pypy/pypy-5.0.1-linux.tar.bz2#4b9a294033f917a1674c9ddcb2e7e8d32c4f4351f8216fd1fe23f6d2ad2b1a36" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.0.1-linux" "https://downloads.python.org/pypy/pypy-5.0.1-linux.tar.bz2#4b9a294033f917a1674c9ddcb2e7e8d32c4f4351f8216fd1fe23f6d2ad2b1a36" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.0.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.0.1-linux_i686-portable.tar.bz2#96f1b487655c914a03f56747dfff9c20350175cae01e2911f19b1016442ed6b5" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.0.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.0.1-linux_i686-portable.tar.bz2#96f1b487655c914a03f56747dfff9c20350175cae01e2911f19b1016442ed6b5" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,15 +12,15 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-5.0.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-5.0.1-linux-armhf-raspbian.tar.bz2#338d1c32c1326e6321b222ae357711b38c4a0ffddf020c2a35536b5f69376e28" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.0.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-5.0.1-linux-armhf-raspbian.tar.bz2#338d1c32c1326e6321b222ae357711b38c4a0ffddf020c2a35536b5f69376e28" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-5.0.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-5.0.1-linux-armhf-raring.tar.bz2#1e9146978cc7e7bd30683a518f304a824db7b9b1c6fae5e866eb703684ba3c98" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.0.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-5.0.1-linux-armhf-raring.tar.bz2#1e9146978cc7e7bd30683a518f304a824db7b9b1c6fae5e866eb703684ba3c98" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy-5.0.1-linux64" "https://downloads.python.org/pypy/pypy-5.0.1-linux64.tar.bz2#1b1363a48edd1c1b31ca5e995987eda3d460a3404f36c3bb2dd9f52c93eecff5" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.0.1-linux64" "https://downloads.python.org/pypy/pypy-5.0.1-linux64.tar.bz2#1b1363a48edd1c1b31ca5e995987eda3d460a3404f36c3bb2dd9f52c93eecff5" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.0.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0.1-linux_x86_64-portable.tar.bz2#14d65f84fe8228cfa2b8e924364cf4c71e2bc6b13649098fa340baf044606436" "pypy" verify_py27 ensurepip
   fi

--- a/plugins/python-build/share/python-build/pypy-5.0.1-src
+++ b/plugins/python-build/share/python-build/pypy-5.0.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-5.0.1-src" "https://downloads.python.org/pypy/pypy-5.0.1-src.tar.bz2#1573c9284d3ec236c8e6ef3b954753932dff29462c54b5885b761d1ee68b6e05" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-5.0.1-src" "https://downloads.python.org/pypy/pypy-5.0.1-src.tar.bz2#1573c9284d3ec236c8e6ef3b954753932dff29462c54b5885b761d1ee68b6e05" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.0.1-src
+++ b/plugins/python-build/share/python-build/pypy-5.0.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-5.0.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-src.tar.bz2#1573c9284d3ec236c8e6ef3b954753932dff29462c54b5885b761d1ee68b6e05" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-5.0.1-src" "https://downloads.python.org/pypy/pypy-5.0.1-src.tar.bz2#1573c9284d3ec236c8e6ef3b954753932dff29462c54b5885b761d1ee68b6e05" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.1
+++ b/plugins/python-build/share/python-build/pypy-5.1
@@ -1,44 +1,44 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.1.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-linux.tar.bz2#2f6c521b5b3c1082eab58be78655aa01ec400d19baeec93c455864a7483b8744" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1.0-linux" "https://downloads.python.org/pypy/pypy-5.1.0-linux.tar.bz2#2f6c521b5b3c1082eab58be78655aa01ec400d19baeec93c455864a7483b8744" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1-linux_i686-portable.tar.bz2#893507603a58b8983b69924e60591de39b8f71f70ba36d6e3894db8f7c49c3ea" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-5.1.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-linux-armel.tar.bz2#ea7017449ff0630431866423220c3688fc55c1a0b80a96af0ae138dd0751b81c" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1.0-linux-armel" "https://downloads.python.org/pypy/pypy-5.1.0-linux-armel.tar.bz2#ea7017449ff0630431866423220c3688fc55c1a0b80a96af0ae138dd0751b81c" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-5.1.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-linux-armhf-raspbian.tar.bz2#3bfcd251b4f3fd1a09520b2741c647c364d16d50c82b813732a78ac60ccb2b69" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-5.1.0-linux-armhf-raspbian.tar.bz2#3bfcd251b4f3fd1a09520b2741c647c364d16d50c82b813732a78ac60ccb2b69" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-5.1.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-linux-armhf-raring.tar.bz2#a3e13083591bccc301fb974ff0a6c7e4ab4e611e4b31c0932898b981c794462b" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-5.1.0-linux-armhf-raring.tar.bz2#a3e13083591bccc301fb974ff0a6c7e4ab4e611e4b31c0932898b981c794462b" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-ppc64" )
   require_distro "Fedora 20" || true
-  install_package "pypy-5.1.0-ppc64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-ppc64.tar.bz2#32a31b9ff5174d69f8cf8db711ba2a593fed49b52bdf590bcecd6b727419b6df" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1.0-ppc64" "https://downloads.python.org/pypy/pypy-5.1.0-ppc64.tar.bz2#32a31b9ff5174d69f8cf8db711ba2a593fed49b52bdf590bcecd6b727419b6df" "pypy" verify_py27 ensurepip
   ;;
 "linux-ppc64le" )
   require_distro "Fedora 21" || true
-  install_package "pypy-5.1.0-ppc64le" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-ppc64le.tar.bz2#303764f44154f81d7f0753258c89f8a14653658911a16ec2bcfee04055cbfab6" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1.0-ppc64le" "https://downloads.python.org/pypy/pypy-5.1.0-ppc64le.tar.bz2#303764f44154f81d7f0753258c89f8a14653658911a16ec2bcfee04055cbfab6" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.1.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-linux64.tar.bz2#0e8913351d043a50740b98cb89d99852b8bd6d11225a41c8abfc0baf7084cbf6" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1.0-linux64" "https://downloads.python.org/pypy/pypy-5.1.0-linux64.tar.bz2#0e8913351d043a50740b98cb89d99852b8bd6d11225a41c8abfc0baf7084cbf6" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1-linux_x86_64-portable.tar.bz2#b2df9b0127457d1c3cc0dc9b8f027a53569ccd3ba5a79012d641e576d9cc003a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-5.1.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-osx64.tar.bz2#7e270c66347158dd794c101c4817f742f760ed805aa0d10abe19ba4a78a75118" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1.0-osx64" "https://downloads.python.org/pypy/pypy-5.1.0-osx64.tar.bz2#7e270c66347158dd794c101c4817f742f760ed805aa0d10abe19ba4a78a75118" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-5.1.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-win32.zip#044e7f35223a443412b5948740e60e93069a6f8b0a72053cc9d472874bb1b6cc" "pypy" verify_py27 ensurepip
+  install_zip "pypy-5.1.0-win32" "https://downloads.python.org/pypy/pypy-5.1.0-win32.zip#044e7f35223a443412b5948740e60e93069a6f8b0a72053cc9d472874bb1b6cc" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-5.1
+++ b/plugins/python-build/share/python-build/pypy-5.1
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy-5.1.0-linux" "https://downloads.python.org/pypy/pypy-5.1.0-linux.tar.bz2#2f6c521b5b3c1082eab58be78655aa01ec400d19baeec93c455864a7483b8744" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1-linux_i686-portable.tar.bz2#893507603a58b8983b69924e60591de39b8f71f70ba36d6e3894db8f7c49c3ea" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.1-linux_i686-portable.tar.bz2#893507603a58b8983b69924e60591de39b8f71f70ba36d6e3894db8f7c49c3ea" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -30,7 +30,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy-5.1.0-linux64" "https://downloads.python.org/pypy/pypy-5.1.0-linux64.tar.bz2#0e8913351d043a50740b98cb89d99852b8bd6d11225a41c8abfc0baf7084cbf6" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1-linux_x86_64-portable.tar.bz2#b2df9b0127457d1c3cc0dc9b8f027a53569ccd3ba5a79012d641e576d9cc003a" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.1-linux_x86_64-portable.tar.bz2#b2df9b0127457d1c3cc0dc9b8f027a53569ccd3ba5a79012d641e576d9cc003a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-5.1
+++ b/plugins/python-build/share/python-build/pypy-5.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy-5.1.0-linux" "https://downloads.python.org/pypy/pypy-5.1.0-linux.tar.bz2#2f6c521b5b3c1082eab58be78655aa01ec400d19baeec93c455864a7483b8744" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.1.0-linux" "https://downloads.python.org/pypy/pypy-5.1.0-linux.tar.bz2#2f6c521b5b3c1082eab58be78655aa01ec400d19baeec93c455864a7483b8744" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.1-linux_i686-portable.tar.bz2#893507603a58b8983b69924e60591de39b8f71f70ba36d6e3894db8f7c49c3ea" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.1-linux_i686-portable.tar.bz2#893507603a58b8983b69924e60591de39b8f71f70ba36d6e3894db8f7c49c3ea" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,10 +12,10 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-5.1.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-5.1.0-linux-armhf-raspbian.tar.bz2#3bfcd251b4f3fd1a09520b2741c647c364d16d50c82b813732a78ac60ccb2b69" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.1.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-5.1.0-linux-armhf-raspbian.tar.bz2#3bfcd251b4f3fd1a09520b2741c647c364d16d50c82b813732a78ac60ccb2b69" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-5.1.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-5.1.0-linux-armhf-raring.tar.bz2#a3e13083591bccc301fb974ff0a6c7e4ab4e611e4b31c0932898b981c794462b" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.1.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-5.1.0-linux-armhf-raring.tar.bz2#a3e13083591bccc301fb974ff0a6c7e4ab4e611e4b31c0932898b981c794462b" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-ppc64" )
@@ -28,9 +28,9 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy-5.1.0-linux64" "https://downloads.python.org/pypy/pypy-5.1.0-linux64.tar.bz2#0e8913351d043a50740b98cb89d99852b8bd6d11225a41c8abfc0baf7084cbf6" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.1.0-linux64" "https://downloads.python.org/pypy/pypy-5.1.0-linux64.tar.bz2#0e8913351d043a50740b98cb89d99852b8bd6d11225a41c8abfc0baf7084cbf6" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.1-linux_x86_64-portable.tar.bz2#b2df9b0127457d1c3cc0dc9b8f027a53569ccd3ba5a79012d641e576d9cc003a" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.1-linux_x86_64-portable.tar.bz2#b2df9b0127457d1c3cc0dc9b8f027a53569ccd3ba5a79012d641e576d9cc003a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy-5.1-src
+++ b/plugins/python-build/share/python-build/pypy-5.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-5.1.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-src.tar.bz2#16bab9501e942c0704abbf9cd6c4e950c6a76dc226cf1e447ea084916aef4714" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-5.1.0-src" "https://downloads.python.org/pypy/pypy-5.1.0-src.tar.bz2#16bab9501e942c0704abbf9cd6c4e950c6a76dc226cf1e447ea084916aef4714" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.1-src
+++ b/plugins/python-build/share/python-build/pypy-5.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-5.1.0-src" "https://downloads.python.org/pypy/pypy-5.1.0-src.tar.bz2#16bab9501e942c0704abbf9cd6c4e950c6a76dc226cf1e447ea084916aef4714" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-5.1.0-src" "https://downloads.python.org/pypy/pypy-5.1.0-src.tar.bz2#16bab9501e942c0704abbf9cd6c4e950c6a76dc226cf1e447ea084916aef4714" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.1.1
+++ b/plugins/python-build/share/python-build/pypy-5.1.1
@@ -1,21 +1,21 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.1.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-linux.tar.bz2#7951fd2b87c9e621ec57c932c20da2b8a4a9e87d8daeb9e2b7373f9444219abc" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1.1-linux" "https://downloads.python.org/pypy/pypy-5.1.1-linux.tar.bz2#7951fd2b87c9e621ec57c932c20da2b8a4a9e87d8daeb9e2b7373f9444219abc" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.1.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1.1-linux_i686-portable.tar.bz2#f00faf426f41f9980344d03fd74bb949875c0cf86048ad762dd445f72353eb8f" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-5.1.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-linux-armel.tar.bz2#062b33641c24dfc8c6b5af955c2ddf3815b471de0af4bfc343020651b94d13bf" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1.1-linux-armel" "https://downloads.python.org/pypy/pypy-5.1.1-linux-armel.tar.bz2#062b33641c24dfc8c6b5af955c2ddf3815b471de0af4bfc343020651b94d13bf" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-5.1.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-linux-armhf-raspbian.tar.bz2#fc2a1f8719a7eca5d85d0bdcf499c6ab7409fc32aa312435bcbe66950b47e863" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-5.1.1-linux-armhf-raspbian.tar.bz2#fc2a1f8719a7eca5d85d0bdcf499c6ab7409fc32aa312435bcbe66950b47e863" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-5.1.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-linux-armhf-raring.tar.bz2#c4bcdabccd15669ea44d1c715cd36b2ca55b340a27b63e1a92ef5ab6eb158a8d" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-5.1.1-linux-armhf-raring.tar.bz2#c4bcdabccd15669ea44d1c715cd36b2ca55b340a27b63e1a92ef5ab6eb158a8d" "pypy" verify_py27 ensurepip
   fi
   ;;
 #"linux-ppc64" )
@@ -28,17 +28,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
 #  ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.1.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-linux64.tar.bz2#c852622e8bc81618c137da35fcf57b2349b956c07b6fd853300846e3cefa64fc" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1.1-linux64" "https://downloads.python.org/pypy/pypy-5.1.1-linux64.tar.bz2#c852622e8bc81618c137da35fcf57b2349b956c07b6fd853300846e3cefa64fc" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.1.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1.1-linux_x86_64-portable.tar.bz2#c0502d8db1cc2b81513cc6047813669b0a561cb20e41d60e179f51fe8657a794" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-5.1.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-osx64.tar.bz2#fe2bbb7cf95eb91b1724029f81e85d1dbb6025a2e9a005cfe7258fe07602f771" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1.1-osx64" "https://downloads.python.org/pypy/pypy-5.1.1-osx64.tar.bz2#fe2bbb7cf95eb91b1724029f81e85d1dbb6025a2e9a005cfe7258fe07602f771" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-5.1.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-win32.zip#22a780e328ef053e098f2edc2302957ac3119adf7bf11ff23e225931806e7bcd" "pypy" verify_py27 ensurepip
+  install_zip "pypy-5.1.1-win32" "https://downloads.python.org/pypy/pypy-5.1.1-win32.zip#22a780e328ef053e098f2edc2302957ac3119adf7bf11ff23e225931806e7bcd" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-5.1.1
+++ b/plugins/python-build/share/python-build/pypy-5.1.1
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy-5.1.1-linux" "https://downloads.python.org/pypy/pypy-5.1.1-linux.tar.bz2#7951fd2b87c9e621ec57c932c20da2b8a4a9e87d8daeb9e2b7373f9444219abc" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.1.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1.1-linux_i686-portable.tar.bz2#f00faf426f41f9980344d03fd74bb949875c0cf86048ad762dd445f72353eb8f" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.1.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.1.1-linux_i686-portable.tar.bz2#f00faf426f41f9980344d03fd74bb949875c0cf86048ad762dd445f72353eb8f" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )

--- a/plugins/python-build/share/python-build/pypy-5.1.1
+++ b/plugins/python-build/share/python-build/pypy-5.1.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy-5.1.1-linux" "https://downloads.python.org/pypy/pypy-5.1.1-linux.tar.bz2#7951fd2b87c9e621ec57c932c20da2b8a4a9e87d8daeb9e2b7373f9444219abc" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.1.1-linux" "https://downloads.python.org/pypy/pypy-5.1.1-linux.tar.bz2#7951fd2b87c9e621ec57c932c20da2b8a4a9e87d8daeb9e2b7373f9444219abc" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.1.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.1.1-linux_i686-portable.tar.bz2#f00faf426f41f9980344d03fd74bb949875c0cf86048ad762dd445f72353eb8f" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.1.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.1.1-linux_i686-portable.tar.bz2#f00faf426f41f9980344d03fd74bb949875c0cf86048ad762dd445f72353eb8f" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,10 +12,10 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy-5.1.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-5.1.1-linux-armhf-raspbian.tar.bz2#fc2a1f8719a7eca5d85d0bdcf499c6ab7409fc32aa312435bcbe66950b47e863" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.1.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy-5.1.1-linux-armhf-raspbian.tar.bz2#fc2a1f8719a7eca5d85d0bdcf499c6ab7409fc32aa312435bcbe66950b47e863" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy-5.1.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-5.1.1-linux-armhf-raring.tar.bz2#c4bcdabccd15669ea44d1c715cd36b2ca55b340a27b63e1a92ef5ab6eb158a8d" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.1.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy-5.1.1-linux-armhf-raring.tar.bz2#c4bcdabccd15669ea44d1c715cd36b2ca55b340a27b63e1a92ef5ab6eb158a8d" "pypy" verify_py27 ensurepip
   fi
   ;;
 #"linux-ppc64" )
@@ -28,7 +28,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
 #  ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy-5.1.1-linux64" "https://downloads.python.org/pypy/pypy-5.1.1-linux64.tar.bz2#c852622e8bc81618c137da35fcf57b2349b956c07b6fd853300846e3cefa64fc" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.1.1-linux64" "https://downloads.python.org/pypy/pypy-5.1.1-linux64.tar.bz2#c852622e8bc81618c137da35fcf57b2349b956c07b6fd853300846e3cefa64fc" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.1.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1.1-linux_x86_64-portable.tar.bz2#c0502d8db1cc2b81513cc6047813669b0a561cb20e41d60e179f51fe8657a794" "pypy" verify_py27 ensurepip
   fi

--- a/plugins/python-build/share/python-build/pypy-5.1.1-src
+++ b/plugins/python-build/share/python-build/pypy-5.1.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy-5.1.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-src.tar.bz2#ca3d943d7fbd78bb957ee9e5833ada4bb8506ac99a41b7628790e286a65ed2be" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy-5.1.1-src" "https://downloads.python.org/pypy/pypy-5.1.1-src.tar.bz2#ca3d943d7fbd78bb957ee9e5833ada4bb8506ac99a41b7628790e286a65ed2be" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.1.1-src
+++ b/plugins/python-build/share/python-build/pypy-5.1.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy-5.1.1-src" "https://downloads.python.org/pypy/pypy-5.1.1-src.tar.bz2#ca3d943d7fbd78bb957ee9e5833ada4bb8506ac99a41b7628790e286a65ed2be" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-5.1.1-src" "https://downloads.python.org/pypy/pypy-5.1.1-src.tar.bz2#ca3d943d7fbd78bb957ee9e5833ada4bb8506ac99a41b7628790e286a65ed2be" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-stm-2.3
+++ b/plugins/python-build/share/python-build/pypy-stm-2.3
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
   require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" || true
-  install_package "pypy-stm-2.3-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-stm-2.3-linux64.tar.bz2#2a489280c679503442219782a87a2d16504a1467cac85ad4be1361a21d1f4d54" "pypy" verify_py27 ensurepip
+  install_package "pypy-stm-2.3-linux64" "https://downloads.python.org/pypy/pypy-stm-2.3-linux64.tar.bz2#2a489280c679503442219782a87a2d16504a1467cac85ad4be1361a21d1f4d54" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-stm-2.5.1
+++ b/plugins/python-build/share/python-build/pypy-stm-2.5.1
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
   require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" || true
-  install_package "pypy-stm-2.5.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-stm-2.5.1-linux64.tar.bz2#f280788002f2acf8690b8f9c479bb5b6f0e699ebb42f8bf203da3f70f1a38134" "pypy" verify_py27 ensurepip
+  install_package "pypy-stm-2.5.1-linux64" "https://downloads.python.org/pypy/pypy-stm-2.5.1-linux64.tar.bz2#f280788002f2acf8690b8f9c479bb5b6f0e699ebb42f8bf203da3f70f1a38134" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2-5.3
+++ b/plugins/python-build/share/python-build/pypy2-5.3
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.3.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-linux32.tar.bz2#bd422fe9d0b7d525d1da3f32855b047bc39ba397d0cf708d8f4f96fe874424f2" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.3.0-linux" "https://downloads.python.org/pypy/pypy2-v5.3.0-linux32.tar.bz2#bd422fe9d0b7d525d1da3f32855b047bc39ba397d0cf708d8f4f96fe874424f2" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,19 +14,19 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy2-v5.3.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-linux-armel.tar.bz2#81b6f589a947d7353bb69408c46d4833d6e9cb501f3c3f0c73bd28d0e3df69aa" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.3.0-linux-armel" "https://downloads.python.org/pypy/pypy2-v5.3.0-linux-armel.tar.bz2#81b6f589a947d7353bb69408c46d4833d6e9cb501f3c3f0c73bd28d0e3df69aa" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy2-v5.3.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-linux-armhf-raspbian.tar.bz2#87b3566b6bbb8bf31c2f0d72bf31d95142fdce004d987812336a59d788005bed" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.3.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.3.0-linux-armhf-raspbian.tar.bz2#87b3566b6bbb8bf31c2f0d72bf31d95142fdce004d987812336a59d788005bed" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy2-v5.3.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-linux-armhf-raring.tar.bz2#bdb911a87e773a292334061b9c33b907f46d987e403fe94cc627a3b9b1c9cb19" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.3.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.3.0-linux-armhf-raring.tar.bz2#bdb911a87e773a292334061b9c33b907f46d987e403fe94cc627a3b9b1c9cb19" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.3.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-linux64.tar.bz2#ac336e8877ed676bf87a9a546d5926b6afc4679fa2d3fdf9f3ca56f28ec40588" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.3.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.3.0-linux64.tar.bz2#ac336e8877ed676bf87a9a546d5926b6afc4679fa2d3fdf9f3ca56f28ec40588" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -38,11 +38,11 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "osx64" )
-  install_package "pypy2-v5.3.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-osx64.tar.bz2#1b103bacbdcdbbc490660ec0c7b3d99d1ff1cfc2f13cd403db21c27f03d36a1d" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.3.0-osx64" "https://downloads.python.org/pypy/pypy2-v5.3.0-osx64.tar.bz2#1b103bacbdcdbbc490660ec0c7b3d99d1ff1cfc2f13cd403db21c27f03d36a1d" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy2-v5.3.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-win32.zip#32a9e5286fc344165f63b529a9f84e521e9368e717c583488115654676428a20" "pypy" verify_py27 ensurepip
+  install_zip "pypy2-v5.3.0-win32" "https://downloads.python.org/pypy/pypy2-v5.3.0-win32.zip#32a9e5286fc344165f63b529a9f84e521e9368e717c583488115654676428a20" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2-5.3
+++ b/plugins/python-build/share/python-build/pypy2-5.3
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.3.0-linux" "https://downloads.python.org/pypy/pypy2-v5.3.0-linux32.tar.bz2#bd422fe9d0b7d525d1da3f32855b047bc39ba397d0cf708d8f4f96fe874424f2" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.3.0-linux" "https://downloads.python.org/pypy/pypy2-v5.3.0-linux32.tar.bz2#bd422fe9d0b7d525d1da3f32855b047bc39ba397d0cf708d8f4f96fe874424f2" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -18,15 +18,15 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy2-v5.3.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.3.0-linux-armhf-raspbian.tar.bz2#87b3566b6bbb8bf31c2f0d72bf31d95142fdce004d987812336a59d788005bed" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.3.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.3.0-linux-armhf-raspbian.tar.bz2#87b3566b6bbb8bf31c2f0d72bf31d95142fdce004d987812336a59d788005bed" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy2-v5.3.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.3.0-linux-armhf-raring.tar.bz2#bdb911a87e773a292334061b9c33b907f46d987e403fe94cc627a3b9b1c9cb19" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.3.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.3.0-linux-armhf-raring.tar.bz2#bdb911a87e773a292334061b9c33b907f46d987e403fe94cc627a3b9b1c9cb19" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.3.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.3.0-linux64.tar.bz2#ac336e8877ed676bf87a9a546d5926b6afc4679fa2d3fdf9f3ca56f28ec40588" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.3.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.3.0-linux64.tar.bz2#ac336e8877ed676bf87a9a546d5926b6afc4679fa2d3fdf9f3ca56f28ec40588" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"

--- a/plugins/python-build/share/python-build/pypy2-5.3-src
+++ b/plugins/python-build/share/python-build/pypy2-5.3-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2-v5.3.0-src" "https://downloads.python.org/pypy/pypy2-v5.3.0-src.tar.bz2#4142eb8f403810bc88a4911792bb5a502e152df95806e33e69050c828cd160d5" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2-v5.3.0-src" "https://downloads.python.org/pypy/pypy2-v5.3.0-src.tar.bz2#4142eb8f403810bc88a4911792bb5a502e152df95806e33e69050c828cd160d5" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.3-src
+++ b/plugins/python-build/share/python-build/pypy2-5.3-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2-v5.3.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-src.tar.bz2#4142eb8f403810bc88a4911792bb5a502e152df95806e33e69050c828cd160d5" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2-v5.3.0-src" "https://downloads.python.org/pypy/pypy2-v5.3.0-src.tar.bz2#4142eb8f403810bc88a4911792bb5a502e152df95806e33e69050c828cd160d5" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.3.1
+++ b/plugins/python-build/share/python-build/pypy2-5.3.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.3.1-linux" "https://downloads.python.org/pypy/pypy2-v5.3.1-linux32.tar.bz2#da69f4280b288e524387103eaa3eb4d036965724c3e546da27135c15a77bd2eb" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.3.1-linux" "https://downloads.python.org/pypy/pypy2-v5.3.1-linux32.tar.bz2#da69f4280b288e524387103eaa3eb4d036965724c3e546da27135c15a77bd2eb" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.3.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.3.1-linux_i686-portable.tar.bz2#4460dad6376406c221406676208abae989c126115b0f0b2e46c8b8a027bf978a" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.3.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.3.1-linux_i686-portable.tar.bz2#4460dad6376406c221406676208abae989c126115b0f0b2e46c8b8a027bf978a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,17 +12,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy2-v5.3.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.3.1-linux-armhf-raspbian.tar.bz2#5c93eb3c54fbb2c7d7332f775a096671512e590565e6051196bbc5039c5033b5" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.3.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.3.1-linux-armhf-raspbian.tar.bz2#5c93eb3c54fbb2c7d7332f775a096671512e590565e6051196bbc5039c5033b5" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy2-v5.3.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.3.1-linux-armhf-raring.tar.bz2#b4859496099bde4b17c1e56cc5749dcdcd25b4c68fde1d2ea426de84130e84cc" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.3.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.3.1-linux-armhf-raring.tar.bz2#b4859496099bde4b17c1e56cc5749dcdcd25b4c68fde1d2ea426de84130e84cc" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.3.1-linux64" "https://downloads.python.org/pypy/pypy2-v5.3.1-linux64.tar.bz2#6d0e8b14875b76b1e77f06a2ee3f1fb5015a645a951ba7a7586289344d4d9c22" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.3.1-linux64" "https://downloads.python.org/pypy/pypy2-v5.3.1-linux64.tar.bz2#6d0e8b14875b76b1e77f06a2ee3f1fb5015a645a951ba7a7586289344d4d9c22" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.3.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.3.1-linux_x86_64-portable.tar.bz2#73014c3840609a62c0984b9c383652097f0a8c52fb74dd9de70d9df2a9a743ff" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.3.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.3.1-linux_x86_64-portable.tar.bz2#73014c3840609a62c0984b9c383652097f0a8c52fb74dd9de70d9df2a9a743ff" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2-5.3.1
+++ b/plugins/python-build/share/python-build/pypy2-5.3.1
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.3.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-linux32.tar.bz2#da69f4280b288e524387103eaa3eb4d036965724c3e546da27135c15a77bd2eb" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.3.1-linux" "https://downloads.python.org/pypy/pypy2-v5.3.1-linux32.tar.bz2#da69f4280b288e524387103eaa3eb4d036965724c3e546da27135c15a77bd2eb" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.3.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.3.1-linux_i686-portable.tar.bz2#4460dad6376406c221406676208abae989c126115b0f0b2e46c8b8a027bf978a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy2-v5.3.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-linux-armel.tar.bz2#0425f2022c35ef7f0bb3d2b854c5bcbe500b1aba511a0d83581ba6c784913961" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.3.1-linux-armel" "https://downloads.python.org/pypy/pypy2-v5.3.1-linux-armel.tar.bz2#0425f2022c35ef7f0bb3d2b854c5bcbe500b1aba511a0d83581ba6c784913961" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy2-v5.3.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-linux-armhf-raspbian.tar.bz2#5c93eb3c54fbb2c7d7332f775a096671512e590565e6051196bbc5039c5033b5" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.3.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.3.1-linux-armhf-raspbian.tar.bz2#5c93eb3c54fbb2c7d7332f775a096671512e590565e6051196bbc5039c5033b5" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy2-v5.3.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-linux-armhf-raring.tar.bz2#b4859496099bde4b17c1e56cc5749dcdcd25b4c68fde1d2ea426de84130e84cc" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.3.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.3.1-linux-armhf-raring.tar.bz2#b4859496099bde4b17c1e56cc5749dcdcd25b4c68fde1d2ea426de84130e84cc" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.3.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-linux64.tar.bz2#6d0e8b14875b76b1e77f06a2ee3f1fb5015a645a951ba7a7586289344d4d9c22" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.3.1-linux64" "https://downloads.python.org/pypy/pypy2-v5.3.1-linux64.tar.bz2#6d0e8b14875b76b1e77f06a2ee3f1fb5015a645a951ba7a7586289344d4d9c22" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.3.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.3.1-linux_x86_64-portable.tar.bz2#73014c3840609a62c0984b9c383652097f0a8c52fb74dd9de70d9df2a9a743ff" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy2-v5.3.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-osx64.tar.bz2#7a242d7373b4f18c7f5fe6c2fe6f15e2a405d9adf1f4f934c89b875e60ac5def" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.3.1-osx64" "https://downloads.python.org/pypy/pypy2-v5.3.1-osx64.tar.bz2#7a242d7373b4f18c7f5fe6c2fe6f15e2a405d9adf1f4f934c89b875e60ac5def" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy2-v5.3.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-win32.zip#d83477e2c5f032ebd8c7f47afce03dc8adbeb41a3c74f7db50d9de317dcf3a4a" "pypy" verify_py27 ensurepip
+  install_zip "pypy2-v5.3.1-win32" "https://downloads.python.org/pypy/pypy2-v5.3.1-win32.zip#d83477e2c5f032ebd8c7f47afce03dc8adbeb41a3c74f7db50d9de317dcf3a4a" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2-5.3.1
+++ b/plugins/python-build/share/python-build/pypy2-5.3.1
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy2-v5.3.1-linux" "https://downloads.python.org/pypy/pypy2-v5.3.1-linux32.tar.bz2#da69f4280b288e524387103eaa3eb4d036965724c3e546da27135c15a77bd2eb" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.3.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.3.1-linux_i686-portable.tar.bz2#4460dad6376406c221406676208abae989c126115b0f0b2e46c8b8a027bf978a" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.3.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.3.1-linux_i686-portable.tar.bz2#4460dad6376406c221406676208abae989c126115b0f0b2e46c8b8a027bf978a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -22,7 +22,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy2-v5.3.1-linux64" "https://downloads.python.org/pypy/pypy2-v5.3.1-linux64.tar.bz2#6d0e8b14875b76b1e77f06a2ee3f1fb5015a645a951ba7a7586289344d4d9c22" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.3.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.3.1-linux_x86_64-portable.tar.bz2#73014c3840609a62c0984b9c383652097f0a8c52fb74dd9de70d9df2a9a743ff" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.3.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.3.1-linux_x86_64-portable.tar.bz2#73014c3840609a62c0984b9c383652097f0a8c52fb74dd9de70d9df2a9a743ff" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2-5.3.1-src
+++ b/plugins/python-build/share/python-build/pypy2-5.3.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2-v5.3.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-src.tar.bz2#31a52bab584abf3a0f0defd1bf9a29131dab08df43885e7eeddfc7dc9b71836e" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2-v5.3.1-src" "https://downloads.python.org/pypy/pypy2-v5.3.1-src.tar.bz2#31a52bab584abf3a0f0defd1bf9a29131dab08df43885e7eeddfc7dc9b71836e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.3.1-src
+++ b/plugins/python-build/share/python-build/pypy2-5.3.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2-v5.3.1-src" "https://downloads.python.org/pypy/pypy2-v5.3.1-src.tar.bz2#31a52bab584abf3a0f0defd1bf9a29131dab08df43885e7eeddfc7dc9b71836e" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2-v5.3.1-src" "https://downloads.python.org/pypy/pypy2-v5.3.1-src.tar.bz2#31a52bab584abf3a0f0defd1bf9a29131dab08df43885e7eeddfc7dc9b71836e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.4
+++ b/plugins/python-build/share/python-build/pypy2-5.4
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.4.0-linux" "https://downloads.python.org/pypy/pypy2-v5.4.0-linux32.tar.bz2#ce581270464b14cdecd13dedb9bd7bf98232f767ac4ac282229a405d8e807af1" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.4.0-linux" "https://downloads.python.org/pypy/pypy2-v5.4.0-linux32.tar.bz2#ce581270464b14cdecd13dedb9bd7bf98232f767ac4ac282229a405d8e807af1" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.4-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.4-linux_i686-portable.tar.bz2#7d7d253f009bb2624f43db6b8caeeb73d29177c4166a643a581a231a099c8689" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.4-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.4-linux_i686-portable.tar.bz2#7d7d253f009bb2624f43db6b8caeeb73d29177c4166a643a581a231a099c8689" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,17 +12,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy2-v5.4.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.4.0-linux-armhf-raspbian.tar.bz2#839b08db89b7e20cb670b8cf02596e033ea0b76fb8336af7bedfbb04b6b502da" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.4.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.4.0-linux-armhf-raspbian.tar.bz2#839b08db89b7e20cb670b8cf02596e033ea0b76fb8336af7bedfbb04b6b502da" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy2-v5.4.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.4.0-linux-armhf-raring.tar.bz2#95c690bcae6771ebce6cf06c7c2842e0662e007e35162afc963337aa597b471a" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.4.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.4.0-linux-armhf-raring.tar.bz2#95c690bcae6771ebce6cf06c7c2842e0662e007e35162afc963337aa597b471a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.4.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.4.0-linux64.tar.bz2#bdfea513d59dcd580970cb6f79f3a250d00191fd46b68133d5327e924ca845f8" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.4.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.4.0-linux64.tar.bz2#bdfea513d59dcd580970cb6f79f3a250d00191fd46b68133d5327e924ca845f8" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.4-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.4-linux_x86_64-portable.tar.bz2#0a48c7ba7163589b1ade9cfe184f422d1bc9a0f988321b2fdcbd924d90594d9a" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.4-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.4-linux_x86_64-portable.tar.bz2#0a48c7ba7163589b1ade9cfe184f422d1bc9a0f988321b2fdcbd924d90594d9a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2-5.4
+++ b/plugins/python-build/share/python-build/pypy2-5.4
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.4.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.0-linux32.tar.bz2#ce581270464b14cdecd13dedb9bd7bf98232f767ac4ac282229a405d8e807af1" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.4.0-linux" "https://downloads.python.org/pypy/pypy2-v5.4.0-linux32.tar.bz2#ce581270464b14cdecd13dedb9bd7bf98232f767ac4ac282229a405d8e807af1" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.4-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.4-linux_i686-portable.tar.bz2#7d7d253f009bb2624f43db6b8caeeb73d29177c4166a643a581a231a099c8689" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy2-v5.4.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.0-linux-armel.tar.bz2#04509044f21bb41ee6d3fafcf637fc0c586c248d4cdae6ac3357606a7b660fdb" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.4.0-linux-armel" "https://downloads.python.org/pypy/pypy2-v5.4.0-linux-armel.tar.bz2#04509044f21bb41ee6d3fafcf637fc0c586c248d4cdae6ac3357606a7b660fdb" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy2-v5.4.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.0-linux-armhf-raspbian.tar.bz2#839b08db89b7e20cb670b8cf02596e033ea0b76fb8336af7bedfbb04b6b502da" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.4.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.4.0-linux-armhf-raspbian.tar.bz2#839b08db89b7e20cb670b8cf02596e033ea0b76fb8336af7bedfbb04b6b502da" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy2-v5.4.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.0-linux-armhf-raring.tar.bz2#95c690bcae6771ebce6cf06c7c2842e0662e007e35162afc963337aa597b471a" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.4.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.4.0-linux-armhf-raring.tar.bz2#95c690bcae6771ebce6cf06c7c2842e0662e007e35162afc963337aa597b471a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.4.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.0-linux64.tar.bz2#bdfea513d59dcd580970cb6f79f3a250d00191fd46b68133d5327e924ca845f8" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.4.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.4.0-linux64.tar.bz2#bdfea513d59dcd580970cb6f79f3a250d00191fd46b68133d5327e924ca845f8" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.4-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.4-linux_x86_64-portable.tar.bz2#0a48c7ba7163589b1ade9cfe184f422d1bc9a0f988321b2fdcbd924d90594d9a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy2-v5.4.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.0-osx64.tar.bz2#3adf21c2bf3432759c99123f21240d71a72aba81d73129e48ef912c34631b723" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.4.0-osx64" "https://downloads.python.org/pypy/pypy2-v5.4.0-osx64.tar.bz2#3adf21c2bf3432759c99123f21240d71a72aba81d73129e48ef912c34631b723" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy2-v5.4.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.0-win32.zip#442c0a917781b6155bf78d2648f1ccd9a36c321926a043f83efcea22a99960b4" "pypy" verify_py27 ensurepip
+  install_zip "pypy2-v5.4.0-win32" "https://downloads.python.org/pypy/pypy2-v5.4.0-win32.zip#442c0a917781b6155bf78d2648f1ccd9a36c321926a043f83efcea22a99960b4" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2-5.4
+++ b/plugins/python-build/share/python-build/pypy2-5.4
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy2-v5.4.0-linux" "https://downloads.python.org/pypy/pypy2-v5.4.0-linux32.tar.bz2#ce581270464b14cdecd13dedb9bd7bf98232f767ac4ac282229a405d8e807af1" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.4-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.4-linux_i686-portable.tar.bz2#7d7d253f009bb2624f43db6b8caeeb73d29177c4166a643a581a231a099c8689" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.4-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.4-linux_i686-portable.tar.bz2#7d7d253f009bb2624f43db6b8caeeb73d29177c4166a643a581a231a099c8689" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -22,7 +22,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy2-v5.4.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.4.0-linux64.tar.bz2#bdfea513d59dcd580970cb6f79f3a250d00191fd46b68133d5327e924ca845f8" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.4-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.4-linux_x86_64-portable.tar.bz2#0a48c7ba7163589b1ade9cfe184f422d1bc9a0f988321b2fdcbd924d90594d9a" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.4-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.4-linux_x86_64-portable.tar.bz2#0a48c7ba7163589b1ade9cfe184f422d1bc9a0f988321b2fdcbd924d90594d9a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2-5.4-src
+++ b/plugins/python-build/share/python-build/pypy2-5.4-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2-v5.4.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.0-src.tar.bz2#d9568ebe9a14d0eaefde887d78f3cba63d665e95c0d234bb583932341f55a655" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2-v5.4.0-src" "https://downloads.python.org/pypy/pypy2-v5.4.0-src.tar.bz2#d9568ebe9a14d0eaefde887d78f3cba63d665e95c0d234bb583932341f55a655" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.4-src
+++ b/plugins/python-build/share/python-build/pypy2-5.4-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2-v5.4.0-src" "https://downloads.python.org/pypy/pypy2-v5.4.0-src.tar.bz2#d9568ebe9a14d0eaefde887d78f3cba63d665e95c0d234bb583932341f55a655" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2-v5.4.0-src" "https://downloads.python.org/pypy/pypy2-v5.4.0-src.tar.bz2#d9568ebe9a14d0eaefde887d78f3cba63d665e95c0d234bb583932341f55a655" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.4.1
+++ b/plugins/python-build/share/python-build/pypy2-5.4.1
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy2-v5.4.1-linux32" "https://downloads.python.org/pypy/pypy2-v5.4.1-linux32.tar.bz2#6d1e2386ec1e05dffed493aa2d5e6db5cf5de18d7350d44b85f2e45aa5c9a774" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.4.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.4.1-linux_i686-portable.tar.bz2#190e1df78886f0b2bd700f110b7d312d91cafc84886c5de3c5d55c10fe1a5e75" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.4.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.4.1-linux_i686-portable.tar.bz2#190e1df78886f0b2bd700f110b7d312d91cafc84886c5de3c5d55c10fe1a5e75" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -22,7 +22,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy2-v5.4.1-linux64" "https://downloads.python.org/pypy/pypy2-v5.4.1-linux64.tar.bz2#9c85319778224d7fb0c348f55fe3fada15bb579c5f3870a13ad63b42a737dd72" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.4.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.4.1-linux_x86_64-portable.tar.bz2#0b59f8e69c7883d454fce6364ab01a5ec6a481ed7f0cc0f1612c3b0c253f7da4" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.4.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.4.1-linux_x86_64-portable.tar.bz2#0b59f8e69c7883d454fce6364ab01a5ec6a481ed7f0cc0f1612c3b0c253f7da4" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2-5.4.1
+++ b/plugins/python-build/share/python-build/pypy2-5.4.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.4.1-linux32" "https://downloads.python.org/pypy/pypy2-v5.4.1-linux32.tar.bz2#6d1e2386ec1e05dffed493aa2d5e6db5cf5de18d7350d44b85f2e45aa5c9a774" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.4.1-linux32" "https://downloads.python.org/pypy/pypy2-v5.4.1-linux32.tar.bz2#6d1e2386ec1e05dffed493aa2d5e6db5cf5de18d7350d44b85f2e45aa5c9a774" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.4.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.4.1-linux_i686-portable.tar.bz2#190e1df78886f0b2bd700f110b7d312d91cafc84886c5de3c5d55c10fe1a5e75" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.4.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.4.1-linux_i686-portable.tar.bz2#190e1df78886f0b2bd700f110b7d312d91cafc84886c5de3c5d55c10fe1a5e75" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,17 +12,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy2-v5.4.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.4.1-linux-armhf-raspbian.tar.bz2#b38646519ee1a888c68f8f4713c122867b4b36693c8acabb38eb827a9d2d51f9" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.4.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.4.1-linux-armhf-raspbian.tar.bz2#b38646519ee1a888c68f8f4713c122867b4b36693c8acabb38eb827a9d2d51f9" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy2-v5.4.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.4.1-linux-armhf-raring.tar.bz2#2c4befc4517adec874155a8b6fa0b9d18388943d4ffe778002072db7783e417a" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.4.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.4.1-linux-armhf-raring.tar.bz2#2c4befc4517adec874155a8b6fa0b9d18388943d4ffe778002072db7783e417a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.4.1-linux64" "https://downloads.python.org/pypy/pypy2-v5.4.1-linux64.tar.bz2#9c85319778224d7fb0c348f55fe3fada15bb579c5f3870a13ad63b42a737dd72" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.4.1-linux64" "https://downloads.python.org/pypy/pypy2-v5.4.1-linux64.tar.bz2#9c85319778224d7fb0c348f55fe3fada15bb579c5f3870a13ad63b42a737dd72" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.4.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.4.1-linux_x86_64-portable.tar.bz2#0b59f8e69c7883d454fce6364ab01a5ec6a481ed7f0cc0f1612c3b0c253f7da4" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.4.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.4.1-linux_x86_64-portable.tar.bz2#0b59f8e69c7883d454fce6364ab01a5ec6a481ed7f0cc0f1612c3b0c253f7da4" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2-5.4.1
+++ b/plugins/python-build/share/python-build/pypy2-5.4.1
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.4.1-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.1-linux32.tar.bz2#6d1e2386ec1e05dffed493aa2d5e6db5cf5de18d7350d44b85f2e45aa5c9a774" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.4.1-linux32" "https://downloads.python.org/pypy/pypy2-v5.4.1-linux32.tar.bz2#6d1e2386ec1e05dffed493aa2d5e6db5cf5de18d7350d44b85f2e45aa5c9a774" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.4.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.4.1-linux_i686-portable.tar.bz2#190e1df78886f0b2bd700f110b7d312d91cafc84886c5de3c5d55c10fe1a5e75" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy2-v5.4.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.1-linux-armel.tar.bz2#a1eb5f672aae62606176305e52a51b060ba974b6181ebefcd2c555ecf5f8614f" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.4.1-linux-armel" "https://downloads.python.org/pypy/pypy2-v5.4.1-linux-armel.tar.bz2#a1eb5f672aae62606176305e52a51b060ba974b6181ebefcd2c555ecf5f8614f" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy2-v5.4.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.1-linux-armhf-raspbian.tar.bz2#b38646519ee1a888c68f8f4713c122867b4b36693c8acabb38eb827a9d2d51f9" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.4.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.4.1-linux-armhf-raspbian.tar.bz2#b38646519ee1a888c68f8f4713c122867b4b36693c8acabb38eb827a9d2d51f9" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy2-v5.4.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.1-linux-armhf-raring.tar.bz2#2c4befc4517adec874155a8b6fa0b9d18388943d4ffe778002072db7783e417a" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.4.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.4.1-linux-armhf-raring.tar.bz2#2c4befc4517adec874155a8b6fa0b9d18388943d4ffe778002072db7783e417a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.4.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.1-linux64.tar.bz2#9c85319778224d7fb0c348f55fe3fada15bb579c5f3870a13ad63b42a737dd72" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.4.1-linux64" "https://downloads.python.org/pypy/pypy2-v5.4.1-linux64.tar.bz2#9c85319778224d7fb0c348f55fe3fada15bb579c5f3870a13ad63b42a737dd72" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.4.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.4.1-linux_x86_64-portable.tar.bz2#0b59f8e69c7883d454fce6364ab01a5ec6a481ed7f0cc0f1612c3b0c253f7da4" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy2-v5.4.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.1-osx64.tar.bz2#ae9329c8f0a6df431c6224c27c634f998688ac803e8d100cee9a774e6bba38b5" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.4.1-osx64" "https://downloads.python.org/pypy/pypy2-v5.4.1-osx64.tar.bz2#ae9329c8f0a6df431c6224c27c634f998688ac803e8d100cee9a774e6bba38b5" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy2-v5.4.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.1-win32.zip#ec729218a820bc2aa2cf1fcacf9de0fee9e04144fe138596198a6b4615505e03" "pypy" verify_py27 ensurepip
+  install_zip "pypy2-v5.4.1-win32" "https://downloads.python.org/pypy/pypy2-v5.4.1-win32.zip#ec729218a820bc2aa2cf1fcacf9de0fee9e04144fe138596198a6b4615505e03" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2-5.4.1-src
+++ b/plugins/python-build/share/python-build/pypy2-5.4.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2-v5.4.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.1-src.tar.bz2#45dbc50c81498f6f1067201b8fc887074b43b84ee32cc47f15e7db17571e9352" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2-v5.4.1-src" "https://downloads.python.org/pypy/pypy2-v5.4.1-src.tar.bz2#45dbc50c81498f6f1067201b8fc887074b43b84ee32cc47f15e7db17571e9352" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.4.1-src
+++ b/plugins/python-build/share/python-build/pypy2-5.4.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2-v5.4.1-src" "https://downloads.python.org/pypy/pypy2-v5.4.1-src.tar.bz2#45dbc50c81498f6f1067201b8fc887074b43b84ee32cc47f15e7db17571e9352" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2-v5.4.1-src" "https://downloads.python.org/pypy/pypy2-v5.4.1-src.tar.bz2#45dbc50c81498f6f1067201b8fc887074b43b84ee32cc47f15e7db17571e9352" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.6.0
+++ b/plugins/python-build/share/python-build/pypy2-5.6.0
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.6.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.6.0-linux32.tar.bz2#5d4ad43aed5c5e147f7e7c84766c729f34f63b714b6d224e912a2bb42dc95d62" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.6.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.6.0-linux32.tar.bz2#5d4ad43aed5c5e147f7e7c84766c729f34f63b714b6d224e912a2bb42dc95d62" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.6-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.6-linux_i686-portable.tar.bz2#1f220e05ddd4423882794f0e9d3e2dfdecee259d00f1151a52dd244607313399" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.6-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.6-linux_i686-portable.tar.bz2#1f220e05ddd4423882794f0e9d3e2dfdecee259d00f1151a52dd244607313399" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,17 +12,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy2-v5.6.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.6.0-linux-armhf-raspbian.tar.bz2#0f69c40a38d72254bf12094620bda9d2face758f763cd0d989588642d81eccae" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.6.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.6.0-linux-armhf-raspbian.tar.bz2#0f69c40a38d72254bf12094620bda9d2face758f763cd0d989588642d81eccae" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy2-v5.6.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.6.0-linux-armhf-raring.tar.bz2#2c430240cecb562102c677598f106aa57899f00cd37f719989e18ed9ca44bd01" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.6.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.6.0-linux-armhf-raring.tar.bz2#2c430240cecb562102c677598f106aa57899f00cd37f719989e18ed9ca44bd01" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.6.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.6.0-linux64.tar.bz2#aad55328cb0673a60b2633dcc3c36cf452917ac906b577eb3aed5876a7666fca" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.6.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.6.0-linux64.tar.bz2#aad55328cb0673a60b2633dcc3c36cf452917ac906b577eb3aed5876a7666fca" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.6-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.6-linux_x86_64-portable.tar.bz2#9bd220bc54000e142bd4929435959305efeef8c832fbe3c907211cc5214095ce" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.6-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.6-linux_x86_64-portable.tar.bz2#9bd220bc54000e142bd4929435959305efeef8c832fbe3c907211cc5214095ce" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2-5.6.0
+++ b/plugins/python-build/share/python-build/pypy2-5.6.0
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy2-v5.6.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.6.0-linux32.tar.bz2#5d4ad43aed5c5e147f7e7c84766c729f34f63b714b6d224e912a2bb42dc95d62" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.6-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.6-linux_i686-portable.tar.bz2#1f220e05ddd4423882794f0e9d3e2dfdecee259d00f1151a52dd244607313399" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.6-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.6-linux_i686-portable.tar.bz2#1f220e05ddd4423882794f0e9d3e2dfdecee259d00f1151a52dd244607313399" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -22,7 +22,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy2-v5.6.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.6.0-linux64.tar.bz2#aad55328cb0673a60b2633dcc3c36cf452917ac906b577eb3aed5876a7666fca" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.6-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.6-linux_x86_64-portable.tar.bz2#9bd220bc54000e142bd4929435959305efeef8c832fbe3c907211cc5214095ce" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.6-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.6-linux_x86_64-portable.tar.bz2#9bd220bc54000e142bd4929435959305efeef8c832fbe3c907211cc5214095ce" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2-5.6.0
+++ b/plugins/python-build/share/python-build/pypy2-5.6.0
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.6.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.6.0-linux32.tar.bz2#5d4ad43aed5c5e147f7e7c84766c729f34f63b714b6d224e912a2bb42dc95d62" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.6.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.6.0-linux32.tar.bz2#5d4ad43aed5c5e147f7e7c84766c729f34f63b714b6d224e912a2bb42dc95d62" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.6-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.6-linux_i686-portable.tar.bz2#1f220e05ddd4423882794f0e9d3e2dfdecee259d00f1151a52dd244607313399" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy2-v5.6.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.6.0-linux-armel.tar.bz2#2d1c7820f6368c92bb43a153d2c995f70aa183ff8f1df6916b0d2e57838d8a30" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.6.0-linux-armel" "https://downloads.python.org/pypy/pypy2-v5.6.0-linux-armel.tar.bz2#2d1c7820f6368c92bb43a153d2c995f70aa183ff8f1df6916b0d2e57838d8a30" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy2-v5.6.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.6.0-linux-armhf-raspbian.tar.bz2#0f69c40a38d72254bf12094620bda9d2face758f763cd0d989588642d81eccae" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.6.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.6.0-linux-armhf-raspbian.tar.bz2#0f69c40a38d72254bf12094620bda9d2face758f763cd0d989588642d81eccae" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy2-v5.6.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.6.0-linux-armhf-raring.tar.bz2#2c430240cecb562102c677598f106aa57899f00cd37f719989e18ed9ca44bd01" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.6.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.6.0-linux-armhf-raring.tar.bz2#2c430240cecb562102c677598f106aa57899f00cd37f719989e18ed9ca44bd01" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.6.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.6.0-linux64.tar.bz2#aad55328cb0673a60b2633dcc3c36cf452917ac906b577eb3aed5876a7666fca" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.6.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.6.0-linux64.tar.bz2#aad55328cb0673a60b2633dcc3c36cf452917ac906b577eb3aed5876a7666fca" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.6-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.6-linux_x86_64-portable.tar.bz2#9bd220bc54000e142bd4929435959305efeef8c832fbe3c907211cc5214095ce" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy2-v5.6.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.6.0-osx64.tar.bz2#6121f791f440564d3a0a41315e9f2d2d61bc484654acffd85d9e1c6e92b85c36" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.6.0-osx64" "https://downloads.python.org/pypy/pypy2-v5.6.0-osx64.tar.bz2#6121f791f440564d3a0a41315e9f2d2d61bc484654acffd85d9e1c6e92b85c36" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy2-v5.6.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.6.0-win32.zip#bab4fa37ef2d32660e291393d955a4e951d5e883abea8bee83be1ec044ddcaac" "pypy" verify_py27 ensurepip
+  install_zip "pypy2-v5.6.0-win32" "https://downloads.python.org/pypy/pypy2-v5.6.0-win32.zip#bab4fa37ef2d32660e291393d955a4e951d5e883abea8bee83be1ec044ddcaac" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2-5.6.0-src
+++ b/plugins/python-build/share/python-build/pypy2-5.6.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2-v5.6.0-src" "https://downloads.python.org/pypy/pypy2-v5.6.0-src.tar.bz2#7411448045f77eb9e087afdce66fe7eafda1876c9e17aad88cf891f762b608b0" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2-v5.6.0-src" "https://downloads.python.org/pypy/pypy2-v5.6.0-src.tar.bz2#7411448045f77eb9e087afdce66fe7eafda1876c9e17aad88cf891f762b608b0" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.6.0-src
+++ b/plugins/python-build/share/python-build/pypy2-5.6.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2-v5.6.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.6.0-src.tar.bz2#7411448045f77eb9e087afdce66fe7eafda1876c9e17aad88cf891f762b608b0" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2-v5.6.0-src" "https://downloads.python.org/pypy/pypy2-v5.6.0-src.tar.bz2#7411448045f77eb9e087afdce66fe7eafda1876c9e17aad88cf891f762b608b0" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.7.0
+++ b/plugins/python-build/share/python-build/pypy2-5.7.0
@@ -1,34 +1,34 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.7.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-linux32.tar.bz2#aaa55085d11a49cb982b059b4159495d7a4fb9afcfda7bfd680cc0175e9fa33b" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.7.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.7.0-linux32.tar.bz2#aaa55085d11a49cb982b059b4159495d7a4fb9afcfda7bfd680cc0175e9fa33b" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy2-v5.7.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-linux-armel.tar.bz2#3bc0d2616cacef9f544e739d4c25a89e16d7aa8c1ccb18c32dceeb021ed73711" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.7.0-linux-armel" "https://downloads.python.org/pypy/pypy2-v5.7.0-linux-armel.tar.bz2#3bc0d2616cacef9f544e739d4c25a89e16d7aa8c1ccb18c32dceeb021ed73711" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy2-v5.7.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-linux-armhf-raspbian.tar.bz2#6328e4767cf20d20a290739db2d1ec769f3c9c360fa9824f61581b3356add79b" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.7.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.7.0-linux-armhf-raspbian.tar.bz2#6328e4767cf20d20a290739db2d1ec769f3c9c360fa9824f61581b3356add79b" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy2-v5.7.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-linux-armhf-raring.tar.bz2#413df8097c87a8e79cc46df65837b1d533de83b7cb06ce88b168697807fff696" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.7.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.7.0-linux-armhf-raring.tar.bz2#413df8097c87a8e79cc46df65837b1d533de83b7cb06ce88b168697807fff696" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.7.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-linux64.tar.bz2#64bed80e299b09c13296f577a0f52c5d4be9f7c699a390ca6026f967aeff3846" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.7.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.7.0-linux64.tar.bz2#64bed80e299b09c13296f577a0f52c5d4be9f7c699a390ca6026f967aeff3846" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.7-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.7-linux_x86_64-portable.tar.bz2#209d2224fe461d85afb201a0c8da18df21219687defadd4550b60420a120bacb" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy2-v5.7.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-osx64.tar.bz2#9204aa1b55771a374a3118bb43e498c88caca8c33710eecf3249855c4dd1352a" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.7.0-osx64" "https://downloads.python.org/pypy/pypy2-v5.7.0-osx64.tar.bz2#9204aa1b55771a374a3118bb43e498c88caca8c33710eecf3249855c4dd1352a" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy2-v5.7.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-win32.zip#09c8da3a7e09cea821f9b300c6f4f52f4a571d949d91839ecbce93b84a08d570" "pypy" verify_py27 ensurepip
+  install_zip "pypy2-v5.7.0-win32" "https://downloads.python.org/pypy/pypy2-v5.7.0-win32.zip#09c8da3a7e09cea821f9b300c6f4f52f4a571d949d91839ecbce93b84a08d570" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2-5.7.0
+++ b/plugins/python-build/share/python-build/pypy2-5.7.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.7.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.7.0-linux32.tar.bz2#aaa55085d11a49cb982b059b4159495d7a4fb9afcfda7bfd680cc0175e9fa33b" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.7.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.7.0-linux32.tar.bz2#aaa55085d11a49cb982b059b4159495d7a4fb9afcfda7bfd680cc0175e9fa33b" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -10,17 +10,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy2-v5.7.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.7.0-linux-armhf-raspbian.tar.bz2#6328e4767cf20d20a290739db2d1ec769f3c9c360fa9824f61581b3356add79b" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.7.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.7.0-linux-armhf-raspbian.tar.bz2#6328e4767cf20d20a290739db2d1ec769f3c9c360fa9824f61581b3356add79b" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy2-v5.7.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.7.0-linux-armhf-raring.tar.bz2#413df8097c87a8e79cc46df65837b1d533de83b7cb06ce88b168697807fff696" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.7.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.7.0-linux-armhf-raring.tar.bz2#413df8097c87a8e79cc46df65837b1d533de83b7cb06ce88b168697807fff696" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.7.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.7.0-linux64.tar.bz2#64bed80e299b09c13296f577a0f52c5d4be9f7c699a390ca6026f967aeff3846" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.7.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.7.0-linux64.tar.bz2#64bed80e299b09c13296f577a0f52c5d4be9f7c699a390ca6026f967aeff3846" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.7-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.7-linux_x86_64-portable.tar.bz2#209d2224fe461d85afb201a0c8da18df21219687defadd4550b60420a120bacb" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.7-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.7-linux_x86_64-portable.tar.bz2#209d2224fe461d85afb201a0c8da18df21219687defadd4550b60420a120bacb" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2-5.7.0
+++ b/plugins/python-build/share/python-build/pypy2-5.7.0
@@ -20,7 +20,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy2-v5.7.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.7.0-linux64.tar.bz2#64bed80e299b09c13296f577a0f52c5d4be9f7c699a390ca6026f967aeff3846" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.7-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.7-linux_x86_64-portable.tar.bz2#209d2224fe461d85afb201a0c8da18df21219687defadd4550b60420a120bacb" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.7-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.7-linux_x86_64-portable.tar.bz2#209d2224fe461d85afb201a0c8da18df21219687defadd4550b60420a120bacb" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2-5.7.0-src
+++ b/plugins/python-build/share/python-build/pypy2-5.7.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2-v5.7.0-src" "https://downloads.python.org/pypy/pypy2-v5.7.0-src.tar.bz2#e522ea7ca51b16ee5505f22b86803664b762a263a6d69ba84c359fcf8365ad3e" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2-v5.7.0-src" "https://downloads.python.org/pypy/pypy2-v5.7.0-src.tar.bz2#e522ea7ca51b16ee5505f22b86803664b762a263a6d69ba84c359fcf8365ad3e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.7.0-src
+++ b/plugins/python-build/share/python-build/pypy2-5.7.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2-v5.7.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-src.tar.bz2#e522ea7ca51b16ee5505f22b86803664b762a263a6d69ba84c359fcf8365ad3e" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2-v5.7.0-src" "https://downloads.python.org/pypy/pypy2-v5.7.0-src.tar.bz2#e522ea7ca51b16ee5505f22b86803664b762a263a6d69ba84c359fcf8365ad3e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.7.1
+++ b/plugins/python-build/share/python-build/pypy2-5.7.1
@@ -20,7 +20,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy2-v5.7.1-linux64" "https://downloads.python.org/pypy/pypy2-v5.7.1-linux64.tar.bz2#c4fa3da42156bed4a9d912433b618a141e0c5161d7cc8c328786736ea5d1c2da" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.7.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.7.1-linux_x86_64-portable.tar.bz2#8a6a194963eb58d582413c4bcdef6119f9f9f117a05032d1fb13192d934510c6" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.7.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.7.1-linux_x86_64-portable.tar.bz2#8a6a194963eb58d582413c4bcdef6119f9f9f117a05032d1fb13192d934510c6" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2-5.7.1
+++ b/plugins/python-build/share/python-build/pypy2-5.7.1
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.7.1-linux32" "https://downloads.python.org/pypy/pypy2-v5.7.1-linux32.tar.bz2#f125a227f8c814ba1698168a639ea6ca59bb69c280529639eed29076d8429a73" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.7.1-linux32" "https://downloads.python.org/pypy/pypy2-v5.7.1-linux32.tar.bz2#f125a227f8c814ba1698168a639ea6ca59bb69c280529639eed29076d8429a73" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -10,17 +10,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy2-v5.7.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.7.1-linux-armhf-raspbian.tar.bz2#67544f8c4b284db71cf1af74edef290722f97f82476cbdaff2015fdab244c6ee" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.7.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.7.1-linux-armhf-raspbian.tar.bz2#67544f8c4b284db71cf1af74edef290722f97f82476cbdaff2015fdab244c6ee" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy2-v5.7.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.7.1-linux-armhf-raring.tar.bz2#c1b1a0968b22c58672f7492dc7900bc85e3bd02c791f219f31401a00ef387207" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.7.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.7.1-linux-armhf-raring.tar.bz2#c1b1a0968b22c58672f7492dc7900bc85e3bd02c791f219f31401a00ef387207" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.7.1-linux64" "https://downloads.python.org/pypy/pypy2-v5.7.1-linux64.tar.bz2#c4fa3da42156bed4a9d912433b618a141e0c5161d7cc8c328786736ea5d1c2da" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.7.1-linux64" "https://downloads.python.org/pypy/pypy2-v5.7.1-linux64.tar.bz2#c4fa3da42156bed4a9d912433b618a141e0c5161d7cc8c328786736ea5d1c2da" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.7.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.7.1-linux_x86_64-portable.tar.bz2#8a6a194963eb58d582413c4bcdef6119f9f9f117a05032d1fb13192d934510c6" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.7.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.7.1-linux_x86_64-portable.tar.bz2#8a6a194963eb58d582413c4bcdef6119f9f9f117a05032d1fb13192d934510c6" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2-5.7.1
+++ b/plugins/python-build/share/python-build/pypy2-5.7.1
@@ -1,34 +1,34 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.7.1-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.1-linux32.tar.bz2#f125a227f8c814ba1698168a639ea6ca59bb69c280529639eed29076d8429a73" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.7.1-linux32" "https://downloads.python.org/pypy/pypy2-v5.7.1-linux32.tar.bz2#f125a227f8c814ba1698168a639ea6ca59bb69c280529639eed29076d8429a73" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy2-v5.7.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.1-linux-armel.tar.bz2#591a4a73cc945a1125848f3615a28559692db8febf677d7087eaef40cb119a8d" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.7.1-linux-armel" "https://downloads.python.org/pypy/pypy2-v5.7.1-linux-armel.tar.bz2#591a4a73cc945a1125848f3615a28559692db8febf677d7087eaef40cb119a8d" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy2-v5.7.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.1-linux-armhf-raspbian.tar.bz2#67544f8c4b284db71cf1af74edef290722f97f82476cbdaff2015fdab244c6ee" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.7.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.7.1-linux-armhf-raspbian.tar.bz2#67544f8c4b284db71cf1af74edef290722f97f82476cbdaff2015fdab244c6ee" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy2-v5.7.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.1-linux-armhf-raring.tar.bz2#c1b1a0968b22c58672f7492dc7900bc85e3bd02c791f219f31401a00ef387207" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.7.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.7.1-linux-armhf-raring.tar.bz2#c1b1a0968b22c58672f7492dc7900bc85e3bd02c791f219f31401a00ef387207" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.7.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.1-linux64.tar.bz2#c4fa3da42156bed4a9d912433b618a141e0c5161d7cc8c328786736ea5d1c2da" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.7.1-linux64" "https://downloads.python.org/pypy/pypy2-v5.7.1-linux64.tar.bz2#c4fa3da42156bed4a9d912433b618a141e0c5161d7cc8c328786736ea5d1c2da" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.7.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.7.1-linux_x86_64-portable.tar.bz2#8a6a194963eb58d582413c4bcdef6119f9f9f117a05032d1fb13192d934510c6" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy2-v5.7.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.1-osx64.tar.bz2#4e99ba356432861534917a9477ace0ccee617bd631512759a530f8383e153a3d" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.7.1-osx64" "https://downloads.python.org/pypy/pypy2-v5.7.1-osx64.tar.bz2#4e99ba356432861534917a9477ace0ccee617bd631512759a530f8383e153a3d" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy2-v5.7.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.1-win32.zip#a3ba7c946635236836f8536d8767a0f456b3b9a86876cb5c3173a04522bf451b" "pypy" verify_py27 ensurepip
+  install_zip "pypy2-v5.7.1-win32" "https://downloads.python.org/pypy/pypy2-v5.7.1-win32.zip#a3ba7c946635236836f8536d8767a0f456b3b9a86876cb5c3173a04522bf451b" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2-5.7.1-src
+++ b/plugins/python-build/share/python-build/pypy2-5.7.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2-v5.7.0-src" "https://downloads.python.org/pypy/pypy2-v5.7.0-src.tar.bz2#e522ea7ca51b16ee5505f22b86803664b762a263a6d69ba84c359fcf8365ad3e" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2-v5.7.0-src" "https://downloads.python.org/pypy/pypy2-v5.7.0-src.tar.bz2#e522ea7ca51b16ee5505f22b86803664b762a263a6d69ba84c359fcf8365ad3e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2-5.7.1-src
+++ b/plugins/python-build/share/python-build/pypy2-5.7.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2-v5.7.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.0-src.tar.bz2#e522ea7ca51b16ee5505f22b86803664b762a263a6d69ba84c359fcf8365ad3e" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2-v5.7.0-src" "https://downloads.python.org/pypy/pypy2-v5.7.0-src.tar.bz2#e522ea7ca51b16ee5505f22b86803664b762a263a6d69ba84c359fcf8365ad3e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-5.10.0
+++ b/plugins/python-build/share/python-build/pypy2.7-5.10.0
@@ -8,7 +8,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
   install_package "pypy2-v5.10.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.10.0-linux64.tar.bz2#da85af9240220179493ad66c857934dc7ea91aef8f168cd293a2d99af8346ee2" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.10.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.10.0-linux_x86_64-portable.tar.bz2#c966124497ba8728654ce1161fa4c46b035ff30f289be70960f58292e5897cc8" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.10.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.10.0-linux_x86_64-portable.tar.bz2#c966124497ba8728654ce1161fa4c46b035ff30f289be70960f58292e5897cc8" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )

--- a/plugins/python-build/share/python-build/pypy2.7-5.10.0
+++ b/plugins/python-build/share/python-build/pypy2.7-5.10.0
@@ -1,14 +1,14 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.10.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.10.0-linux32.tar.bz2#ee1980467ac8cc9fa9d609f7da93c5282503e59a548781248fe1914a7199d540" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.10.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.10.0-linux32.tar.bz2#ee1980467ac8cc9fa9d609f7da93c5282503e59a548781248fe1914a7199d540" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.10.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.10.0-linux64.tar.bz2#da85af9240220179493ad66c857934dc7ea91aef8f168cd293a2d99af8346ee2" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.10.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.10.0-linux64.tar.bz2#da85af9240220179493ad66c857934dc7ea91aef8f168cd293a2d99af8346ee2" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.10.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.10.0-linux_x86_64-portable.tar.bz2#c966124497ba8728654ce1161fa4c46b035ff30f289be70960f58292e5897cc8" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.10.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.10.0-linux_x86_64-portable.tar.bz2#c966124497ba8728654ce1161fa4c46b035ff30f289be70960f58292e5897cc8" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -17,7 +17,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy2-v5.10.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.10.0-linux-armhf-raspbian.tar.bz2#5ec3617bb9a07a0a0b2f3c8fbe69912345da4696cdb0a2aca7889b6f1e74435c" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.10.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.10.0-linux-armhf-raspbian.tar.bz2#5ec3617bb9a07a0a0b2f3c8fbe69912345da4696cdb0a2aca7889b6f1e74435c" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"

--- a/plugins/python-build/share/python-build/pypy2.7-5.10.0
+++ b/plugins/python-build/share/python-build/pypy2.7-5.10.0
@@ -1,23 +1,23 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.10.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-linux32.tar.bz2#ee1980467ac8cc9fa9d609f7da93c5282503e59a548781248fe1914a7199d540" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.10.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.10.0-linux32.tar.bz2#ee1980467ac8cc9fa9d609f7da93c5282503e59a548781248fe1914a7199d540" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.10.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-linux64.tar.bz2#da85af9240220179493ad66c857934dc7ea91aef8f168cd293a2d99af8346ee2" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.10.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.10.0-linux64.tar.bz2#da85af9240220179493ad66c857934dc7ea91aef8f168cd293a2d99af8346ee2" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.10.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.10.0-linux_x86_64-portable.tar.bz2#c966124497ba8728654ce1161fa4c46b035ff30f289be70960f58292e5897cc8" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy2-v5.10.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-linux-armel.tar.bz2#6fdd55dd8f674efd06f76edb60a09a03b9b04a5fbc56741f416a94a0b9d2ff91" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.10.0-linux-armel" "https://downloads.python.org/pypy/pypy2-v5.10.0-linux-armel.tar.bz2#6fdd55dd8f674efd06f76edb60a09a03b9b04a5fbc56741f416a94a0b9d2ff91" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy2-v5.10.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-linux-armhf-raspbian.tar.bz2#5ec3617bb9a07a0a0b2f3c8fbe69912345da4696cdb0a2aca7889b6f1e74435c" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.10.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.10.0-linux-armhf-raspbian.tar.bz2#5ec3617bb9a07a0a0b2f3c8fbe69912345da4696cdb0a2aca7889b6f1e74435c" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -29,11 +29,11 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "osx64" )
-  install_package "pypy2-v5.10.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-osx64.tar.bz2#7e4120f0a83529a6851cbae0ec107dc7085ba8a4aeff4e7bd9da9aadb1ef37a4" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.10.0-osx64" "https://downloads.python.org/pypy/pypy2-v5.10.0-osx64.tar.bz2#7e4120f0a83529a6851cbae0ec107dc7085ba8a4aeff4e7bd9da9aadb1ef37a4" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy2-v5.10.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-win32.zip#350914f9b70404781674f2f188f84d440d9d25da46ed9733b3f98269a510e033" "pypy" verify_py27 ensurepip
+  install_zip "pypy2-v5.10.0-win32" "https://downloads.python.org/pypy/pypy2-v5.10.0-win32.zip#350914f9b70404781674f2f188f84d440d9d25da46ed9733b3f98269a510e033" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2.7-5.10.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-5.10.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2-v5.10.0-src" "https://downloads.python.org/pypy/pypy2-v5.10.0-src.tar.bz2#1209f2db718e6afda17528baa5138177a14a0938588a7d3e1b7c722c483079a8" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2-v5.10.0-src" "https://downloads.python.org/pypy/pypy2-v5.10.0-src.tar.bz2#1209f2db718e6afda17528baa5138177a14a0938588a7d3e1b7c722c483079a8" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-5.10.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-5.10.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2-v5.10.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-src.tar.bz2#1209f2db718e6afda17528baa5138177a14a0938588a7d3e1b7c722c483079a8" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2-v5.10.0-src" "https://downloads.python.org/pypy/pypy2-v5.10.0-src.tar.bz2#1209f2db718e6afda17528baa5138177a14a0938588a7d3e1b7c722c483079a8" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-5.8.0
+++ b/plugins/python-build/share/python-build/pypy2.7-5.8.0
@@ -20,7 +20,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy2-v5.8.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.8.0-linux64.tar.bz2#6274292d0e954a2609b15978cde6efa30942ba20aa5d2acbbf1c70c0a54e9b1e" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.8-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.8-1-linux_x86_64-portable.tar.bz2#52556230af5769c656173ae8a1bdcb2e16aef46e3993ed89f3aec3d220aec862" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.8-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.8-1-linux_x86_64-portable.tar.bz2#52556230af5769c656173ae8a1bdcb2e16aef46e3993ed89f3aec3d220aec862" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2.7-5.8.0
+++ b/plugins/python-build/share/python-build/pypy2.7-5.8.0
@@ -1,34 +1,34 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.8.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.8.0-linux32.tar.bz2#a0b125a5781f7e5ddfc3baca46503b14f4ee6a0e234e8d72bfcf3afdf4120bef" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.8.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.8.0-linux32.tar.bz2#a0b125a5781f7e5ddfc3baca46503b14f4ee6a0e234e8d72bfcf3afdf4120bef" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy2-v5.8.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.8.0-linux-armel.tar.bz2#28b7fd0cc7418ffc66c71520728e87941be40ebf4b82675c57e25598a2a702b0" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.8.0-linux-armel" "https://downloads.python.org/pypy/pypy2-v5.8.0-linux-armel.tar.bz2#28b7fd0cc7418ffc66c71520728e87941be40ebf4b82675c57e25598a2a702b0" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy2-v5.8.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.8.0-linux-armhf-raspbian.tar.bz2#da58279a0e3706889fc0df06087cea08f8cfd22322139fe9bae73ef9b2d119b7" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.8.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.8.0-linux-armhf-raspbian.tar.bz2#da58279a0e3706889fc0df06087cea08f8cfd22322139fe9bae73ef9b2d119b7" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy2-v5.8.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.8.0-linux-armhf-raring.tar.bz2#ddceca9c5c9a456d4bf1beab177660adffbbdf255a922244e1cc05f20318be46" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.8.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.8.0-linux-armhf-raring.tar.bz2#ddceca9c5c9a456d4bf1beab177660adffbbdf255a922244e1cc05f20318be46" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.8.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.8.0-linux64.tar.bz2#6274292d0e954a2609b15978cde6efa30942ba20aa5d2acbbf1c70c0a54e9b1e" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.8.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.8.0-linux64.tar.bz2#6274292d0e954a2609b15978cde6efa30942ba20aa5d2acbbf1c70c0a54e9b1e" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.8-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.8-1-linux_x86_64-portable.tar.bz2#52556230af5769c656173ae8a1bdcb2e16aef46e3993ed89f3aec3d220aec862" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy2-v5.8.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.8.0-osx64.tar.bz2#04b61d1cf13aaca6d0420e854c820b8bd049dc88be16c02542abe8ca26eb075c" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.8.0-osx64" "https://downloads.python.org/pypy/pypy2-v5.8.0-osx64.tar.bz2#04b61d1cf13aaca6d0420e854c820b8bd049dc88be16c02542abe8ca26eb075c" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy2-v5.8.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.8.0-win32.zip#43d6217653e5bdc09e3ff8cb56fb52c4eb019429063d80107be4e88eef79ea8d" "pypy" verify_py27 ensurepip
+  install_zip "pypy2-v5.8.0-win32" "https://downloads.python.org/pypy/pypy2-v5.8.0-win32.zip#43d6217653e5bdc09e3ff8cb56fb52c4eb019429063d80107be4e88eef79ea8d" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2.7-5.8.0
+++ b/plugins/python-build/share/python-build/pypy2.7-5.8.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.8.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.8.0-linux32.tar.bz2#a0b125a5781f7e5ddfc3baca46503b14f4ee6a0e234e8d72bfcf3afdf4120bef" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.8.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.8.0-linux32.tar.bz2#a0b125a5781f7e5ddfc3baca46503b14f4ee6a0e234e8d72bfcf3afdf4120bef" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -10,17 +10,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy2-v5.8.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.8.0-linux-armhf-raspbian.tar.bz2#da58279a0e3706889fc0df06087cea08f8cfd22322139fe9bae73ef9b2d119b7" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.8.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.8.0-linux-armhf-raspbian.tar.bz2#da58279a0e3706889fc0df06087cea08f8cfd22322139fe9bae73ef9b2d119b7" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy2-v5.8.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.8.0-linux-armhf-raring.tar.bz2#ddceca9c5c9a456d4bf1beab177660adffbbdf255a922244e1cc05f20318be46" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.8.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.8.0-linux-armhf-raring.tar.bz2#ddceca9c5c9a456d4bf1beab177660adffbbdf255a922244e1cc05f20318be46" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.8.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.8.0-linux64.tar.bz2#6274292d0e954a2609b15978cde6efa30942ba20aa5d2acbbf1c70c0a54e9b1e" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.8.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.8.0-linux64.tar.bz2#6274292d0e954a2609b15978cde6efa30942ba20aa5d2acbbf1c70c0a54e9b1e" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.8-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.8-1-linux_x86_64-portable.tar.bz2#52556230af5769c656173ae8a1bdcb2e16aef46e3993ed89f3aec3d220aec862" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.8-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.8-1-linux_x86_64-portable.tar.bz2#52556230af5769c656173ae8a1bdcb2e16aef46e3993ed89f3aec3d220aec862" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2.7-5.8.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-5.8.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2-v5.8.0-src" "https://downloads.python.org/pypy/pypy2-v5.8.0-src.tar.bz2#504c2d522595baf8775ae1045a217a2b120732537861d31b889d47c340b58bd5" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2-v5.8.0-src" "https://downloads.python.org/pypy/pypy2-v5.8.0-src.tar.bz2#504c2d522595baf8775ae1045a217a2b120732537861d31b889d47c340b58bd5" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-5.8.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-5.8.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2-v5.8.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.8.0-src.tar.bz2#504c2d522595baf8775ae1045a217a2b120732537861d31b889d47c340b58bd5" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2-v5.8.0-src" "https://downloads.python.org/pypy/pypy2-v5.8.0-src.tar.bz2#504c2d522595baf8775ae1045a217a2b120732537861d31b889d47c340b58bd5" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-5.9.0
+++ b/plugins/python-build/share/python-build/pypy2.7-5.9.0
@@ -1,34 +1,34 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.9.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-linux32.tar.bz2#a2431a9e4ef879da1a2b56b111013b4a6efb87d4173a37bf650de47834ac5fe4" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.9.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.9.0-linux32.tar.bz2#a2431a9e4ef879da1a2b56b111013b4a6efb87d4173a37bf650de47834ac5fe4" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy2-v5.9.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-linux-armel.tar.bz2#ac0676d91dfb388c799ec5c2845f42018a666423376f52f3ae13d61fd2e6f87d" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.9.0-linux-armel" "https://downloads.python.org/pypy/pypy2-v5.9.0-linux-armel.tar.bz2#ac0676d91dfb388c799ec5c2845f42018a666423376f52f3ae13d61fd2e6f87d" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy2-v5.9.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-linux-armhf-raspbian.tar.bz2#b8a20042a3f34486a372ff7c751539b2e16859c0a7ea69d5a73af92f0fdcb25a" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.9.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.9.0-linux-armhf-raspbian.tar.bz2#b8a20042a3f34486a372ff7c751539b2e16859c0a7ea69d5a73af92f0fdcb25a" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy2-v5.9.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-linux-armhf-raring.tar.bz2#2597b7b21acdef4f2b81074a594157c9450363c74a17f005548c6b102f93cff4" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.9.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.9.0-linux-armhf-raring.tar.bz2#2597b7b21acdef4f2b81074a594157c9450363c74a17f005548c6b102f93cff4" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.9.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-linux64.tar.bz2#790febd4f09e22d6e2f81154efc7dc4b2feec72712aaf4f82aa91b550abb4b48" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.9.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.9.0-linux64.tar.bz2#790febd4f09e22d6e2f81154efc7dc4b2feec72712aaf4f82aa91b550abb4b48" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-5.9-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.9-linux_x86_64-portable.tar.bz2#8d39eb98df3adf7882a7f3551f47b8c7cff47a0e20d6aabc57bb592f155c2616" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy2-v5.9.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-osx64.tar.bz2#94de50ed80c7f6392ed356c03fd54cdc84858df43ad21e9e971d1b6da0f6b867" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v5.9.0-osx64" "https://downloads.python.org/pypy/pypy2-v5.9.0-osx64.tar.bz2#94de50ed80c7f6392ed356c03fd54cdc84858df43ad21e9e971d1b6da0f6b867" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy2-v5.9.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-win32.zip#b61081e24e05b83d8110da1262be19f0094532c6cacc293e318a1c186d926533" "pypy" verify_py27 ensurepip
+  install_zip "pypy2-v5.9.0-win32" "https://downloads.python.org/pypy/pypy2-v5.9.0-win32.zip#b61081e24e05b83d8110da1262be19f0094532c6cacc293e318a1c186d926533" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2.7-5.9.0
+++ b/plugins/python-build/share/python-build/pypy2.7-5.9.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.9.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.9.0-linux32.tar.bz2#a2431a9e4ef879da1a2b56b111013b4a6efb87d4173a37bf650de47834ac5fe4" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.9.0-linux32" "https://downloads.python.org/pypy/pypy2-v5.9.0-linux32.tar.bz2#a2431a9e4ef879da1a2b56b111013b4a6efb87d4173a37bf650de47834ac5fe4" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -10,17 +10,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy2-v5.9.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.9.0-linux-armhf-raspbian.tar.bz2#b8a20042a3f34486a372ff7c751539b2e16859c0a7ea69d5a73af92f0fdcb25a" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.9.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v5.9.0-linux-armhf-raspbian.tar.bz2#b8a20042a3f34486a372ff7c751539b2e16859c0a7ea69d5a73af92f0fdcb25a" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy2-v5.9.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.9.0-linux-armhf-raring.tar.bz2#2597b7b21acdef4f2b81074a594157c9450363c74a17f005548c6b102f93cff4" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.9.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy2-v5.9.0-linux-armhf-raring.tar.bz2#2597b7b21acdef4f2b81074a594157c9450363c74a17f005548c6b102f93cff4" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v5.9.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.9.0-linux64.tar.bz2#790febd4f09e22d6e2f81154efc7dc4b2feec72712aaf4f82aa91b550abb4b48" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v5.9.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.9.0-linux64.tar.bz2#790febd4f09e22d6e2f81154efc7dc4b2feec72712aaf4f82aa91b550abb4b48" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-5.9-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.9-linux_x86_64-portable.tar.bz2#8d39eb98df3adf7882a7f3551f47b8c7cff47a0e20d6aabc57bb592f155c2616" "pypy" verify_py27 ensurepip
+    install_package "pypy-5.9-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.9-linux_x86_64-portable.tar.bz2#8d39eb98df3adf7882a7f3551f47b8c7cff47a0e20d6aabc57bb592f155c2616" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2.7-5.9.0
+++ b/plugins/python-build/share/python-build/pypy2.7-5.9.0
@@ -20,7 +20,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy2-v5.9.0-linux64" "https://downloads.python.org/pypy/pypy2-v5.9.0-linux64.tar.bz2#790febd4f09e22d6e2f81154efc7dc4b2feec72712aaf4f82aa91b550abb4b48" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.9-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.9-linux_x86_64-portable.tar.bz2#8d39eb98df3adf7882a7f3551f47b8c7cff47a0e20d6aabc57bb592f155c2616" "pypy" verify_py27 ensurepip
+  install_package "pypy-5.9-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-5.9-linux_x86_64-portable.tar.bz2#8d39eb98df3adf7882a7f3551f47b8c7cff47a0e20d6aabc57bb592f155c2616" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2.7-5.9.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-5.9.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2-v5.9.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-src.tar.bz2#de4bf05df47f1349dbac97233d9277bbaf1ef3331663ea2557fd5da3dbcfd0a7" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2-v5.9.0-src" "https://downloads.python.org/pypy/pypy2-v5.9.0-src.tar.bz2#de4bf05df47f1349dbac97233d9277bbaf1ef3331663ea2557fd5da3dbcfd0a7" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-5.9.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-5.9.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2-v5.9.0-src" "https://downloads.python.org/pypy/pypy2-v5.9.0-src.tar.bz2#de4bf05df47f1349dbac97233d9277bbaf1ef3331663ea2557fd5da3dbcfd0a7" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2-v5.9.0-src" "https://downloads.python.org/pypy/pypy2-v5.9.0-src.tar.bz2#de4bf05df47f1349dbac97233d9277bbaf1ef3331663ea2557fd5da3dbcfd0a7" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-6.0.0
+++ b/plugins/python-build/share/python-build/pypy2.7-6.0.0
@@ -28,7 +28,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy2-v6.0.0-linux64" "https://downloads.python.org/pypy/pypy2-v6.0.0-linux64.tar.bz2#6cbf942ba7c90f504d8d6a2e45d4244e3bf146c8722d64e9410b85eac6b5af67" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-6.0.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-6.0.0-linux_x86_64-portable.tar.bz2#1d2a833680f9432b6b5f6b8503f656535f429eeb6c4bc5408abe5b637bfb9b94" "pypy" verify_py27 ensurepip
+  install_package "pypy-6.0.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-6.0.0-linux_x86_64-portable.tar.bz2#1d2a833680f9432b6b5f6b8503f656535f429eeb6c4bc5408abe5b637bfb9b94" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2.7-6.0.0
+++ b/plugins/python-build/share/python-build/pypy2.7-6.0.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v6.0.0-linux32" "https://downloads.python.org/pypy/pypy2-v6.0.0-linux32.tar.bz2#ad1082d4328ae8f32617b14628648583b82b6d29df3aa42b97bd1853c08c4bc8" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v6.0.0-linux32" "https://downloads.python.org/pypy/pypy2-v6.0.0-linux32.tar.bz2#ad1082d4328ae8f32617b14628648583b82b6d29df3aa42b97bd1853c08c4bc8" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -18,7 +18,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy2-v6.0.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v6.0.0-linux-armhf-raspbian.tar.bz2#6506ce739e31981e5596d3cc2e2c7f5b086ee77bb4d97773082b62b2f283eef2" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v6.0.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v6.0.0-linux-armhf-raspbian.tar.bz2#6506ce739e31981e5596d3cc2e2c7f5b086ee77bb4d97773082b62b2f283eef2" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
     install_package "pypy2-v6.0.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-linux-armhf-raring.tar.bz2#2c430240cecb562102c677598f106aa57899f00cd37f719989e18ed9ca44bd01" "pypy" verify_py27 ensurepip
@@ -26,9 +26,9 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy2-v6.0.0-linux64" "https://downloads.python.org/pypy/pypy2-v6.0.0-linux64.tar.bz2#6cbf942ba7c90f504d8d6a2e45d4244e3bf146c8722d64e9410b85eac6b5af67" "pypy" verify_py27 ensurepip
+    install_package "pypy2-v6.0.0-linux64" "https://downloads.python.org/pypy/pypy2-v6.0.0-linux64.tar.bz2#6cbf942ba7c90f504d8d6a2e45d4244e3bf146c8722d64e9410b85eac6b5af67" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-6.0.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-6.0.0-linux_x86_64-portable.tar.bz2#1d2a833680f9432b6b5f6b8503f656535f429eeb6c4bc5408abe5b637bfb9b94" "pypy" verify_py27 ensurepip
+    install_package "pypy-6.0.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-6.0.0-linux_x86_64-portable.tar.bz2#1d2a833680f9432b6b5f6b8503f656535f429eeb6c4bc5408abe5b637bfb9b94" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2.7-6.0.0
+++ b/plugins/python-build/share/python-build/pypy2.7-6.0.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v6.0.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-linux32.tar.bz2#ad1082d4328ae8f32617b14628648583b82b6d29df3aa42b97bd1853c08c4bc8" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v6.0.0-linux32" "https://downloads.python.org/pypy/pypy2-v6.0.0-linux32.tar.bz2#ad1082d4328ae8f32617b14628648583b82b6d29df3aa42b97bd1853c08c4bc8" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,11 +14,11 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy2-v6.0.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-linux-armel.tar.bz2#924ca3f90aa28e8961859508c25752c95253b842318a0f267267ffe90f56a916" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v6.0.0-linux-armel" "https://downloads.python.org/pypy/pypy2-v6.0.0-linux-armel.tar.bz2#924ca3f90aa28e8961859508c25752c95253b842318a0f267267ffe90f56a916" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy2-v6.0.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-linux-armhf-raspbian.tar.bz2#6506ce739e31981e5596d3cc2e2c7f5b086ee77bb4d97773082b62b2f283eef2" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v6.0.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy2-v6.0.0-linux-armhf-raspbian.tar.bz2#6506ce739e31981e5596d3cc2e2c7f5b086ee77bb4d97773082b62b2f283eef2" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
     install_package "pypy2-v6.0.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-linux-armhf-raring.tar.bz2#2c430240cecb562102c677598f106aa57899f00cd37f719989e18ed9ca44bd01" "pypy" verify_py27 ensurepip
@@ -26,17 +26,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v6.0.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-linux64.tar.bz2#6cbf942ba7c90f504d8d6a2e45d4244e3bf146c8722d64e9410b85eac6b5af67" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v6.0.0-linux64" "https://downloads.python.org/pypy/pypy2-v6.0.0-linux64.tar.bz2#6cbf942ba7c90f504d8d6a2e45d4244e3bf146c8722d64e9410b85eac6b5af67" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-6.0.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-6.0.0-linux_x86_64-portable.tar.bz2#1d2a833680f9432b6b5f6b8503f656535f429eeb6c4bc5408abe5b637bfb9b94" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy2-v6.0.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-osx64.tar.bz2#d7dc443e6bb9a45212e8d8f5a63e9f6ce23f1d88c50709efea1c75b76c8bc186" "pypy" verify_py27 ensurepip
+  install_package "pypy2-v6.0.0-osx64" "https://downloads.python.org/pypy/pypy2-v6.0.0-osx64.tar.bz2#d7dc443e6bb9a45212e8d8f5a63e9f6ce23f1d88c50709efea1c75b76c8bc186" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy2-v6.0.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-win32.zip#6e2210dae1ae721ed4eb9cba19f15453514b64111511c84f24843c4fdefdaf7f" "pypy" verify_py27 ensurepip
+  install_zip "pypy2-v6.0.0-win32" "https://downloads.python.org/pypy/pypy2-v6.0.0-win32.zip#6e2210dae1ae721ed4eb9cba19f15453514b64111511c84f24843c4fdefdaf7f" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2.7-6.0.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-6.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2-v6.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-src.tar.bz2#6097ec5ee23d0d34d8cd27a1072bed041c8a080ad48731190a03a2223029212d" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2-v6.0.0-src" "https://downloads.python.org/pypy/pypy2-v6.0.0-src.tar.bz2#6097ec5ee23d0d34d8cd27a1072bed041c8a080ad48731190a03a2223029212d" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-6.0.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-6.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2-v6.0.0-src" "https://downloads.python.org/pypy/pypy2-v6.0.0-src.tar.bz2#6097ec5ee23d0d34d8cd27a1072bed041c8a080ad48731190a03a2223029212d" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2-v6.0.0-src" "https://downloads.python.org/pypy/pypy2-v6.0.0-src.tar.bz2#6097ec5ee23d0d34d8cd27a1072bed041c8a080ad48731190a03a2223029212d" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.0.0
+++ b/plugins/python-build/share/python-build/pypy2.7-7.0.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy2.7-v7.0.0-linux32" "https://downloads.python.org/pypy/pypy2.7-v7.0.0-linux32.tar.bz2#446fc208dd77a0048368da830564e6e4180bcd786e524b5369c61785af5c903a" "pypy" verify_py27 ensurepip
+    install_package "pypy2.7-v7.0.0-linux32" "https://downloads.python.org/pypy/pypy2.7-v7.0.0-linux32.tar.bz2#446fc208dd77a0048368da830564e6e4180bcd786e524b5369c61785af5c903a" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy2.7-v7.0.0-linux64" "https://downloads.python.org/pypy/pypy2.7-v7.0.0-linux64.tar.bz2#971b1909f9fe960c4c643a6940d3f8a60d9a7a2937119535ab0cfaf83498ecd7" "pypy" verify_py27 ensurepip
+    install_package "pypy2.7-v7.0.0-linux64" "https://downloads.python.org/pypy/pypy2.7-v7.0.0-linux64.tar.bz2#971b1909f9fe960c4c643a6940d3f8a60d9a7a2937119535ab0cfaf83498ecd7" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-7.0.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-7.0.0-linux_x86_64-portable.tar.bz2#fd71f2bef69c342e492239c2de04a67676bbc08b262d31948bef9e1385a44646" "pypy" verify_py27 ensurepip
+    install_package "pypy-7.0.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-7.0.0-linux_x86_64-portable.tar.bz2#fd71f2bef69c342e492239c2de04a67676bbc08b262d31948bef9e1385a44646" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-  install_package "pypy2.7-v7.0.0-osx64" "https://downloads.python.org/pypy/pypy2.7-v7.0.0-osx64.tar.bz2#e7ecb029d9c7a59388838fc4820a50a2f5bee6536010031060e3dfa882730dc8" "pypy" verify_py27 ensurepip
+    install_package "pypy2.7-v7.0.0-osx64" "https://downloads.python.org/pypy/pypy2.7-v7.0.0-osx64.tar.bz2#e7ecb029d9c7a59388838fc4820a50a2f5bee6536010031060e3dfa882730dc8" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"

--- a/plugins/python-build/share/python-build/pypy2.7-7.0.0
+++ b/plugins/python-build/share/python-build/pypy2.7-7.0.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy2.7-v7.0.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.0.0-linux32.tar.bz2#446fc208dd77a0048368da830564e6e4180bcd786e524b5369c61785af5c903a" "pypy" verify_py27 ensurepip
+  install_package "pypy2.7-v7.0.0-linux32" "https://downloads.python.org/pypy/pypy2.7-v7.0.0-linux32.tar.bz2#446fc208dd77a0048368da830564e6e4180bcd786e524b5369c61785af5c903a" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy2.7-v7.0.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.0.0-linux64.tar.bz2#971b1909f9fe960c4c643a6940d3f8a60d9a7a2937119535ab0cfaf83498ecd7" "pypy" verify_py27 ensurepip
+  install_package "pypy2.7-v7.0.0-linux64" "https://downloads.python.org/pypy/pypy2.7-v7.0.0-linux64.tar.bz2#971b1909f9fe960c4c643a6940d3f8a60d9a7a2937119535ab0cfaf83498ecd7" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-7.0.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-7.0.0-linux_x86_64-portable.tar.bz2#fd71f2bef69c342e492239c2de04a67676bbc08b262d31948bef9e1385a44646" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy2.7-v7.0.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.0.0-osx64.tar.bz2#e7ecb029d9c7a59388838fc4820a50a2f5bee6536010031060e3dfa882730dc8" "pypy" verify_py27 ensurepip
+  install_package "pypy2.7-v7.0.0-osx64" "https://downloads.python.org/pypy/pypy2.7-v7.0.0-osx64.tar.bz2#e7ecb029d9c7a59388838fc4820a50a2f5bee6536010031060e3dfa882730dc8" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -33,7 +33,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "win32" )
-  install_zip "pypy2.7-v7.0.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.0.0-win32.zip#04477a41194240cd71e485c3f41dec35a787d1b3bc030f9aa59e5e81bcf4118b" "pypy" verify_py27 ensurepip
+  install_zip "pypy2.7-v7.0.0-win32" "https://downloads.python.org/pypy/pypy2.7-v7.0.0-win32.zip#04477a41194240cd71e485c3f41dec35a787d1b3bc030f9aa59e5e81bcf4118b" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2.7-7.0.0
+++ b/plugins/python-build/share/python-build/pypy2.7-7.0.0
@@ -16,7 +16,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
   install_package "pypy2.7-v7.0.0-linux64" "https://downloads.python.org/pypy/pypy2.7-v7.0.0-linux64.tar.bz2#971b1909f9fe960c4c643a6940d3f8a60d9a7a2937119535ab0cfaf83498ecd7" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-7.0.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-7.0.0-linux_x86_64-portable.tar.bz2#fd71f2bef69c342e492239c2de04a67676bbc08b262d31948bef9e1385a44646" "pypy" verify_py27 ensurepip
+  install_package "pypy-7.0.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-7.0.0-linux_x86_64-portable.tar.bz2#fd71f2bef69c342e492239c2de04a67676bbc08b262d31948bef9e1385a44646" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2.7-7.0.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2.7-v7.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.0.0-src.tar.bz2#f51d8bbfc4e73a8a01820b7871a45d13c59f1399822cdf8a19388c69eb20c18c" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2.7-v7.0.0-src" "https://downloads.python.org/pypy/pypy2.7-v7.0.0-src.tar.bz2#f51d8bbfc4e73a8a01820b7871a45d13c59f1399822cdf8a19388c69eb20c18c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.0.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2.7-v7.0.0-src" "https://downloads.python.org/pypy/pypy2.7-v7.0.0-src.tar.bz2#f51d8bbfc4e73a8a01820b7871a45d13c59f1399822cdf8a19388c69eb20c18c" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2.7-v7.0.0-src" "https://downloads.python.org/pypy/pypy2.7-v7.0.0-src.tar.bz2#f51d8bbfc4e73a8a01820b7871a45d13c59f1399822cdf8a19388c69eb20c18c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.1.0
+++ b/plugins/python-build/share/python-build/pypy2.7-7.1.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy2.7-v7.1.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.0-linux32.tar.bz2#44ec91e8cb01caab289d8763c203f3aaf288d14325a6c42692bd1ac4e870d758" "pypy" verify_py27 ensurepip
+  install_package "pypy2.7-v7.1.0-linux32" "https://downloads.python.org/pypy/pypy2.7-v7.1.0-linux32.tar.bz2#44ec91e8cb01caab289d8763c203f3aaf288d14325a6c42692bd1ac4e870d758" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy2.7-v7.1.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.0-linux64.tar.bz2#fef176a29a2ef068c00c8098e59dab935ca6e956f089672b3f7351da95a034f5" "pypy" verify_py27 ensurepip
+  install_package "pypy2.7-v7.1.0-linux64" "https://downloads.python.org/pypy/pypy2.7-v7.1.0-linux64.tar.bz2#fef176a29a2ef068c00c8098e59dab935ca6e956f089672b3f7351da95a034f5" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-7.1.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-7.1.0-linux_x86_64-portable.tar.bz2#ee917d9d72fb6a7d15e31e6c5e470ce561a940f112e99f29ac5dd6b41f512657" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy2.7-v7.1.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.0-osx64.tar.bz2#8be43685ce718b0768387450fc6dc395d60809b778b6146c353ef67826022153" "pypy" verify_py27 ensurepip
+  install_package "pypy2.7-v7.1.0-osx64" "https://downloads.python.org/pypy/pypy2.7-v7.1.0-osx64.tar.bz2#8be43685ce718b0768387450fc6dc395d60809b778b6146c353ef67826022153" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -33,7 +33,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "win32" )
-  install_zip "pypy2.7-v7.1.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.0-win32.zip#76658c9ad679d562b8b6a09d006caa666406337b9834ff56db16980c5e549f20" "pypy" verify_py27 ensurepip
+  install_zip "pypy2.7-v7.1.0-win32" "https://downloads.python.org/pypy/pypy2.7-v7.1.0-win32.zip#76658c9ad679d562b8b6a09d006caa666406337b9834ff56db16980c5e549f20" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2.7-7.1.0
+++ b/plugins/python-build/share/python-build/pypy2.7-7.1.0
@@ -16,7 +16,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
   install_package "pypy2.7-v7.1.0-linux64" "https://downloads.python.org/pypy/pypy2.7-v7.1.0-linux64.tar.bz2#fef176a29a2ef068c00c8098e59dab935ca6e956f089672b3f7351da95a034f5" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-7.1.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-7.1.0-linux_x86_64-portable.tar.bz2#ee917d9d72fb6a7d15e31e6c5e470ce561a940f112e99f29ac5dd6b41f512657" "pypy" verify_py27 ensurepip
+  install_package "pypy-7.1.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-7.1.0-linux_x86_64-portable.tar.bz2#ee917d9d72fb6a7d15e31e6c5e470ce561a940f112e99f29ac5dd6b41f512657" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2.7-7.1.0
+++ b/plugins/python-build/share/python-build/pypy2.7-7.1.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy2.7-v7.1.0-linux32" "https://downloads.python.org/pypy/pypy2.7-v7.1.0-linux32.tar.bz2#44ec91e8cb01caab289d8763c203f3aaf288d14325a6c42692bd1ac4e870d758" "pypy" verify_py27 ensurepip
+    install_package "pypy2.7-v7.1.0-linux32" "https://downloads.python.org/pypy/pypy2.7-v7.1.0-linux32.tar.bz2#44ec91e8cb01caab289d8763c203f3aaf288d14325a6c42692bd1ac4e870d758" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy2.7-v7.1.0-linux64" "https://downloads.python.org/pypy/pypy2.7-v7.1.0-linux64.tar.bz2#fef176a29a2ef068c00c8098e59dab935ca6e956f089672b3f7351da95a034f5" "pypy" verify_py27 ensurepip
+    install_package "pypy2.7-v7.1.0-linux64" "https://downloads.python.org/pypy/pypy2.7-v7.1.0-linux64.tar.bz2#fef176a29a2ef068c00c8098e59dab935ca6e956f089672b3f7351da95a034f5" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-7.1.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-7.1.0-linux_x86_64-portable.tar.bz2#ee917d9d72fb6a7d15e31e6c5e470ce561a940f112e99f29ac5dd6b41f512657" "pypy" verify_py27 ensurepip
+    install_package "pypy-7.1.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-7.1.0-linux_x86_64-portable.tar.bz2#ee917d9d72fb6a7d15e31e6c5e470ce561a940f112e99f29ac5dd6b41f512657" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-  install_package "pypy2.7-v7.1.0-osx64" "https://downloads.python.org/pypy/pypy2.7-v7.1.0-osx64.tar.bz2#8be43685ce718b0768387450fc6dc395d60809b778b6146c353ef67826022153" "pypy" verify_py27 ensurepip
+    install_package "pypy2.7-v7.1.0-osx64" "https://downloads.python.org/pypy/pypy2.7-v7.1.0-osx64.tar.bz2#8be43685ce718b0768387450fc6dc395d60809b778b6146c353ef67826022153" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"

--- a/plugins/python-build/share/python-build/pypy2.7-7.1.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.1.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2.7-v7.1.0-src" "https://downloads.python.org/pypy/pypy2.7-v7.1.0-src.tar.bz2#b051a71ea5b4fa27d0a744b28e6054661adfce8904dcc82500716b5edff5ce4b" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2.7-v7.1.0-src" "https://downloads.python.org/pypy/pypy2.7-v7.1.0-src.tar.bz2#b051a71ea5b4fa27d0a744b28e6054661adfce8904dcc82500716b5edff5ce4b" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.1.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.1.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2.7-v7.1.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.0-src.tar.bz2#b051a71ea5b4fa27d0a744b28e6054661adfce8904dcc82500716b5edff5ce4b" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2.7-v7.1.0-src" "https://downloads.python.org/pypy/pypy2.7-v7.1.0-src.tar.bz2#b051a71ea5b4fa27d0a744b28e6054661adfce8904dcc82500716b5edff5ce4b" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.1.1
+++ b/plugins/python-build/share/python-build/pypy2.7-7.1.1
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy2.7-v7.1.1-linux32" "https://downloads.python.org/pypy/pypy2.7-v7.1.1-linux32.tar.bz2#41ca390a76ca0d47b8353a0d6a20d5aab5fad8b0bb647b960d8c33e873d18ef5" "pypy" verify_py27 ensurepip
+    install_package "pypy2.7-v7.1.1-linux32" "https://downloads.python.org/pypy/pypy2.7-v7.1.1-linux32.tar.bz2#41ca390a76ca0d47b8353a0d6a20d5aab5fad8b0bb647b960d8c33e873d18ef5" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy2.7-v7.1.1-linux64" "https://downloads.python.org/pypy/pypy2.7-v7.1.1-linux64.tar.bz2#73b09ef0860eb9ad7997af3030b22909806a273d90786d78420926df53279d66" "pypy" verify_py27 ensurepip
+    install_package "pypy2.7-v7.1.1-linux64" "https://downloads.python.org/pypy/pypy2.7-v7.1.1-linux64.tar.bz2#73b09ef0860eb9ad7997af3030b22909806a273d90786d78420926df53279d66" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy-7.1.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-7.1.1-linux_x86_64-portable.tar.bz2#d0b226d2dd656c622cee4e3e982225e1b346653823b49f736d8b0ddc06fd0c73" "pypy" verify_py27 ensurepip
+    install_package "pypy-7.1.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-7.1.1-linux_x86_64-portable.tar.bz2#d0b226d2dd656c622cee4e3e982225e1b346653823b49f736d8b0ddc06fd0c73" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-  install_package "pypy2.7-v7.1.1-osx64" "https://downloads.python.org/pypy/pypy2.7-v7.1.1-osx64.tar.bz2#31a17294dec96c2191885c776b4ee02112957dc874f7ba03e570537a77b78c35" "pypy" verify_py27 ensurepip
+    install_package "pypy2.7-v7.1.1-osx64" "https://downloads.python.org/pypy/pypy2.7-v7.1.1-osx64.tar.bz2#31a17294dec96c2191885c776b4ee02112957dc874f7ba03e570537a77b78c35" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"

--- a/plugins/python-build/share/python-build/pypy2.7-7.1.1
+++ b/plugins/python-build/share/python-build/pypy2.7-7.1.1
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy2.7-v7.1.1-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.1-linux32.tar.bz2#41ca390a76ca0d47b8353a0d6a20d5aab5fad8b0bb647b960d8c33e873d18ef5" "pypy" verify_py27 ensurepip
+  install_package "pypy2.7-v7.1.1-linux32" "https://downloads.python.org/pypy/pypy2.7-v7.1.1-linux32.tar.bz2#41ca390a76ca0d47b8353a0d6a20d5aab5fad8b0bb647b960d8c33e873d18ef5" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy2.7-v7.1.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.1-linux64.tar.bz2#73b09ef0860eb9ad7997af3030b22909806a273d90786d78420926df53279d66" "pypy" verify_py27 ensurepip
+  install_package "pypy2.7-v7.1.1-linux64" "https://downloads.python.org/pypy/pypy2.7-v7.1.1-linux64.tar.bz2#73b09ef0860eb9ad7997af3030b22909806a273d90786d78420926df53279d66" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-7.1.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-7.1.1-linux_x86_64-portable.tar.bz2#d0b226d2dd656c622cee4e3e982225e1b346653823b49f736d8b0ddc06fd0c73" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy2.7-v7.1.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.1-osx64.tar.bz2#31a17294dec96c2191885c776b4ee02112957dc874f7ba03e570537a77b78c35" "pypy" verify_py27 ensurepip
+  install_package "pypy2.7-v7.1.1-osx64" "https://downloads.python.org/pypy/pypy2.7-v7.1.1-osx64.tar.bz2#31a17294dec96c2191885c776b4ee02112957dc874f7ba03e570537a77b78c35" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -33,7 +33,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "win32" )
-  install_zip "pypy2.7-v7.1.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.1-win32.zip#9c59226311f216a181e70ee7b5aa4d9665a15d00f24ae02acec9af7d96355f63" "pypy" verify_py27 ensurepip
+  install_zip "pypy2.7-v7.1.1-win32" "https://downloads.python.org/pypy/pypy2.7-v7.1.1-win32.zip#9c59226311f216a181e70ee7b5aa4d9665a15d00f24ae02acec9af7d96355f63" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2.7-7.1.1
+++ b/plugins/python-build/share/python-build/pypy2.7-7.1.1
@@ -16,7 +16,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
   install_package "pypy2.7-v7.1.1-linux64" "https://downloads.python.org/pypy/pypy2.7-v7.1.1-linux64.tar.bz2#73b09ef0860eb9ad7997af3030b22909806a273d90786d78420926df53279d66" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-7.1.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-7.1.1-linux_x86_64-portable.tar.bz2#d0b226d2dd656c622cee4e3e982225e1b346653823b49f736d8b0ddc06fd0c73" "pypy" verify_py27 ensurepip
+  install_package "pypy-7.1.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy-7.1.1-linux_x86_64-portable.tar.bz2#d0b226d2dd656c622cee4e3e982225e1b346653823b49f736d8b0ddc06fd0c73" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy2.7-7.1.1-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.1.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2.7-v7.1.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.1-src.tar.bz2#5f06bede6d71dce8dfbfe797aab26c8e35cb990e16b826914652dc093ad74451" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2.7-v7.1.1-src" "https://downloads.python.org/pypy/pypy2.7-v7.1.1-src.tar.bz2#5f06bede6d71dce8dfbfe797aab26c8e35cb990e16b826914652dc093ad74451" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.1.1-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.1.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2.7-v7.1.1-src" "https://downloads.python.org/pypy/pypy2.7-v7.1.1-src.tar.bz2#5f06bede6d71dce8dfbfe797aab26c8e35cb990e16b826914652dc093ad74451" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2.7-v7.1.1-src" "https://downloads.python.org/pypy/pypy2.7-v7.1.1-src.tar.bz2#5f06bede6d71dce8dfbfe797aab26c8e35cb990e16b826914652dc093ad74451" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.2.0
+++ b/plugins/python-build/share/python-build/pypy2.7-7.2.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy2.7-v7.2.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.2.0-linux32.tar.bz2#76d666e5aee54b519d6ec1af4ef0cbdc85f7f9276dd554e97deb026adfd0c936" "pypy" verify_py27 ensurepip
+  install_package "pypy2.7-v7.2.0-linux32" "https://downloads.python.org/pypy/pypy2.7-v7.2.0-linux32.tar.bz2#76d666e5aee54b519d6ec1af4ef0cbdc85f7f9276dd554e97deb026adfd0c936" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy2.7-v7.2.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.2.0-linux64.tar.bz2#05acf28e6a243026ecad933b9361d8f74b41f00818071b76b38c4694cc4c9599" "pypy" verify_py27 ensurepip
+  install_package "pypy2.7-v7.2.0-linux64" "https://downloads.python.org/pypy/pypy2.7-v7.2.0-linux64.tar.bz2#05acf28e6a243026ecad933b9361d8f74b41f00818071b76b38c4694cc4c9599" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-7.2.0-linux_x86_64-portable" "https://github.com/squeaky-pl/portable-pypy/releases/download/pypy-7.2.0/pypy-7.2.0-linux_x86_64-portable.tar.bz2#a4f301e7629aafe4691ed1c3e9a39cf2158d86524f6ce584e5b850303e77ad81" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy2.7-v7.2.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.2.0-osx64.tar.bz2#36aa2f2440e762333569118dd0b3d5371d575c40966effa194d116c5453ddb52" "pypy" verify_py27 ensurepip
+  install_package "pypy2.7-v7.2.0-osx64" "https://downloads.python.org/pypy/pypy2.7-v7.2.0-osx64.tar.bz2#36aa2f2440e762333569118dd0b3d5371d575c40966effa194d116c5453ddb52" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -33,7 +33,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "win32" )
-  install_zip "pypy2.7-v7.2.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.2.0-win32.zip#956eeaaaac053e5d0917e77a3d2ad1933ab5561eb3e6e71235780b5aa5fd2bb7" "pypy" verify_py27 ensurepip
+  install_zip "pypy2.7-v7.2.0-win32" "https://downloads.python.org/pypy/pypy2.7-v7.2.0-win32.zip#956eeaaaac053e5d0917e77a3d2ad1933ab5561eb3e6e71235780b5aa5fd2bb7" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2.7-7.2.0
+++ b/plugins/python-build/share/python-build/pypy2.7-7.2.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy2.7-v7.2.0-linux32" "https://downloads.python.org/pypy/pypy2.7-v7.2.0-linux32.tar.bz2#76d666e5aee54b519d6ec1af4ef0cbdc85f7f9276dd554e97deb026adfd0c936" "pypy" verify_py27 ensurepip
+    install_package "pypy2.7-v7.2.0-linux32" "https://downloads.python.org/pypy/pypy2.7-v7.2.0-linux32.tar.bz2#76d666e5aee54b519d6ec1af4ef0cbdc85f7f9276dd554e97deb026adfd0c936" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy2.7-v7.2.0-linux64" "https://downloads.python.org/pypy/pypy2.7-v7.2.0-linux64.tar.bz2#05acf28e6a243026ecad933b9361d8f74b41f00818071b76b38c4694cc4c9599" "pypy" verify_py27 ensurepip
+    install_package "pypy2.7-v7.2.0-linux64" "https://downloads.python.org/pypy/pypy2.7-v7.2.0-linux64.tar.bz2#05acf28e6a243026ecad933b9361d8f74b41f00818071b76b38c4694cc4c9599" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-7.2.0-linux_x86_64-portable" "https://github.com/squeaky-pl/portable-pypy/releases/download/pypy-7.2.0/pypy-7.2.0-linux_x86_64-portable.tar.bz2#a4f301e7629aafe4691ed1c3e9a39cf2158d86524f6ce584e5b850303e77ad81" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-  install_package "pypy2.7-v7.2.0-osx64" "https://downloads.python.org/pypy/pypy2.7-v7.2.0-osx64.tar.bz2#36aa2f2440e762333569118dd0b3d5371d575c40966effa194d116c5453ddb52" "pypy" verify_py27 ensurepip
+    install_package "pypy2.7-v7.2.0-osx64" "https://downloads.python.org/pypy/pypy2.7-v7.2.0-osx64.tar.bz2#36aa2f2440e762333569118dd0b3d5371d575c40966effa194d116c5453ddb52" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"

--- a/plugins/python-build/share/python-build/pypy2.7-7.2.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.2.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2.7-v7.2.0-src" "https://downloads.python.org/pypy/pypy2.7-v7.2.0-src.tar.bz2#55cb7757784fbe3952102447f65b27d80e6c885a464a7af1a9ce264492439dcc" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2.7-v7.2.0-src" "https://downloads.python.org/pypy/pypy2.7-v7.2.0-src.tar.bz2#55cb7757784fbe3952102447f65b27d80e6c885a464a7af1a9ce264492439dcc" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.2.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.2.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2.7-v7.2.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.2.0-src.tar.bz2#55cb7757784fbe3952102447f65b27d80e6c885a464a7af1a9ce264492439dcc" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2.7-v7.2.0-src" "https://downloads.python.org/pypy/pypy2.7-v7.2.0-src.tar.bz2#55cb7757784fbe3952102447f65b27d80e6c885a464a7af1a9ce264492439dcc" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.3.0
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.0
@@ -3,17 +3,17 @@ PYVER='2.7'
 
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#eac1308b7d523003a5f6d20f58406d52ab14611bcec750122ae513a5a35110db" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#eac1308b7d523003a5f6d20f58406d52ab14611bcec750122ae513a5a35110db" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 "linux64" )
-  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#f4950a54378ac637da2a6defa52d6ffed96af12fcd5d74e1182fb834883c9826" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#f4950a54378ac637da2a6defa52d6ffed96af12fcd5d74e1182fb834883c9826" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 "linux-aarch64" )
-  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#a3dd8d5e2a656849fa344dce4679d854a19bc4a096a0cf62b46a1be127a5d56c" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#a3dd8d5e2a656849fa344dce4679d854a19bc4a096a0cf62b46a1be127a5d56c" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#ca7b056b243a6221ad04fa7fc8696e36a2fb858396999dcaa31dbbae53c54474" "pypy" "verify_py${PYVER//./}" ensurepip
+    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#ca7b056b243a6221ad04fa7fc8696e36a2fb858396999dcaa31dbbae53c54474" "pypy" "verify_py${PYVER//./}" ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -25,7 +25,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "win32" )
-  install_zip "pypy${PYVER}-v${VERSION}-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-win32.zip#a9e3c5c983edba0313a41d3c1ab55b080816c4129e67a6c272c53b9dbcdd97ec" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_zip "pypy${PYVER}-v${VERSION}-win32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-win32.zip#a9e3c5c983edba0313a41d3c1ab55b080816c4129e67a6c272c53b9dbcdd97ec" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2.7-7.3.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2.7-v7.3.0-src" "https://downloads.python.org/pypy/pypy2.7-v7.3.0-src.tar.bz2#b0b25c7f8938ab0fedd8dedf26b9e73c490913b002b484c1b2f19d5844a518de" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2.7-v7.3.0-src" "https://downloads.python.org/pypy/pypy2.7-v7.3.0-src.tar.bz2#b0b25c7f8938ab0fedd8dedf26b9e73c490913b002b484c1b2f19d5844a518de" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.3.0-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2.7-v7.3.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.3.0-src.tar.bz2#b0b25c7f8938ab0fedd8dedf26b9e73c490913b002b484c1b2f19d5844a518de" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2.7-v7.3.0-src" "https://downloads.python.org/pypy/pypy2.7-v7.3.0-src.tar.bz2#b0b25c7f8938ab0fedd8dedf26b9e73c490913b002b484c1b2f19d5844a518de" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.3.1
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.1
@@ -3,17 +3,17 @@ PYVER='2.7'
 
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#cd155d06cd0956d9de4a16e8a6bdf0722cb45b5bc4bbf805825d393ebd6690ad" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#cd155d06cd0956d9de4a16e8a6bdf0722cb45b5bc4bbf805825d393ebd6690ad" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 "linux64" )
-  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#be74886547df7bf7094096a11fc0a48496779d0d1b71901797b0c816f92caca3" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#be74886547df7bf7094096a11fc0a48496779d0d1b71901797b0c816f92caca3" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 "linux-aarch64" )
-  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#094f23ab262e666d8740bf27459a6b1215a628dad9b6c2a88f1ed5c793fab267" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#094f23ab262e666d8740bf27459a6b1215a628dad9b6c2a88f1ed5c793fab267" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#dfd4651243441d2f8f1c348e9ecc09848642d0c31bb323aa8ac320e5b9f232f0" "pypy" "verify_py${PYVER//./}" ensurepip
+    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#dfd4651243441d2f8f1c348e9ecc09848642d0c31bb323aa8ac320e5b9f232f0" "pypy" "verify_py${PYVER//./}" ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -25,7 +25,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "win32" )
-  install_zip "pypy${PYVER}-v${VERSION}-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-win32.zip#e3c0dfb385d9825dd7723f26576d55d43ed92f1178f2399ab39e9fa11621a47b" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_zip "pypy${PYVER}-v${VERSION}-win32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-win32.zip#e3c0dfb385d9825dd7723f26576d55d43ed92f1178f2399ab39e9fa11621a47b" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy2.7-7.3.1-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
-install_package "pypy2.7-v7.3.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.3.1-src.tar.bz2#fa3771514c8a354969be9bd3b26d65a489c30e28f91d350e4ad2f4081a9c9321" "pypy_builder" verify_py27 ensurepip
+  install_package "pypy2.7-v7.3.1-src" "https://downloads.python.org/pypy/pypy2.7-v7.3.1-src.tar.bz2#fa3771514c8a354969be9bd3b26d65a489c30e28f91d350e4ad2f4081a9c9321" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy2.7-7.3.1-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy2.7-v7.3.1-src" "https://downloads.python.org/pypy/pypy2.7-v7.3.1-src.tar.bz2#fa3771514c8a354969be9bd3b26d65a489c30e28f91d350e4ad2f4081a9c9321" "pypy_builder" verify_py27 ensurepip
+install_package "pypy2.7-v7.3.1-src" "https://downloads.python.org/pypy/pypy2.7-v7.3.1-src.tar.bz2#fa3771514c8a354969be9bd3b26d65a489c30e28f91d350e4ad2f4081a9c9321" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy3-2.3.1
+++ b/plugins/python-build/share/python-build/pypy3-2.3.1
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
   install_package "pypy3-2.3.1-linux" "https://downloads.python.org/pypy/pypy3-2.3.1-linux.tar.bz2#7eddc6826e58c9c89e68b59ec8caf1596b76401517ad8d26ad5e18e0ffa45db9" "pypy" verify_py32 ensurepip
   else
-    install_package "pypy3-2.3.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.3.1-linux_i686-portable.tar.bz2#32a5b3fd4299b13aedf7bc6262eee0f6be9a27744ccf787718553d973ec38abb" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.3.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3-2.3.1-linux_i686-portable.tar.bz2#32a5b3fd4299b13aedf7bc6262eee0f6be9a27744ccf787718553d973ec38abb" "pypy" verify_py32 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -22,7 +22,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
   install_package "pypy3-2.3.1-linux64" "https://downloads.python.org/pypy/pypy3-2.3.1-linux64.tar.bz2#303df2cf4766db20ec77786d9091dce284fdab01d7173c5828a35e86bc931b99" "pypy" verify_py32 ensurepip
   else
-    install_package "pypy3-2.3.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.3.1-linux_x86_64-portable.tar.bz2#cb56b5bde8f444d44a0ea9cd475ddeed00aa895f3dcc89fd37577a51439540aa" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.3.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3-2.3.1-linux_x86_64-portable.tar.bz2#cb56b5bde8f444d44a0ea9cd475ddeed00aa895f3dcc89fd37577a51439540aa" "pypy" verify_py32 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy3-2.3.1
+++ b/plugins/python-build/share/python-build/pypy3-2.3.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-  install_package "pypy3-2.3.1-linux" "https://downloads.python.org/pypy/pypy3-2.3.1-linux.tar.bz2#7eddc6826e58c9c89e68b59ec8caf1596b76401517ad8d26ad5e18e0ffa45db9" "pypy" verify_py32 ensurepip
+    install_package "pypy3-2.3.1-linux" "https://downloads.python.org/pypy/pypy3-2.3.1-linux.tar.bz2#7eddc6826e58c9c89e68b59ec8caf1596b76401517ad8d26ad5e18e0ffa45db9" "pypy" verify_py32 ensurepip
   else
-  install_package "pypy3-2.3.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3-2.3.1-linux_i686-portable.tar.bz2#32a5b3fd4299b13aedf7bc6262eee0f6be9a27744ccf787718553d973ec38abb" "pypy" verify_py32 ensurepip
+    install_package "pypy3-2.3.1-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3-2.3.1-linux_i686-portable.tar.bz2#32a5b3fd4299b13aedf7bc6262eee0f6be9a27744ccf787718553d973ec38abb" "pypy" verify_py32 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,17 +12,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf")
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy3-2.3.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3-2.3.1-linux-armhf-raspbian.tar.bz2#033ccca1e3d7156d05ca8accd58b6371e15efc17468bbc3f963625b0c829b66b" "pypy" verify_py32 ensurepip
+    install_package "pypy3-2.3.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3-2.3.1-linux-armhf-raspbian.tar.bz2#033ccca1e3d7156d05ca8accd58b6371e15efc17468bbc3f963625b0c829b66b" "pypy" verify_py32 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy3-2.3.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy3-2.3.1-linux-armhf-raring.tar.bz2#bd7c19bde4b18158da42534a677f27c9b23855968e7cc3d4178cc9d1620a250a" "pypy" verify_py32 ensurepip
+    install_package "pypy3-2.3.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy3-2.3.1-linux-armhf-raring.tar.bz2#bd7c19bde4b18158da42534a677f27c9b23855968e7cc3d4178cc9d1620a250a" "pypy" verify_py32 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
-  install_package "pypy3-2.3.1-linux64" "https://downloads.python.org/pypy/pypy3-2.3.1-linux64.tar.bz2#303df2cf4766db20ec77786d9091dce284fdab01d7173c5828a35e86bc931b99" "pypy" verify_py32 ensurepip
+    install_package "pypy3-2.3.1-linux64" "https://downloads.python.org/pypy/pypy3-2.3.1-linux64.tar.bz2#303df2cf4766db20ec77786d9091dce284fdab01d7173c5828a35e86bc931b99" "pypy" verify_py32 ensurepip
   else
-  install_package "pypy3-2.3.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3-2.3.1-linux_x86_64-portable.tar.bz2#cb56b5bde8f444d44a0ea9cd475ddeed00aa895f3dcc89fd37577a51439540aa" "pypy" verify_py32 ensurepip
+    install_package "pypy3-2.3.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3-2.3.1-linux_x86_64-portable.tar.bz2#cb56b5bde8f444d44a0ea9cd475ddeed00aa895f3dcc89fd37577a51439540aa" "pypy" verify_py32 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy3-2.3.1
+++ b/plugins/python-build/share/python-build/pypy3-2.3.1
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-2.3.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux.tar.bz2#7eddc6826e58c9c89e68b59ec8caf1596b76401517ad8d26ad5e18e0ffa45db9" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.3.1-linux" "https://downloads.python.org/pypy/pypy3-2.3.1-linux.tar.bz2#7eddc6826e58c9c89e68b59ec8caf1596b76401517ad8d26ad5e18e0ffa45db9" "pypy" verify_py32 ensurepip
   else
     install_package "pypy3-2.3.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.3.1-linux_i686-portable.tar.bz2#32a5b3fd4299b13aedf7bc6262eee0f6be9a27744ccf787718553d973ec38abb" "pypy" verify_py32 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy3-2.3.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux-armel.tar.bz2#37ccdc68df322ba1bafe4177593b4ca293d1fffd60d72f2cf2326d090677f04f" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.3.1-linux-armel" "https://downloads.python.org/pypy/pypy3-2.3.1-linux-armel.tar.bz2#37ccdc68df322ba1bafe4177593b4ca293d1fffd60d72f2cf2326d090677f04f" "pypy" verify_py32 ensurepip
   ;;
 "linux-armhf")
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy3-2.3.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux-armhf-raspbian.tar.bz2#033ccca1e3d7156d05ca8accd58b6371e15efc17468bbc3f963625b0c829b66b" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.3.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3-2.3.1-linux-armhf-raspbian.tar.bz2#033ccca1e3d7156d05ca8accd58b6371e15efc17468bbc3f963625b0c829b66b" "pypy" verify_py32 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy3-2.3.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux-armhf-raring.tar.bz2#bd7c19bde4b18158da42534a677f27c9b23855968e7cc3d4178cc9d1620a250a" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.3.1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy3-2.3.1-linux-armhf-raring.tar.bz2#bd7c19bde4b18158da42534a677f27c9b23855968e7cc3d4178cc9d1620a250a" "pypy" verify_py32 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-2.3.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux64.tar.bz2#303df2cf4766db20ec77786d9091dce284fdab01d7173c5828a35e86bc931b99" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.3.1-linux64" "https://downloads.python.org/pypy/pypy3-2.3.1-linux64.tar.bz2#303df2cf4766db20ec77786d9091dce284fdab01d7173c5828a35e86bc931b99" "pypy" verify_py32 ensurepip
   else
     install_package "pypy3-2.3.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.3.1-linux_x86_64-portable.tar.bz2#cb56b5bde8f444d44a0ea9cd475ddeed00aa895f3dcc89fd37577a51439540aa" "pypy" verify_py32 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy3-2.3.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-osx64.tar.bz2#600d4dad2039b8035582c0e0ce9b71e8236d95db26cff48c84c6d1e0ea6814c1" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.3.1-osx64" "https://downloads.python.org/pypy/pypy3-2.3.1-osx64.tar.bz2#600d4dad2039b8035582c0e0ce9b71e8236d95db26cff48c84c6d1e0ea6814c1" "pypy" verify_py32 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy3-2.3.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-win32.zip#3f3566a39100da9b0fb730ff629352b48c5ae322546fce2c528c58fc0a652b26" "pypy" verify_py32 ensurepip
+  install_zip "pypy3-2.3.1-win32" "https://downloads.python.org/pypy/pypy3-2.3.1-win32.zip#3f3566a39100da9b0fb730ff629352b48c5ae322546fce2c528c58fc0a652b26" "pypy" verify_py32 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3-2.3.1-src
+++ b/plugins/python-build/share/python-build/pypy3-2.3.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3-2.3.1-src" "https://downloads.python.org/pypy/pypy3-2.3.1-src.tar.bz2#924ca36bf85e02469c71d451c145f9a6d19b905df473a3d1c25179c63ea79d74" "pypy_builder" verify_py32 ensurepip
+install_package "pypy3-2.3.1-src" "https://downloads.python.org/pypy/pypy3-2.3.1-src.tar.bz2#924ca36bf85e02469c71d451c145f9a6d19b905df473a3d1c25179c63ea79d74" "pypy_builder" verify_py32 ensurepip

--- a/plugins/python-build/share/python-build/pypy3-2.3.1-src
+++ b/plugins/python-build/share/python-build/pypy3-2.3.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3-2.3.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-src.tar.bz2#924ca36bf85e02469c71d451c145f9a6d19b905df473a3d1c25179c63ea79d74" "pypy_builder" verify_py32 ensurepip
+  install_package "pypy3-2.3.1-src" "https://downloads.python.org/pypy/pypy3-2.3.1-src.tar.bz2#924ca36bf85e02469c71d451c145f9a6d19b905df473a3d1c25179c63ea79d74" "pypy_builder" verify_py32 ensurepip

--- a/plugins/python-build/share/python-build/pypy3-2.4.0
+++ b/plugins/python-build/share/python-build/pypy3-2.4.0
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-2.4.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-linux.tar.bz2#108fdcccfddb9b2cb2fc3cbca5e6f7902ed3ab74a24c8ae29da7fbdadbab4345" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.4.0-linux" "https://downloads.python.org/pypy/pypy3-2.4.0-linux.tar.bz2#108fdcccfddb9b2cb2fc3cbca5e6f7902ed3ab74a24c8ae29da7fbdadbab4345" "pypy" verify_py32 ensurepip
   else
     install_package "pypy3-2.4-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.4-linux_i686-portable.tar.bz2#7ce050b4928dc58f7e9dd01e3e48c443c85616ca83f4bcc9147f1078d0fd126c" "pypy" verify_py32 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" || true
-  install_package "pypy3-2.4.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-linux-armel.tar.bz2#322ddc863006a97d48edc302a73bb0981bbc142951237ed161ca0ca2cd02831f" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.4.0-linux-armel" "https://downloads.python.org/pypy/pypy3-2.4.0-linux-armel.tar.bz2#322ddc863006a97d48edc302a73bb0981bbc142951237ed161ca0ca2cd02831f" "pypy" verify_py32 ensurepip
   ;;
 "linux-armhf")
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy3-2.4.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-linux-armhf-raspbian.tar.bz2#ad8f00255c85bf3c1012d56d5638c7aee12bc9f1ddcdaad35985bbd65a16c602" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.4.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3-2.4.0-linux-armhf-raspbian.tar.bz2#ad8f00255c85bf3c1012d56d5638c7aee12bc9f1ddcdaad35985bbd65a16c602" "pypy" verify_py32 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy3-2.4.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-linux-armhf-raring.tar.bz2#eb41a3ee62741199aeeab818553ded460db991911609acf36e5710f491e5ac0a" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.4.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy3-2.4.0-linux-armhf-raring.tar.bz2#eb41a3ee62741199aeeab818553ded460db991911609acf36e5710f491e5ac0a" "pypy" verify_py32 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-2.4.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-linux64.tar.bz2#24e680b1742af7361107876a421dd793f5ef852dd5f097546f84b1378f7f70cc" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.4.0-linux64" "https://downloads.python.org/pypy/pypy3-2.4.0-linux64.tar.bz2#24e680b1742af7361107876a421dd793f5ef852dd5f097546f84b1378f7f70cc" "pypy" verify_py32 ensurepip
   else
     install_package "pypy3-2.4-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.4-linux_x86_64-portable.tar.bz2#7b3e0f0bc924bd0d68d85c0b566979e74a2b366595db3d81502267367370a5fb" "pypy" verify_py32 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy3-2.4.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-osx64.tar.bz2#dcd86bdb753e93dbf55e1f3af3ffa97eea328b8b77aa60e92ea2260a6258cedb" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.4.0-osx64" "https://downloads.python.org/pypy/pypy3-2.4.0-osx64.tar.bz2#dcd86bdb753e93dbf55e1f3af3ffa97eea328b8b77aa60e92ea2260a6258cedb" "pypy" verify_py32 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy3-2.4.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-win32.zip#7ea499993b07405898dee9435836220d8c7b8abfa1b1f760c4a1c04b43945797" "pypy" verify_py32 ensurepip
+  install_zip "pypy3-2.4.0-win32" "https://downloads.python.org/pypy/pypy3-2.4.0-win32.zip#7ea499993b07405898dee9435836220d8c7b8abfa1b1f760c4a1c04b43945797" "pypy" verify_py32 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3-2.4.0
+++ b/plugins/python-build/share/python-build/pypy3-2.4.0
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
   install_package "pypy3-2.4.0-linux" "https://downloads.python.org/pypy/pypy3-2.4.0-linux.tar.bz2#108fdcccfddb9b2cb2fc3cbca5e6f7902ed3ab74a24c8ae29da7fbdadbab4345" "pypy" verify_py32 ensurepip
   else
-    install_package "pypy3-2.4-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.4-linux_i686-portable.tar.bz2#7ce050b4928dc58f7e9dd01e3e48c443c85616ca83f4bcc9147f1078d0fd126c" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.4-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3-2.4-linux_i686-portable.tar.bz2#7ce050b4928dc58f7e9dd01e3e48c443c85616ca83f4bcc9147f1078d0fd126c" "pypy" verify_py32 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -22,7 +22,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
   install_package "pypy3-2.4.0-linux64" "https://downloads.python.org/pypy/pypy3-2.4.0-linux64.tar.bz2#24e680b1742af7361107876a421dd793f5ef852dd5f097546f84b1378f7f70cc" "pypy" verify_py32 ensurepip
   else
-    install_package "pypy3-2.4-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.4-linux_x86_64-portable.tar.bz2#7b3e0f0bc924bd0d68d85c0b566979e74a2b366595db3d81502267367370a5fb" "pypy" verify_py32 ensurepip
+  install_package "pypy3-2.4-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3-2.4-linux_x86_64-portable.tar.bz2#7b3e0f0bc924bd0d68d85c0b566979e74a2b366595db3d81502267367370a5fb" "pypy" verify_py32 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy3-2.4.0
+++ b/plugins/python-build/share/python-build/pypy3-2.4.0
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-  install_package "pypy3-2.4.0-linux" "https://downloads.python.org/pypy/pypy3-2.4.0-linux.tar.bz2#108fdcccfddb9b2cb2fc3cbca5e6f7902ed3ab74a24c8ae29da7fbdadbab4345" "pypy" verify_py32 ensurepip
+    install_package "pypy3-2.4.0-linux" "https://downloads.python.org/pypy/pypy3-2.4.0-linux.tar.bz2#108fdcccfddb9b2cb2fc3cbca5e6f7902ed3ab74a24c8ae29da7fbdadbab4345" "pypy" verify_py32 ensurepip
   else
-  install_package "pypy3-2.4-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3-2.4-linux_i686-portable.tar.bz2#7ce050b4928dc58f7e9dd01e3e48c443c85616ca83f4bcc9147f1078d0fd126c" "pypy" verify_py32 ensurepip
+    install_package "pypy3-2.4-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3-2.4-linux_i686-portable.tar.bz2#7ce050b4928dc58f7e9dd01e3e48c443c85616ca83f4bcc9147f1078d0fd126c" "pypy" verify_py32 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,17 +12,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf")
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy3-2.4.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3-2.4.0-linux-armhf-raspbian.tar.bz2#ad8f00255c85bf3c1012d56d5638c7aee12bc9f1ddcdaad35985bbd65a16c602" "pypy" verify_py32 ensurepip
+    install_package "pypy3-2.4.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3-2.4.0-linux-armhf-raspbian.tar.bz2#ad8f00255c85bf3c1012d56d5638c7aee12bc9f1ddcdaad35985bbd65a16c602" "pypy" verify_py32 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy3-2.4.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy3-2.4.0-linux-armhf-raring.tar.bz2#eb41a3ee62741199aeeab818553ded460db991911609acf36e5710f491e5ac0a" "pypy" verify_py32 ensurepip
+    install_package "pypy3-2.4.0-linux-armhf-raring" "https://downloads.python.org/pypy/pypy3-2.4.0-linux-armhf-raring.tar.bz2#eb41a3ee62741199aeeab818553ded460db991911609acf36e5710f491e5ac0a" "pypy" verify_py32 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
-  install_package "pypy3-2.4.0-linux64" "https://downloads.python.org/pypy/pypy3-2.4.0-linux64.tar.bz2#24e680b1742af7361107876a421dd793f5ef852dd5f097546f84b1378f7f70cc" "pypy" verify_py32 ensurepip
+    install_package "pypy3-2.4.0-linux64" "https://downloads.python.org/pypy/pypy3-2.4.0-linux64.tar.bz2#24e680b1742af7361107876a421dd793f5ef852dd5f097546f84b1378f7f70cc" "pypy" verify_py32 ensurepip
   else
-  install_package "pypy3-2.4-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3-2.4-linux_x86_64-portable.tar.bz2#7b3e0f0bc924bd0d68d85c0b566979e74a2b366595db3d81502267367370a5fb" "pypy" verify_py32 ensurepip
+    install_package "pypy3-2.4-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3-2.4-linux_x86_64-portable.tar.bz2#7b3e0f0bc924bd0d68d85c0b566979e74a2b366595db3d81502267367370a5fb" "pypy" verify_py32 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy3-2.4.0-src
+++ b/plugins/python-build/share/python-build/pypy3-2.4.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3-2.4.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-src.tar.bz2#d9ba207d6eecf8a0dc4414e9f4e92db1abd143e8cc6ec4a6bdcac75b29f104f3" "pypy_builder" verify_py32 ensurepip
+  install_package "pypy3-2.4.0-src" "https://downloads.python.org/pypy/pypy3-2.4.0-src.tar.bz2#d9ba207d6eecf8a0dc4414e9f4e92db1abd143e8cc6ec4a6bdcac75b29f104f3" "pypy_builder" verify_py32 ensurepip

--- a/plugins/python-build/share/python-build/pypy3-2.4.0-src
+++ b/plugins/python-build/share/python-build/pypy3-2.4.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3-2.4.0-src" "https://downloads.python.org/pypy/pypy3-2.4.0-src.tar.bz2#d9ba207d6eecf8a0dc4414e9f4e92db1abd143e8cc6ec4a6bdcac75b29f104f3" "pypy_builder" verify_py32 ensurepip
+install_package "pypy3-2.4.0-src" "https://downloads.python.org/pypy/pypy3-2.4.0-src.tar.bz2#d9ba207d6eecf8a0dc4414e9f4e92db1abd143e8cc6ec4a6bdcac75b29f104f3" "pypy_builder" verify_py32 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1
+++ b/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
   install_package "pypy3.3-v5.2.0-alpha1-linux" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-linux32.tar.bz2#351aec101bdedddae7ea1b63845a5654b1a95fc9393894ef84a66749f6945f17" "pypy" verify_py33 ensurepip
   else
-    install_package "pypy3.3-5.2-alpha-20160602-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.3-5.2-alpha-20160602-linux_i686-portable.tar.bz2#6f2412167c63d6711b41062a23794828f95a75400082a6957595867762cb170d" "pypy" verify_py33 ensurepip
+  install_package "pypy3.3-5.2-alpha-20160602-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.3-5.2-alpha-20160602-linux_i686-portable.tar.bz2#6f2412167c63d6711b41062a23794828f95a75400082a6957595867762cb170d" "pypy" verify_py33 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -22,7 +22,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy3.3-v5.2.0-alpha1-linux64" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-linux64.tar.bz2#f5e66ab24267d6ddf662d07c512d06c10ebc732ae62093dabbd775ac63b9060a" "pypy" verify_py33 ensurepip
   else
-    install_package "pypy3.3-5.2-alpha-20160602-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.3-5.2-alpha-20160602-linux_x86_64-portable.tar.bz2#4d1e7dd727448c1b2caa90c943713c0aa10b32e9d977c2c3b348835f515a3ad4" "pypy" verify_py33 ensurepip
+  install_package "pypy3.3-5.2-alpha-20160602-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.3-5.2-alpha-20160602-linux_x86_64-portable.tar.bz2#4d1e7dd727448c1b2caa90c943713c0aa10b32e9d977c2c3b348835f515a3ad4" "pypy" verify_py33 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1
+++ b/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-  install_package "pypy3.3-v5.2.0-alpha1-linux" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-linux32.tar.bz2#351aec101bdedddae7ea1b63845a5654b1a95fc9393894ef84a66749f6945f17" "pypy" verify_py33 ensurepip
+    install_package "pypy3.3-v5.2.0-alpha1-linux" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-linux32.tar.bz2#351aec101bdedddae7ea1b63845a5654b1a95fc9393894ef84a66749f6945f17" "pypy" verify_py33 ensurepip
   else
-  install_package "pypy3.3-5.2-alpha-20160602-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.3-5.2-alpha-20160602-linux_i686-portable.tar.bz2#6f2412167c63d6711b41062a23794828f95a75400082a6957595867762cb170d" "pypy" verify_py33 ensurepip
+    install_package "pypy3.3-5.2-alpha-20160602-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.3-5.2-alpha-20160602-linux_i686-portable.tar.bz2#6f2412167c63d6711b41062a23794828f95a75400082a6957595867762cb170d" "pypy" verify_py33 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,17 +12,17 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy3.3-v5.2.0-alpha1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-linux-armhf-raspbian.tar.bz2#ba9a5d0cbac1c622363315b30df288ab2cf8fcccf7e2882bf5946115dbfa657e" "pypy" verify_py33 ensurepip
+    install_package "pypy3.3-v5.2.0-alpha1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-linux-armhf-raspbian.tar.bz2#ba9a5d0cbac1c622363315b30df288ab2cf8fcccf7e2882bf5946115dbfa657e" "pypy" verify_py33 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-  install_package "pypy3.3-v5.2.0-alpha1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-linux-armhf-raring.tar.bz2#b4d847d33c1bf9b3956d1d17b9e37505eb32f68e341c9333a74a82010a63e799" "pypy" verify_py33 ensurepip
+    install_package "pypy3.3-v5.2.0-alpha1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-linux-armhf-raring.tar.bz2#b4d847d33c1bf9b3956d1d17b9e37505eb32f68e341c9333a74a82010a63e799" "pypy" verify_py33 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy3.3-v5.2.0-alpha1-linux64" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-linux64.tar.bz2#f5e66ab24267d6ddf662d07c512d06c10ebc732ae62093dabbd775ac63b9060a" "pypy" verify_py33 ensurepip
+    install_package "pypy3.3-v5.2.0-alpha1-linux64" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-linux64.tar.bz2#f5e66ab24267d6ddf662d07c512d06c10ebc732ae62093dabbd775ac63b9060a" "pypy" verify_py33 ensurepip
   else
-  install_package "pypy3.3-5.2-alpha-20160602-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.3-5.2-alpha-20160602-linux_x86_64-portable.tar.bz2#4d1e7dd727448c1b2caa90c943713c0aa10b32e9d977c2c3b348835f515a3ad4" "pypy" verify_py33 ensurepip
+    install_package "pypy3.3-5.2-alpha-20160602-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.3-5.2-alpha-20160602-linux_x86_64-portable.tar.bz2#4d1e7dd727448c1b2caa90c943713c0aa10b32e9d977c2c3b348835f515a3ad4" "pypy" verify_py33 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1
+++ b/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1
@@ -1,32 +1,32 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy3.3-v5.2.0-alpha1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux32.tar.bz2#351aec101bdedddae7ea1b63845a5654b1a95fc9393894ef84a66749f6945f17" "pypy" verify_py33 ensurepip
+  install_package "pypy3.3-v5.2.0-alpha1-linux" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-linux32.tar.bz2#351aec101bdedddae7ea1b63845a5654b1a95fc9393894ef84a66749f6945f17" "pypy" verify_py33 ensurepip
   else
     install_package "pypy3.3-5.2-alpha-20160602-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.3-5.2-alpha-20160602-linux_i686-portable.tar.bz2#6f2412167c63d6711b41062a23794828f95a75400082a6957595867762cb170d" "pypy" verify_py33 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy3.3-v5.2.0-alpha1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux-armel.tar.bz2#ac83e632213f078ab60045e6ad0564b146d65dcd9a52c130026fab6dd85bf2dc" "pypy" verify_py33 ensurepip
+  install_package "pypy3.3-v5.2.0-alpha1-linux-armel" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-linux-armel.tar.bz2#ac83e632213f078ab60045e6ad0564b146d65dcd9a52c130026fab6dd85bf2dc" "pypy" verify_py33 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy3.3-v5.2.0-alpha1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux-armhf-raspbian.tar.bz2#ba9a5d0cbac1c622363315b30df288ab2cf8fcccf7e2882bf5946115dbfa657e" "pypy" verify_py33 ensurepip
+  install_package "pypy3.3-v5.2.0-alpha1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-linux-armhf-raspbian.tar.bz2#ba9a5d0cbac1c622363315b30df288ab2cf8fcccf7e2882bf5946115dbfa657e" "pypy" verify_py33 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy3.3-v5.2.0-alpha1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux-armhf-raring.tar.bz2#b4d847d33c1bf9b3956d1d17b9e37505eb32f68e341c9333a74a82010a63e799" "pypy" verify_py33 ensurepip
+  install_package "pypy3.3-v5.2.0-alpha1-linux-armhf-raring" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-linux-armhf-raring.tar.bz2#b4d847d33c1bf9b3956d1d17b9e37505eb32f68e341c9333a74a82010a63e799" "pypy" verify_py33 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy3.3-v5.2.0-alpha1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux64.tar.bz2#f5e66ab24267d6ddf662d07c512d06c10ebc732ae62093dabbd775ac63b9060a" "pypy" verify_py33 ensurepip
+  install_package "pypy3.3-v5.2.0-alpha1-linux64" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-linux64.tar.bz2#f5e66ab24267d6ddf662d07c512d06c10ebc732ae62093dabbd775ac63b9060a" "pypy" verify_py33 ensurepip
   else
     install_package "pypy3.3-5.2-alpha-20160602-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.3-5.2-alpha-20160602-linux_x86_64-portable.tar.bz2#4d1e7dd727448c1b2caa90c943713c0aa10b32e9d977c2c3b348835f515a3ad4" "pypy" verify_py33 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy3.3-v5.2.0-alpha1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-osx64.tar.bz2#abaceab5d2790f49e04e0d80669283da41f94b77cf483b30ac0de48d3c19f304" "pypy" verify_py33 ensurepip
+  install_package "pypy3.3-v5.2.0-alpha1-osx64" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-osx64.tar.bz2#abaceab5d2790f49e04e0d80669283da41f94b77cf483b30ac0de48d3c19f304" "pypy" verify_py33 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1-src
+++ b/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3.3-v5.2.0-alpha1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-src.tar.bz2#344c2f088c82ea1274964bb0505ab80d3f9e538cc03f91aa109325ddbaa61426" "pypy_builder" verify_py33 ensurepip
+  install_package "pypy3.3-v5.2.0-alpha1-src" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-src.tar.bz2#344c2f088c82ea1274964bb0505ab80d3f9e538cc03f91aa109325ddbaa61426" "pypy_builder" verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1-src
+++ b/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3.3-v5.2.0-alpha1-src" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-src.tar.bz2#344c2f088c82ea1274964bb0505ab80d3f9e538cc03f91aa109325ddbaa61426" "pypy_builder" verify_py33 ensurepip
+install_package "pypy3.3-v5.2.0-alpha1-src" "https://downloads.python.org/pypy/pypy3.3-v5.2.0-alpha1-src.tar.bz2#344c2f088c82ea1274964bb0505ab80d3f9e538cc03f91aa109325ddbaa61426" "pypy_builder" verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.3-5.5-alpha
+++ b/plugins/python-build/share/python-build/pypy3.3-5.5-alpha
@@ -1,18 +1,18 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy3.3-v5.5.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.5.0-alpha-linux32.tar.bz2#966ee7951ad497ac907e01554fe48da77cc64a5e35a1307477c2f78652eba622" "pypy" verify_py33 ensurepip
+  install_package "pypy3.3-v5.5.0-linux32" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-linux32.tar.bz2#966ee7951ad497ac907e01554fe48da77cc64a5e35a1307477c2f78652eba622" "pypy" verify_py33 ensurepip
   else
     install_package "pypy3.3-5.5-alpha-20161014-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.3-5.5-alpha-20161014-linux_i686-portable.tar.bz2#af32420f368bc3276d15a5cf4e2e8cb0bef16f711ee830a636ad117e55c3268f" "pypy" verify_py33 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy3-v5.5.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.5.0-alpha-linux-armel.tar.bz2#9f081041867f434f18456f936befbacd9f40c0ede24137cbf80f9f45ff37b69f" "pypy" verify_py33 ensurepip
+  install_package "pypy3-v5.5.0-linux-armel" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-linux-armel.tar.bz2#9f081041867f434f18456f936befbacd9f40c0ede24137cbf80f9f45ff37b69f" "pypy" verify_py33 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy3-v5.5.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.5.0-alpha-linux-armhf-raspbian.tar.bz2#d8e94c834307081d5c4be863fab935e34df360a77b06e8bc833624c4b712b2aa" "pypy" verify_py33 ensurepip
+  install_package "pypy3-v5.5.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-linux-armhf-raspbian.tar.bz2#d8e94c834307081d5c4be863fab935e34df360a77b06e8bc833624c4b712b2aa" "pypy" verify_py33 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -25,13 +25,13 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-v5.5.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.5.0-alpha-linux64.tar.bz2#41ef7c25fd04eeb20deaa83c5d88c10aef2bbc8bcfd9e53e7cc61136220861cc" "pypy" verify_py33 ensurepip
+  install_package "pypy3-v5.5.0-linux64" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-linux64.tar.bz2#41ef7c25fd04eeb20deaa83c5d88c10aef2bbc8bcfd9e53e7cc61136220861cc" "pypy" verify_py33 ensurepip
   else
     install_package "pypy3.3-5.5-alpha-20161013-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.3-5.5-alpha-20161013-linux_x86_64-portable.tar.bz2#1cd7a00da376b2db29b3e1f3e9bb7a77afc8ad988b3f13fd0805f37b23960a34" "pypy" verify_py33 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy3-v5.5.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.5.0-alpha-osx64.tar.bz2#fa45f861a6c40ae44f99ec94c521adfb6b64b0c9c0b6fc6e9df018241a648986" "pypy" verify_py33 ensurepip
+  install_package "pypy3-v5.5.0-osx64" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-osx64.tar.bz2#fa45f861a6c40ae44f99ec94c521adfb6b64b0c9c0b6fc6e9df018241a648986" "pypy" verify_py33 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3.3-5.5-alpha
+++ b/plugins/python-build/share/python-build/pypy3.3-5.5-alpha
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy3.3-v5.5.0-linux32" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-linux32.tar.bz2#966ee7951ad497ac907e01554fe48da77cc64a5e35a1307477c2f78652eba622" "pypy" verify_py33 ensurepip
   else
-    install_package "pypy3.3-5.5-alpha-20161014-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.3-5.5-alpha-20161014-linux_i686-portable.tar.bz2#af32420f368bc3276d15a5cf4e2e8cb0bef16f711ee830a636ad117e55c3268f" "pypy" verify_py33 ensurepip
+  install_package "pypy3.3-5.5-alpha-20161014-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.3-5.5-alpha-20161014-linux_i686-portable.tar.bz2#af32420f368bc3276d15a5cf4e2e8cb0bef16f711ee830a636ad117e55c3268f" "pypy" verify_py33 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -27,7 +27,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy3-v5.5.0-linux64" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-linux64.tar.bz2#41ef7c25fd04eeb20deaa83c5d88c10aef2bbc8bcfd9e53e7cc61136220861cc" "pypy" verify_py33 ensurepip
   else
-    install_package "pypy3.3-5.5-alpha-20161013-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.3-5.5-alpha-20161013-linux_x86_64-portable.tar.bz2#1cd7a00da376b2db29b3e1f3e9bb7a77afc8ad988b3f13fd0805f37b23960a34" "pypy" verify_py33 ensurepip
+  install_package "pypy3.3-5.5-alpha-20161013-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.3-5.5-alpha-20161013-linux_x86_64-portable.tar.bz2#1cd7a00da376b2db29b3e1f3e9bb7a77afc8ad988b3f13fd0805f37b23960a34" "pypy" verify_py33 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy3.3-5.5-alpha
+++ b/plugins/python-build/share/python-build/pypy3.3-5.5-alpha
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy3.3-v5.5.0-linux32" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-linux32.tar.bz2#966ee7951ad497ac907e01554fe48da77cc64a5e35a1307477c2f78652eba622" "pypy" verify_py33 ensurepip
+    install_package "pypy3.3-v5.5.0-linux32" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-linux32.tar.bz2#966ee7951ad497ac907e01554fe48da77cc64a5e35a1307477c2f78652eba622" "pypy" verify_py33 ensurepip
   else
-  install_package "pypy3.3-5.5-alpha-20161014-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.3-5.5-alpha-20161014-linux_i686-portable.tar.bz2#af32420f368bc3276d15a5cf4e2e8cb0bef16f711ee830a636ad117e55c3268f" "pypy" verify_py33 ensurepip
+    install_package "pypy3.3-5.5-alpha-20161014-linux_i686-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.3-5.5-alpha-20161014-linux_i686-portable.tar.bz2#af32420f368bc3276d15a5cf4e2e8cb0bef16f711ee830a636ad117e55c3268f" "pypy" verify_py33 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -12,7 +12,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy3-v5.5.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-linux-armhf-raspbian.tar.bz2#d8e94c834307081d5c4be863fab935e34df360a77b06e8bc833624c4b712b2aa" "pypy" verify_py33 ensurepip
+    install_package "pypy3-v5.5.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-linux-armhf-raspbian.tar.bz2#d8e94c834307081d5c4be863fab935e34df360a77b06e8bc833624c4b712b2aa" "pypy" verify_py33 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -25,9 +25,9 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy3-v5.5.0-linux64" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-linux64.tar.bz2#41ef7c25fd04eeb20deaa83c5d88c10aef2bbc8bcfd9e53e7cc61136220861cc" "pypy" verify_py33 ensurepip
+    install_package "pypy3-v5.5.0-linux64" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-linux64.tar.bz2#41ef7c25fd04eeb20deaa83c5d88c10aef2bbc8bcfd9e53e7cc61136220861cc" "pypy" verify_py33 ensurepip
   else
-  install_package "pypy3.3-5.5-alpha-20161013-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.3-5.5-alpha-20161013-linux_x86_64-portable.tar.bz2#1cd7a00da376b2db29b3e1f3e9bb7a77afc8ad988b3f13fd0805f37b23960a34" "pypy" verify_py33 ensurepip
+    install_package "pypy3.3-5.5-alpha-20161013-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.3-5.5-alpha-20161013-linux_x86_64-portable.tar.bz2#1cd7a00da376b2db29b3e1f3e9bb7a77afc8ad988b3f13fd0805f37b23960a34" "pypy" verify_py33 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy3.3-5.5-alpha-src
+++ b/plugins/python-build/share/python-build/pypy3.3-5.5-alpha-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3-v5.5.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.5.0-alpha-src.tar.bz2#d5591c34d77253e9ed57d182b6f49585b95f7c09c3e121f0e8630e5a7e75ab5f" "pypy_builder" verify_py33 ensurepip
+  install_package "pypy3-v5.5.0-src" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-src.tar.bz2#d5591c34d77253e9ed57d182b6f49585b95f7c09c3e121f0e8630e5a7e75ab5f" "pypy_builder" verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.3-5.5-alpha-src
+++ b/plugins/python-build/share/python-build/pypy3.3-5.5-alpha-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3-v5.5.0-src" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-src.tar.bz2#d5591c34d77253e9ed57d182b6f49585b95f7c09c3e121f0e8630e5a7e75ab5f" "pypy_builder" verify_py33 ensurepip
+install_package "pypy3-v5.5.0-src" "https://downloads.python.org/pypy/pypy3.3-v5.5.0-alpha-src.tar.bz2#d5591c34d77253e9ed57d182b6f49585b95f7c09c3e121f0e8630e5a7e75ab5f" "pypy_builder" verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.0
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.0
@@ -1,14 +1,14 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy3-v5.10.0-linux32" "https://downloads.python.org/pypy/pypy3-v5.10.0-linux32.tar.bz2#529bc3b11edbdcdd676d90c805b8f607f6eedd5f0ec457a31bbe09c03f5bebfe" "pypy" verify_py27 ensurepip
+    install_package "pypy3-v5.10.0-linux32" "https://downloads.python.org/pypy/pypy3-v5.10.0-linux32.tar.bz2#529bc3b11edbdcdd676d90c805b8f607f6eedd5f0ec457a31bbe09c03f5bebfe" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy3-v5.10.0-linux64" "https://downloads.python.org/pypy/pypy3-v5.10.0-linux64.tar.bz2#aa4fb52fb858d973dd838dcf8d74f30705e5afdf1150acb8e056eb99353dfe77" "pypy" verify_py27 ensurepip
+    install_package "pypy3-v5.10.0-linux64" "https://downloads.python.org/pypy/pypy3-v5.10.0-linux64.tar.bz2#aa4fb52fb858d973dd838dcf8d74f30705e5afdf1150acb8e056eb99353dfe77" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy3.5-5.10.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-5.10.0-linux_x86_64-portable.tar.bz2#d03f81f26e5e67d808569c5c69d56ceb007df78f7e36ab1c50da4d9096cebde0" "pypy" verify_py35 ensurepip
+    install_package "pypy3.5-5.10.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-5.10.0-linux_x86_64-portable.tar.bz2#d03f81f26e5e67d808569c5c69d56ceb007df78f7e36ab1c50da4d9096cebde0" "pypy" verify_py35 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -17,7 +17,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy3-v5.10.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3-v5.10.0-linux-armhf-raspbian.tar.bz2#4e902e0e79f62f2a9049c1c71310ff4fc801011bec4d25082edb5c537d3f15c9" "pypy" verify_py27 ensurepip
+    install_package "pypy3-v5.10.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3-v5.10.0-linux-armhf-raspbian.tar.bz2#4e902e0e79f62f2a9049c1c71310ff4fc801011bec4d25082edb5c537d3f15c9" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -30,9 +30,9 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-  install_package "pypy3-v5.10.0-osx64" "https://downloads.python.org/pypy/pypy3-v5.10.0-osx64.tar.bz2#7e389a103f560de1eead1271ec3a2df9424c6ccffe7cbae8e95e6e81ae811a16" "pypy" verify_py27 ensurepip
+    install_package "pypy3-v5.10.0-osx64" "https://downloads.python.org/pypy/pypy3-v5.10.0-osx64.tar.bz2#7e389a103f560de1eead1271ec3a2df9424c6ccffe7cbae8e95e6e81ae811a16" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy3-v5.10.0-osx64-2" "https://downloads.python.org/pypy/pypy3-v5.10.0-osx64-2.tar.bz2#f5ced20934fff78e55c72aa82a4703954349a5a8099b94e77d74b96a94326a2c" "pypy" verify_py27 ensurepip
+    install_package "pypy3-v5.10.0-osx64-2" "https://downloads.python.org/pypy/pypy3-v5.10.0-osx64-2.tar.bz2#f5ced20934fff78e55c72aa82a4703954349a5a8099b94e77d74b96a94326a2c" "pypy" verify_py27 ensurepip
   fi
   ;;
 "win32" )

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.0
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.0
@@ -8,7 +8,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
   install_package "pypy3-v5.10.0-linux64" "https://downloads.python.org/pypy/pypy3-v5.10.0-linux64.tar.bz2#aa4fb52fb858d973dd838dcf8d74f30705e5afdf1150acb8e056eb99353dfe77" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy3.5-5.10.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.10.0-linux_x86_64-portable.tar.bz2#d03f81f26e5e67d808569c5c69d56ceb007df78f7e36ab1c50da4d9096cebde0" "pypy" verify_py35 ensurepip
+  install_package "pypy3.5-5.10.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-5.10.0-linux_x86_64-portable.tar.bz2#d03f81f26e5e67d808569c5c69d56ceb007df78f7e36ab1c50da4d9096cebde0" "pypy" verify_py35 ensurepip
   fi
   ;;
 "linux-armel" )

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.0
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.0
@@ -1,23 +1,23 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-v5.10.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-linux32.tar.bz2#529bc3b11edbdcdd676d90c805b8f607f6eedd5f0ec457a31bbe09c03f5bebfe" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v5.10.0-linux32" "https://downloads.python.org/pypy/pypy3-v5.10.0-linux32.tar.bz2#529bc3b11edbdcdd676d90c805b8f607f6eedd5f0ec457a31bbe09c03f5bebfe" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-v5.10.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-linux64.tar.bz2#aa4fb52fb858d973dd838dcf8d74f30705e5afdf1150acb8e056eb99353dfe77" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v5.10.0-linux64" "https://downloads.python.org/pypy/pypy3-v5.10.0-linux64.tar.bz2#aa4fb52fb858d973dd838dcf8d74f30705e5afdf1150acb8e056eb99353dfe77" "pypy" verify_py27 ensurepip
   else
     install_package "pypy3.5-5.10.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.10.0-linux_x86_64-portable.tar.bz2#d03f81f26e5e67d808569c5c69d56ceb007df78f7e36ab1c50da4d9096cebde0" "pypy" verify_py35 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy3-v5.10.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-linux-armel.tar.bz2#c2cc529befb3e1f2ef8bd4e96af4a823c52ef2d180b0b3bd87511c5b47d59210" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v5.10.0-linux-armel" "https://downloads.python.org/pypy/pypy3-v5.10.0-linux-armel.tar.bz2#c2cc529befb3e1f2ef8bd4e96af4a823c52ef2d180b0b3bd87511c5b47d59210" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy3-v5.10.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-linux-armhf-raspbian.tar.bz2#4e902e0e79f62f2a9049c1c71310ff4fc801011bec4d25082edb5c537d3f15c9" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v5.10.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3-v5.10.0-linux-armhf-raspbian.tar.bz2#4e902e0e79f62f2a9049c1c71310ff4fc801011bec4d25082edb5c537d3f15c9" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -30,14 +30,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy3-v5.10.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-osx64.tar.bz2#7e389a103f560de1eead1271ec3a2df9424c6ccffe7cbae8e95e6e81ae811a16" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v5.10.0-osx64" "https://downloads.python.org/pypy/pypy3-v5.10.0-osx64.tar.bz2#7e389a103f560de1eead1271ec3a2df9424c6ccffe7cbae8e95e6e81ae811a16" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy3-v5.10.0-osx64-2" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-osx64-2.tar.bz2#f5ced20934fff78e55c72aa82a4703954349a5a8099b94e77d74b96a94326a2c" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v5.10.0-osx64-2" "https://downloads.python.org/pypy/pypy3-v5.10.0-osx64-2.tar.bz2#f5ced20934fff78e55c72aa82a4703954349a5a8099b94e77d74b96a94326a2c" "pypy" verify_py27 ensurepip
   fi
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy3-v5.10.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-win32.zip#2d93bf2bd7b1d031b96331d3fde6cacdda95673ce6875d6d1669c4c0ea2a52bc" "pypy" verify_py27 ensurepip
+  install_zip "pypy3-v5.10.0-win32" "https://downloads.python.org/pypy/pypy3-v5.10.0-win32.zip#2d93bf2bd7b1d031b96331d3fde6cacdda95673ce6875d6d1669c4c0ea2a52bc" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3-v5.10.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.0-src.tar.bz2#a6e4cffde71e3f08b6e1befa5c0352a9bcc5f4e9f5cbf395001e0763a1a0d9e3" "pypy_builder" verify_py35 ensurepip
+  install_package "pypy3-v5.10.0-src" "https://downloads.python.org/pypy/pypy3-v5.10.0-src.tar.bz2#a6e4cffde71e3f08b6e1befa5c0352a9bcc5f4e9f5cbf395001e0763a1a0d9e3" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3-v5.10.0-src" "https://downloads.python.org/pypy/pypy3-v5.10.0-src.tar.bz2#a6e4cffde71e3f08b6e1befa5c0352a9bcc5f4e9f5cbf395001e0763a1a0d9e3" "pypy_builder" verify_py35 ensurepip
+install_package "pypy3-v5.10.0-src" "https://downloads.python.org/pypy/pypy3-v5.10.0-src.tar.bz2#a6e4cffde71e3f08b6e1befa5c0352a9bcc5f4e9f5cbf395001e0763a1a0d9e3" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.1
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.1
@@ -30,7 +30,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-  install_package "pypy3-v5.10.1-osx64" "https://downloads.python.org/pypy/pypy3-v5.10.1-osx64.tar.bz2#52f006611513c995fdebba6e72d394186d4085460408cbbe086e5467bf3fb9b6" "pypy" verify_py27 ensurepip
+    install_package "pypy3-v5.10.1-osx64" "https://downloads.python.org/pypy/pypy3-v5.10.1-osx64.tar.bz2#52f006611513c995fdebba6e72d394186d4085460408cbbe086e5467bf3fb9b6" "pypy" verify_py27 ensurepip
   else
   #  install_package "pypy3-v5.10.1-osx64-2" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.1-osx64-2.tar.bz2#" "pypy" verify_py27 ensurepip
     { echo

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.1
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.1
@@ -1,14 +1,14 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy3-v5.10.1-linux32" "https://downloads.python.org/pypy/pypy3-v5.10.1-linux32.tar.bz2#a6ceca9ee5dc511de7902164464b88311fec9366c5673d0c00528eda862bbe54" "pypy" verify_py27 ensurepip
+    install_package "pypy3-v5.10.1-linux32" "https://downloads.python.org/pypy/pypy3-v5.10.1-linux32.tar.bz2#a6ceca9ee5dc511de7902164464b88311fec9366c5673d0c00528eda862bbe54" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy3-v5.10.1-linux64" "https://downloads.python.org/pypy/pypy3-v5.10.1-linux64.tar.bz2#75a276e1ee1863967bbacb70c5bff636de200768c0ec90e72f7ec17aace0aefe" "pypy" verify_py27 ensurepip
+    install_package "pypy3-v5.10.1-linux64" "https://downloads.python.org/pypy/pypy3-v5.10.1-linux64.tar.bz2#75a276e1ee1863967bbacb70c5bff636de200768c0ec90e72f7ec17aace0aefe" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy3.5-5.10.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-5.10.1-linux_x86_64-portable.tar.bz2#b7c7b0e0905208ce8a8061b1a0ae136a702e5218d0d350cb5216ad5a7c20d12e" "pypy" verify_py35 ensurepip
+    install_package "pypy3.5-5.10.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-5.10.1-linux_x86_64-portable.tar.bz2#b7c7b0e0905208ce8a8061b1a0ae136a702e5218d0d350cb5216ad5a7c20d12e" "pypy" verify_py35 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -17,7 +17,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy3-v5.10.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3-v5.10.1-linux-armhf-raspbian.tar.bz2#203dd595fbad7055340b23326f20c85b0d6c11c4877e3559a437611fc2ac40c2" "pypy" verify_py27 ensurepip
+    install_package "pypy3-v5.10.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3-v5.10.1-linux-armhf-raspbian.tar.bz2#203dd595fbad7055340b23326f20c85b0d6c11c4877e3559a437611fc2ac40c2" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.1
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.1
@@ -8,7 +8,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
   install_package "pypy3-v5.10.1-linux64" "https://downloads.python.org/pypy/pypy3-v5.10.1-linux64.tar.bz2#75a276e1ee1863967bbacb70c5bff636de200768c0ec90e72f7ec17aace0aefe" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy3.5-5.10.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.10.1-linux_x86_64-portable.tar.bz2#b7c7b0e0905208ce8a8061b1a0ae136a702e5218d0d350cb5216ad5a7c20d12e" "pypy" verify_py35 ensurepip
+  install_package "pypy3.5-5.10.1-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-5.10.1-linux_x86_64-portable.tar.bz2#b7c7b0e0905208ce8a8061b1a0ae136a702e5218d0d350cb5216ad5a7c20d12e" "pypy" verify_py35 ensurepip
   fi
   ;;
 "linux-armel" )

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.1
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.1
@@ -1,23 +1,23 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-v5.10.1-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.1-linux32.tar.bz2#a6ceca9ee5dc511de7902164464b88311fec9366c5673d0c00528eda862bbe54" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v5.10.1-linux32" "https://downloads.python.org/pypy/pypy3-v5.10.1-linux32.tar.bz2#a6ceca9ee5dc511de7902164464b88311fec9366c5673d0c00528eda862bbe54" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-v5.10.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.1-linux64.tar.bz2#75a276e1ee1863967bbacb70c5bff636de200768c0ec90e72f7ec17aace0aefe" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v5.10.1-linux64" "https://downloads.python.org/pypy/pypy3-v5.10.1-linux64.tar.bz2#75a276e1ee1863967bbacb70c5bff636de200768c0ec90e72f7ec17aace0aefe" "pypy" verify_py27 ensurepip
   else
     install_package "pypy3.5-5.10.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.10.1-linux_x86_64-portable.tar.bz2#b7c7b0e0905208ce8a8061b1a0ae136a702e5218d0d350cb5216ad5a7c20d12e" "pypy" verify_py35 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy3-v5.10.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.1-linux-armel.tar.bz2#5065e9ad958d06b9612ba974f43997d20168d4245c054dd43270e4b458782282" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v5.10.1-linux-armel" "https://downloads.python.org/pypy/pypy3-v5.10.1-linux-armel.tar.bz2#5065e9ad958d06b9612ba974f43997d20168d4245c054dd43270e4b458782282" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy3-v5.10.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.1-linux-armhf-raspbian.tar.bz2#203dd595fbad7055340b23326f20c85b0d6c11c4877e3559a437611fc2ac40c2" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v5.10.1-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3-v5.10.1-linux-armhf-raspbian.tar.bz2#203dd595fbad7055340b23326f20c85b0d6c11c4877e3559a437611fc2ac40c2" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -30,7 +30,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy3-v5.10.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.1-osx64.tar.bz2#52f006611513c995fdebba6e72d394186d4085460408cbbe086e5467bf3fb9b6" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v5.10.1-osx64" "https://downloads.python.org/pypy/pypy3-v5.10.1-osx64.tar.bz2#52f006611513c995fdebba6e72d394186d4085460408cbbe086e5467bf3fb9b6" "pypy" verify_py27 ensurepip
   else
   #  install_package "pypy3-v5.10.1-osx64-2" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.1-osx64-2.tar.bz2#" "pypy" verify_py27 ensurepip
     { echo
@@ -44,7 +44,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy3-v5.10.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.1-win32.zip#4edf4f021689a529e5a631c5cca72a1a9dc19a6ea2091e64289cdd5b60eaf929" "pypy" verify_py27 ensurepip
+  install_zip "pypy3-v5.10.1-win32" "https://downloads.python.org/pypy/pypy3-v5.10.1-win32.zip#4edf4f021689a529e5a631c5cca72a1a9dc19a6ea2091e64289cdd5b60eaf929" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.1-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3-v5.10.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.10.1-src.tar.bz2#f5548e06e2fc0c24ec8b6e3c5b09f90081818f7caa3e436dc312592611724713" "pypy_builder" verify_py35 ensurepip
+  install_package "pypy3-v5.10.1-src" "https://downloads.python.org/pypy/pypy3-v5.10.1-src.tar.bz2#f5548e06e2fc0c24ec8b6e3c5b09f90081818f7caa3e436dc312592611724713" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.10.1-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.10.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3-v5.10.1-src" "https://downloads.python.org/pypy/pypy3-v5.10.1-src.tar.bz2#f5548e06e2fc0c24ec8b6e3c5b09f90081818f7caa3e436dc312592611724713" "pypy_builder" verify_py35 ensurepip
+install_package "pypy3-v5.10.1-src" "https://downloads.python.org/pypy/pypy3-v5.10.1-src.tar.bz2#f5548e06e2fc0c24ec8b6e3c5b09f90081818f7caa3e436dc312592611724713" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.7-beta
+++ b/plugins/python-build/share/python-build/pypy3.5-5.7-beta
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy3-v5.7.0-linux64" "https://downloads.python.org/pypy/pypy3-v5.7.0-linux64.tar.bz2#921894884a647220a712ecdaad516d9c22fbadf3b4bb3a5db8f3635c60eabc7b" "pypy" verify_py35 ensurepip
+    install_package "pypy3-v5.7.0-linux64" "https://downloads.python.org/pypy/pypy3-v5.7.0-linux64.tar.bz2#921894884a647220a712ecdaad516d9c22fbadf3b4bb3a5db8f3635c60eabc7b" "pypy" verify_py35 ensurepip
   else
     install_package "pypy3.5-5.7-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.7-beta-linux_x86_64-portable.tar.bz2#d289ff7c32fd4263c3889994c8191c626891513e8ab60a65ba41a58b331db92c" "pypy" verify_py35 ensurepip
   fi

--- a/plugins/python-build/share/python-build/pypy3.5-5.7-beta
+++ b/plugins/python-build/share/python-build/pypy3.5-5.7-beta
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-v5.7.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.7.0-linux64.tar.bz2#921894884a647220a712ecdaad516d9c22fbadf3b4bb3a5db8f3635c60eabc7b" "pypy" verify_py35 ensurepip
+  install_package "pypy3-v5.7.0-linux64" "https://downloads.python.org/pypy/pypy3-v5.7.0-linux64.tar.bz2#921894884a647220a712ecdaad516d9c22fbadf3b4bb3a5db8f3635c60eabc7b" "pypy" verify_py35 ensurepip
   else
     install_package "pypy3.5-5.7-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.7-beta-linux_x86_64-portable.tar.bz2#d289ff7c32fd4263c3889994c8191c626891513e8ab60a65ba41a58b331db92c" "pypy" verify_py35 ensurepip
   fi

--- a/plugins/python-build/share/python-build/pypy3.5-5.7-beta-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.7-beta-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3-v5.7.0-src" "https://downloads.python.org/pypy/pypy3-v5.7.0-src.tar.bz2#f0f563b74f8b82ec33b022393219b93cc0d81e9f9500614fe8417b67a52e9569" "pypy_builder" verify_py35 ensurepip
+install_package "pypy3-v5.7.0-src" "https://downloads.python.org/pypy/pypy3-v5.7.0-src.tar.bz2#f0f563b74f8b82ec33b022393219b93cc0d81e9f9500614fe8417b67a52e9569" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.7-beta-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.7-beta-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3-v5.7.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.7.0-src.tar.bz2#f0f563b74f8b82ec33b022393219b93cc0d81e9f9500614fe8417b67a52e9569" "pypy_builder" verify_py35 ensurepip
+  install_package "pypy3-v5.7.0-src" "https://downloads.python.org/pypy/pypy3-v5.7.0-src.tar.bz2#f0f563b74f8b82ec33b022393219b93cc0d81e9f9500614fe8417b67a52e9569" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.7.1-beta
+++ b/plugins/python-build/share/python-build/pypy3.5-5.7.1-beta
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-v5.7.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.7.1-linux64.tar.bz2#2abaa54d88c9b70b64c37083e7e430a1d3a8f78f8de92e484a988b7aca1e50a7" "pypy" verify_py35 ensurepip
+  install_package "pypy3-v5.7.1-linux64" "https://downloads.python.org/pypy/pypy3-v5.7.1-linux64.tar.bz2#2abaa54d88c9b70b64c37083e7e430a1d3a8f78f8de92e484a988b7aca1e50a7" "pypy" verify_py35 ensurepip
   else
     install_package "pypy3.5-5.7.1-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.7.1-beta-linux_x86_64-portable.tar.bz2#3d1b02f6ef50d4e9069885e0b3f19f26491c7f4f9c5ccc8aa118e38fd6a23997" "pypy" verify_py35 ensurepip
   fi

--- a/plugins/python-build/share/python-build/pypy3.5-5.7.1-beta
+++ b/plugins/python-build/share/python-build/pypy3.5-5.7.1-beta
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy3-v5.7.1-linux64" "https://downloads.python.org/pypy/pypy3-v5.7.1-linux64.tar.bz2#2abaa54d88c9b70b64c37083e7e430a1d3a8f78f8de92e484a988b7aca1e50a7" "pypy" verify_py35 ensurepip
+    install_package "pypy3-v5.7.1-linux64" "https://downloads.python.org/pypy/pypy3-v5.7.1-linux64.tar.bz2#2abaa54d88c9b70b64c37083e7e430a1d3a8f78f8de92e484a988b7aca1e50a7" "pypy" verify_py35 ensurepip
   else
-  install_package "pypy3.5-5.7.1-beta-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-5.7.1-beta-linux_x86_64-portable.tar.bz2#3d1b02f6ef50d4e9069885e0b3f19f26491c7f4f9c5ccc8aa118e38fd6a23997" "pypy" verify_py35 ensurepip
+    install_package "pypy3.5-5.7.1-beta-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-5.7.1-beta-linux_x86_64-portable.tar.bz2#3d1b02f6ef50d4e9069885e0b3f19f26491c7f4f9c5ccc8aa118e38fd6a23997" "pypy" verify_py35 ensurepip
   fi
   ;;
 * )

--- a/plugins/python-build/share/python-build/pypy3.5-5.7.1-beta
+++ b/plugins/python-build/share/python-build/pypy3.5-5.7.1-beta
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy3-v5.7.1-linux64" "https://downloads.python.org/pypy/pypy3-v5.7.1-linux64.tar.bz2#2abaa54d88c9b70b64c37083e7e430a1d3a8f78f8de92e484a988b7aca1e50a7" "pypy" verify_py35 ensurepip
   else
-    install_package "pypy3.5-5.7.1-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.7.1-beta-linux_x86_64-portable.tar.bz2#3d1b02f6ef50d4e9069885e0b3f19f26491c7f4f9c5ccc8aa118e38fd6a23997" "pypy" verify_py35 ensurepip
+  install_package "pypy3.5-5.7.1-beta-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-5.7.1-beta-linux_x86_64-portable.tar.bz2#3d1b02f6ef50d4e9069885e0b3f19f26491c7f4f9c5ccc8aa118e38fd6a23997" "pypy" verify_py35 ensurepip
   fi
   ;;
 * )

--- a/plugins/python-build/share/python-build/pypy3.5-5.7.1-beta-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.7.1-beta-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3-v5.7.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.7.1-src.tar.bz2#40ece0145282980ac121390f13709404c0532896507d5767496381180b631bd0" "pypy_builder" verify_py35 ensurepip
+  install_package "pypy3-v5.7.1-src" "https://downloads.python.org/pypy/pypy3-v5.7.1-src.tar.bz2#40ece0145282980ac121390f13709404c0532896507d5767496381180b631bd0" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.7.1-beta-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.7.1-beta-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3-v5.7.1-src" "https://downloads.python.org/pypy/pypy3-v5.7.1-src.tar.bz2#40ece0145282980ac121390f13709404c0532896507d5767496381180b631bd0" "pypy_builder" verify_py35 ensurepip
+install_package "pypy3-v5.7.1-src" "https://downloads.python.org/pypy/pypy3-v5.7.1-src.tar.bz2#40ece0145282980ac121390f13709404c0532896507d5767496381180b631bd0" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.8.0
+++ b/plugins/python-build/share/python-build/pypy3.5-5.8.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-v5.8.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.8.0-linux64.tar.bz2#57d871a7f1135719c138cee4e3533c3275d682a76a40ff668e95150c65923035" "pypy" verify_py35 ensurepip
+  install_package "pypy3-v5.8.0-linux64" "https://downloads.python.org/pypy/pypy3-v5.8.0-linux64.tar.bz2#57d871a7f1135719c138cee4e3533c3275d682a76a40ff668e95150c65923035" "pypy" verify_py35 ensurepip
   else
     install_package "pypy3.5-5.8-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.8-1-beta-linux_x86_64-portable.tar.bz2#cab20a6d315a1bb05aa953ebc37d8deaa34dcbe298cb5938e373c42c05542b99" "pypy" verify_py35 ensurepip
   fi

--- a/plugins/python-build/share/python-build/pypy3.5-5.8.0
+++ b/plugins/python-build/share/python-build/pypy3.5-5.8.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy3-v5.8.0-linux64" "https://downloads.python.org/pypy/pypy3-v5.8.0-linux64.tar.bz2#57d871a7f1135719c138cee4e3533c3275d682a76a40ff668e95150c65923035" "pypy" verify_py35 ensurepip
+    install_package "pypy3-v5.8.0-linux64" "https://downloads.python.org/pypy/pypy3-v5.8.0-linux64.tar.bz2#57d871a7f1135719c138cee4e3533c3275d682a76a40ff668e95150c65923035" "pypy" verify_py35 ensurepip
   else
     install_package "pypy3.5-5.8-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.8-1-beta-linux_x86_64-portable.tar.bz2#cab20a6d315a1bb05aa953ebc37d8deaa34dcbe298cb5938e373c42c05542b99" "pypy" verify_py35 ensurepip
   fi

--- a/plugins/python-build/share/python-build/pypy3.5-5.8.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.8.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3-v5.8.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.8.0-src.tar.bz2#9d090127335c3c0fd2b14c8835bf91752e62756e55ea06aad3353f24a6854223" "pypy_builder" verify_py35 ensurepip
+  install_package "pypy3-v5.8.0-src" "https://downloads.python.org/pypy/pypy3-v5.8.0-src.tar.bz2#9d090127335c3c0fd2b14c8835bf91752e62756e55ea06aad3353f24a6854223" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.8.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.8.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3-v5.8.0-src" "https://downloads.python.org/pypy/pypy3-v5.8.0-src.tar.bz2#9d090127335c3c0fd2b14c8835bf91752e62756e55ea06aad3353f24a6854223" "pypy_builder" verify_py35 ensurepip
+install_package "pypy3-v5.8.0-src" "https://downloads.python.org/pypy/pypy3-v5.8.0-src.tar.bz2#9d090127335c3c0fd2b14c8835bf91752e62756e55ea06aad3353f24a6854223" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.9.0
+++ b/plugins/python-build/share/python-build/pypy3.5-5.9.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-v5.9.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.9.0-linux64.tar.bz2#d8c41ede3758127718944cc2fd6bf78ed4303d946f85596cac91281ccce36165" "pypy" verify_py35 ensurepip
+  install_package "pypy3-v5.9.0-linux64" "https://downloads.python.org/pypy/pypy3-v5.9.0-linux64.tar.bz2#d8c41ede3758127718944cc2fd6bf78ed4303d946f85596cac91281ccce36165" "pypy" verify_py35 ensurepip
   else
     install_package "pypy3.5-5.9-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.9-beta-linux_x86_64-portable.tar.bz2#b0a79dabe2c48b0374d567936139ecf1379904a504d4a645be5c3e7e35140575" "pypy" verify_py35 ensurepip
   fi

--- a/plugins/python-build/share/python-build/pypy3.5-5.9.0
+++ b/plugins/python-build/share/python-build/pypy3.5-5.9.0
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy3-v5.9.0-linux64" "https://downloads.python.org/pypy/pypy3-v5.9.0-linux64.tar.bz2#d8c41ede3758127718944cc2fd6bf78ed4303d946f85596cac91281ccce36165" "pypy" verify_py35 ensurepip
+    install_package "pypy3-v5.9.0-linux64" "https://downloads.python.org/pypy/pypy3-v5.9.0-linux64.tar.bz2#d8c41ede3758127718944cc2fd6bf78ed4303d946f85596cac91281ccce36165" "pypy" verify_py35 ensurepip
   else
-  install_package "pypy3.5-5.9-beta-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-5.9-beta-linux_x86_64-portable.tar.bz2#b0a79dabe2c48b0374d567936139ecf1379904a504d4a645be5c3e7e35140575" "pypy" verify_py35 ensurepip
+    install_package "pypy3.5-5.9-beta-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-5.9-beta-linux_x86_64-portable.tar.bz2#b0a79dabe2c48b0374d567936139ecf1379904a504d4a645be5c3e7e35140575" "pypy" verify_py35 ensurepip
   fi
   ;;
 * )

--- a/plugins/python-build/share/python-build/pypy3.5-5.9.0
+++ b/plugins/python-build/share/python-build/pypy3.5-5.9.0
@@ -3,7 +3,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
   install_package "pypy3-v5.9.0-linux64" "https://downloads.python.org/pypy/pypy3-v5.9.0-linux64.tar.bz2#d8c41ede3758127718944cc2fd6bf78ed4303d946f85596cac91281ccce36165" "pypy" verify_py35 ensurepip
   else
-    install_package "pypy3.5-5.9-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.9-beta-linux_x86_64-portable.tar.bz2#b0a79dabe2c48b0374d567936139ecf1379904a504d4a645be5c3e7e35140575" "pypy" verify_py35 ensurepip
+  install_package "pypy3.5-5.9-beta-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-5.9-beta-linux_x86_64-portable.tar.bz2#b0a79dabe2c48b0374d567936139ecf1379904a504d4a645be5c3e7e35140575" "pypy" verify_py35 ensurepip
   fi
   ;;
 * )

--- a/plugins/python-build/share/python-build/pypy3.5-5.9.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.9.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3-v5.9.0-src" "https://downloads.python.org/pypy/pypy3-v5.9.0-src.tar.bz2#a014f47f50a1480f871a0b82705f904b38c93c4ca069850eb37653fedafb1b97" "pypy_builder" verify_py35 ensurepip
+install_package "pypy3-v5.9.0-src" "https://downloads.python.org/pypy/pypy3-v5.9.0-src.tar.bz2#a014f47f50a1480f871a0b82705f904b38c93c4ca069850eb37653fedafb1b97" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-5.9.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-5.9.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3-v5.9.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v5.9.0-src.tar.bz2#a014f47f50a1480f871a0b82705f904b38c93c4ca069850eb37653fedafb1b97" "pypy_builder" verify_py35 ensurepip
+  install_package "pypy3-v5.9.0-src" "https://downloads.python.org/pypy/pypy3-v5.9.0-src.tar.bz2#a014f47f50a1480f871a0b82705f904b38c93c4ca069850eb37653fedafb1b97" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-6.0.0
+++ b/plugins/python-build/share/python-build/pypy3.5-6.0.0
@@ -1,14 +1,14 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-  install_package "pypy3-v6.0.0-linux32" "https://downloads.python.org/pypy/pypy3-v6.0.0-linux32.tar.bz2#b04eeee5160e6cb5f8962de80f077ea1dc7be34e77d74bf075519c23603f5ff9" "pypy" verify_py27 ensurepip
+    install_package "pypy3-v6.0.0-linux32" "https://downloads.python.org/pypy/pypy3-v6.0.0-linux32.tar.bz2#b04eeee5160e6cb5f8962de80f077ea1dc7be34e77d74bf075519c23603f5ff9" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy3-v6.0.0-linux64" "https://downloads.python.org/pypy/pypy3-v6.0.0-linux64.tar.bz2#4cfffa292b9ef34bb6ba39cdbaa196c5c5cbbc5aa3faaa157cf45d7e34027048" "pypy" verify_py27 ensurepip
+    install_package "pypy3-v6.0.0-linux64" "https://downloads.python.org/pypy/pypy3-v6.0.0-linux64.tar.bz2#4cfffa292b9ef34bb6ba39cdbaa196c5c5cbbc5aa3faaa157cf45d7e34027048" "pypy" verify_py27 ensurepip
   else
-  install_package "pypy3.5-6.0.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-6.0.0-linux_x86_64-portable.tar.bz2#07f16282d126abfa759702baea869b0f661aa97f4c553ebec66c624bda28155f" "pypy" verify_py35 ensurepip
+    install_package "pypy3.5-6.0.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-6.0.0-linux_x86_64-portable.tar.bz2#07f16282d126abfa759702baea869b0f661aa97f4c553ebec66c624bda28155f" "pypy" verify_py35 ensurepip
   fi
   ;;
 "linux-armel" )
@@ -17,7 +17,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-  install_package "pypy3-v6.0.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3-v6.0.0-linux-armhf-raspbian.tar.bz2#8a0420dda23413925400538bbfc0cff2bbb2ab0de984eef6faaeab6d3309cbcc" "pypy" verify_py27 ensurepip
+    install_package "pypy3-v6.0.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3-v6.0.0-linux-armhf-raspbian.tar.bz2#8a0420dda23413925400538bbfc0cff2bbb2ab0de984eef6faaeab6d3309cbcc" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -30,7 +30,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-  install_package "pypy3-v6.0.0-osx64" "https://downloads.python.org/pypy/pypy3-v6.0.0-osx64.tar.bz2#938b8034e30f5f5060d2a079070c56c3be5559bc7ae9cc0c8395fe6fc45cfe4c" "pypy" verify_py27 ensurepip
+    install_package "pypy3-v6.0.0-osx64" "https://downloads.python.org/pypy/pypy3-v6.0.0-osx64.tar.bz2#938b8034e30f5f5060d2a079070c56c3be5559bc7ae9cc0c8395fe6fc45cfe4c" "pypy" verify_py27 ensurepip
   else
   #  install_package "pypy3-v6.0.0-osx64-2" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-osx64-2.tar.bz2#" "pypy" verify_py27 ensurepip
     { echo

--- a/plugins/python-build/share/python-build/pypy3.5-6.0.0
+++ b/plugins/python-build/share/python-build/pypy3.5-6.0.0
@@ -1,23 +1,23 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-v6.0.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-linux32.tar.bz2#b04eeee5160e6cb5f8962de80f077ea1dc7be34e77d74bf075519c23603f5ff9" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v6.0.0-linux32" "https://downloads.python.org/pypy/pypy3-v6.0.0-linux32.tar.bz2#b04eeee5160e6cb5f8962de80f077ea1dc7be34e77d74bf075519c23603f5ff9" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-v6.0.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-linux64.tar.bz2#4cfffa292b9ef34bb6ba39cdbaa196c5c5cbbc5aa3faaa157cf45d7e34027048" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v6.0.0-linux64" "https://downloads.python.org/pypy/pypy3-v6.0.0-linux64.tar.bz2#4cfffa292b9ef34bb6ba39cdbaa196c5c5cbbc5aa3faaa157cf45d7e34027048" "pypy" verify_py27 ensurepip
   else
     install_package "pypy3.5-6.0.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-6.0.0-linux_x86_64-portable.tar.bz2#07f16282d126abfa759702baea869b0f661aa97f4c553ebec66c624bda28155f" "pypy" verify_py35 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy3-v6.0.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-linux-armel.tar.bz2#6a6888a55192f58594838b8b3d2e7daaad43d3bf4293afab3dd8987d0bbd1124" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v6.0.0-linux-armel" "https://downloads.python.org/pypy/pypy3-v6.0.0-linux-armel.tar.bz2#6a6888a55192f58594838b8b3d2e7daaad43d3bf4293afab3dd8987d0bbd1124" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy3-v6.0.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-linux-armhf-raspbian.tar.bz2#8a0420dda23413925400538bbfc0cff2bbb2ab0de984eef6faaeab6d3309cbcc" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v6.0.0-linux-armhf-raspbian" "https://downloads.python.org/pypy/pypy3-v6.0.0-linux-armhf-raspbian.tar.bz2#8a0420dda23413925400538bbfc0cff2bbb2ab0de984eef6faaeab6d3309cbcc" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -30,7 +30,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy3-v6.0.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-osx64.tar.bz2#938b8034e30f5f5060d2a079070c56c3be5559bc7ae9cc0c8395fe6fc45cfe4c" "pypy" verify_py27 ensurepip
+  install_package "pypy3-v6.0.0-osx64" "https://downloads.python.org/pypy/pypy3-v6.0.0-osx64.tar.bz2#938b8034e30f5f5060d2a079070c56c3be5559bc7ae9cc0c8395fe6fc45cfe4c" "pypy" verify_py27 ensurepip
   else
   #  install_package "pypy3-v6.0.0-osx64-2" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-osx64-2.tar.bz2#" "pypy" verify_py27 ensurepip
     { echo
@@ -44,7 +44,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy3-v6.0.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-win32.zip#72dddb3746a51f7672c77d619c818e27efe899e08ae82762448e50dbfdc2f5f3" "pypy" verify_py27 ensurepip
+  install_zip "pypy3-v6.0.0-win32" "https://downloads.python.org/pypy/pypy3-v6.0.0-win32.zip#72dddb3746a51f7672c77d619c818e27efe899e08ae82762448e50dbfdc2f5f3" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3.5-6.0.0
+++ b/plugins/python-build/share/python-build/pypy3.5-6.0.0
@@ -8,7 +8,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
   install_package "pypy3-v6.0.0-linux64" "https://downloads.python.org/pypy/pypy3-v6.0.0-linux64.tar.bz2#4cfffa292b9ef34bb6ba39cdbaa196c5c5cbbc5aa3faaa157cf45d7e34027048" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy3.5-6.0.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-6.0.0-linux_x86_64-portable.tar.bz2#07f16282d126abfa759702baea869b0f661aa97f4c553ebec66c624bda28155f" "pypy" verify_py35 ensurepip
+  install_package "pypy3.5-6.0.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-6.0.0-linux_x86_64-portable.tar.bz2#07f16282d126abfa759702baea869b0f661aa97f4c553ebec66c624bda28155f" "pypy" verify_py35 ensurepip
   fi
   ;;
 "linux-armel" )

--- a/plugins/python-build/share/python-build/pypy3.5-6.0.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-6.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3-v6.0.0-src" "https://downloads.python.org/pypy/pypy3-v6.0.0-src.tar.bz2#ed8005202b46d6fc6831df1d13a4613bc40084bfa42f275068edadf8954034a3" "pypy_builder" verify_py35 ensurepip
+install_package "pypy3-v6.0.0-src" "https://downloads.python.org/pypy/pypy3-v6.0.0-src.tar.bz2#ed8005202b46d6fc6831df1d13a4613bc40084bfa42f275068edadf8954034a3" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-6.0.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-6.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3-v6.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-src.tar.bz2#ed8005202b46d6fc6831df1d13a4613bc40084bfa42f275068edadf8954034a3" "pypy_builder" verify_py35 ensurepip
+  install_package "pypy3-v6.0.0-src" "https://downloads.python.org/pypy/pypy3-v6.0.0-src.tar.bz2#ed8005202b46d6fc6831df1d13a4613bc40084bfa42f275068edadf8954034a3" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-7.0.0
+++ b/plugins/python-build/share/python-build/pypy3.5-7.0.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy3.5-v7.0.0-linux32" "https://downloads.python.org/pypy/pypy3.5-v7.0.0-linux32.tar.bz2#b8db8fbca9621de8ea8cd7184b322f2dddb2f385e8e5a63dfb75bb3fea4b2e3f" "pypy" verify_py35 ensurepip
+    install_package "pypy3.5-v7.0.0-linux32" "https://downloads.python.org/pypy/pypy3.5-v7.0.0-linux32.tar.bz2#b8db8fbca9621de8ea8cd7184b322f2dddb2f385e8e5a63dfb75bb3fea4b2e3f" "pypy" verify_py35 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy3.5-v7.0.0-linux64" "https://downloads.python.org/pypy/pypy3.5-v7.0.0-linux64.tar.bz2#729e3c54325969c98bd3658c6342b9f5987b96bad1d6def04250a08401b54c4b" "pypy" verify_py35 ensurepip
+    install_package "pypy3.5-v7.0.0-linux64" "https://downloads.python.org/pypy/pypy3.5-v7.0.0-linux64.tar.bz2#729e3c54325969c98bd3658c6342b9f5987b96bad1d6def04250a08401b54c4b" "pypy" verify_py35 ensurepip
   else
-  install_package "pypy3.5-7.0.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-7.0.0-linux_x86_64-portable.tar.bz2#b0fa200f25a5a0ef90b8776ab1d0665c47d47c607d2ef057cce1da1ad2568e1f" "pypy" verify_py35 ensurepip
+    install_package "pypy3.5-7.0.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-7.0.0-linux_x86_64-portable.tar.bz2#b0fa200f25a5a0ef90b8776ab1d0665c47d47c607d2ef057cce1da1ad2568e1f" "pypy" verify_py35 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-  install_package "pypy3.5-v7.0.0-osx64" "https://downloads.python.org/pypy/pypy3.5-v7.0.0-osx64.tar.bz2#7c6d71653d9b1a7946d1eeebbf24b454fe934fba8b0c39f648bdc545fb2895ce" "pypy" verify_py35 ensurepip
+    install_package "pypy3.5-v7.0.0-osx64" "https://downloads.python.org/pypy/pypy3.5-v7.0.0-osx64.tar.bz2#7c6d71653d9b1a7946d1eeebbf24b454fe934fba8b0c39f648bdc545fb2895ce" "pypy" verify_py35 ensurepip
   else
     { echo
       colorize 1 "ERROR"

--- a/plugins/python-build/share/python-build/pypy3.5-7.0.0
+++ b/plugins/python-build/share/python-build/pypy3.5-7.0.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy3.5-v7.0.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy3.5-v7.0.0-linux32.tar.bz2#b8db8fbca9621de8ea8cd7184b322f2dddb2f385e8e5a63dfb75bb3fea4b2e3f" "pypy" verify_py35 ensurepip
+  install_package "pypy3.5-v7.0.0-linux32" "https://downloads.python.org/pypy/pypy3.5-v7.0.0-linux32.tar.bz2#b8db8fbca9621de8ea8cd7184b322f2dddb2f385e8e5a63dfb75bb3fea4b2e3f" "pypy" verify_py35 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy3.5-v7.0.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.5-v7.0.0-linux64.tar.bz2#729e3c54325969c98bd3658c6342b9f5987b96bad1d6def04250a08401b54c4b" "pypy" verify_py35 ensurepip
+  install_package "pypy3.5-v7.0.0-linux64" "https://downloads.python.org/pypy/pypy3.5-v7.0.0-linux64.tar.bz2#729e3c54325969c98bd3658c6342b9f5987b96bad1d6def04250a08401b54c4b" "pypy" verify_py35 ensurepip
   else
     install_package "pypy3.5-7.0.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-7.0.0-linux_x86_64-portable.tar.bz2#b0fa200f25a5a0ef90b8776ab1d0665c47d47c607d2ef057cce1da1ad2568e1f" "pypy" verify_py35 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy3.5-v7.0.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.5-v7.0.0-osx64.tar.bz2#7c6d71653d9b1a7946d1eeebbf24b454fe934fba8b0c39f648bdc545fb2895ce" "pypy" verify_py35 ensurepip
+  install_package "pypy3.5-v7.0.0-osx64" "https://downloads.python.org/pypy/pypy3.5-v7.0.0-osx64.tar.bz2#7c6d71653d9b1a7946d1eeebbf24b454fe934fba8b0c39f648bdc545fb2895ce" "pypy" verify_py35 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -33,7 +33,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "win32" )
-  install_zip "pypy3.5-v7.0.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy3.5-v7.0.0-win32.zip#a840305c24f426e11d8bb3f062cacec1edf7fcbce6a99122d59f73e1984bc5c0" "pypy" verify_py35 ensurepip
+  install_zip "pypy3.5-v7.0.0-win32" "https://downloads.python.org/pypy/pypy3.5-v7.0.0-win32.zip#a840305c24f426e11d8bb3f062cacec1edf7fcbce6a99122d59f73e1984bc5c0" "pypy" verify_py35 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3.5-7.0.0
+++ b/plugins/python-build/share/python-build/pypy3.5-7.0.0
@@ -16,7 +16,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
   install_package "pypy3.5-v7.0.0-linux64" "https://downloads.python.org/pypy/pypy3.5-v7.0.0-linux64.tar.bz2#729e3c54325969c98bd3658c6342b9f5987b96bad1d6def04250a08401b54c4b" "pypy" verify_py35 ensurepip
   else
-    install_package "pypy3.5-7.0.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-7.0.0-linux_x86_64-portable.tar.bz2#b0fa200f25a5a0ef90b8776ab1d0665c47d47c607d2ef057cce1da1ad2568e1f" "pypy" verify_py35 ensurepip
+  install_package "pypy3.5-7.0.0-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-7.0.0-linux_x86_64-portable.tar.bz2#b0fa200f25a5a0ef90b8776ab1d0665c47d47c607d2ef057cce1da1ad2568e1f" "pypy" verify_py35 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy3.5-7.0.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-7.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3.5-v7.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.5-v7.0.0-src.tar.bz2#b2ddb0f45cb4e0384fb498ef7fcca2ac96c730b9000affcf8d730169397f017f" "pypy_builder" verify_py35 ensurepip
+  install_package "pypy3.5-v7.0.0-src" "https://downloads.python.org/pypy/pypy3.5-v7.0.0-src.tar.bz2#b2ddb0f45cb4e0384fb498ef7fcca2ac96c730b9000affcf8d730169397f017f" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-7.0.0-src
+++ b/plugins/python-build/share/python-build/pypy3.5-7.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3.5-v7.0.0-src" "https://downloads.python.org/pypy/pypy3.5-v7.0.0-src.tar.bz2#b2ddb0f45cb4e0384fb498ef7fcca2ac96c730b9000affcf8d730169397f017f" "pypy_builder" verify_py35 ensurepip
+install_package "pypy3.5-v7.0.0-src" "https://downloads.python.org/pypy/pypy3.5-v7.0.0-src.tar.bz2#b2ddb0f45cb4e0384fb498ef7fcca2ac96c730b9000affcf8d730169397f017f" "pypy_builder" verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.0.0
+++ b/plugins/python-build/share/python-build/pypy3.6-7.0.0
@@ -10,14 +10,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy3.6-v7.0.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.0.0-linux64.tar.bz2#8576bde0760c239040706cf4952995eb0e77938b175885392a465a0d1616173d" "pypy" verify_py36 ensurepip
+  install_package "pypy3.6-v7.0.0-linux64" "https://downloads.python.org/pypy/pypy3.6-v7.0.0-linux64.tar.bz2#8576bde0760c239040706cf4952995eb0e77938b175885392a465a0d1616173d" "pypy" verify_py36 ensurepip
   else
     install_package "pypy3.6-7.0.0-alpha-20190209-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.6-7.0.0-alpha-20190209-linux_x86_64-portable.tar.bz2#ef8a5254b9a082dec23a6e029b1bb674a122a789c29d9c452452a9e97498bcbe" "pypy" verify_py36 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy3.6-v7.0.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.0.0-osx64.tar.bz2#4a95ffd61fd2d626a9c099db6e44889c2a7eecee9cb1cbc29e06603c218ba8e2" "pypy" verify_py36 ensurepip
+  install_package "pypy3.6-v7.0.0-osx64" "https://downloads.python.org/pypy/pypy3.6-v7.0.0-osx64.tar.bz2#4a95ffd61fd2d626a9c099db6e44889c2a7eecee9cb1cbc29e06603c218ba8e2" "pypy" verify_py36 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -29,7 +29,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "win32" )
-  install_zip "pypy3.6-v7.0.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.0.0-win32.zip#645d81472d16922fd592e9261da449cb19847ff7d5eaa89bcf05d9214b6b2698" "pypy" verify_py36 ensurepip
+  install_zip "pypy3.6-v7.0.0-win32" "https://downloads.python.org/pypy/pypy3.6-v7.0.0-win32.zip#645d81472d16922fd592e9261da449cb19847ff7d5eaa89bcf05d9214b6b2698" "pypy" verify_py36 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3.6-7.0.0
+++ b/plugins/python-build/share/python-build/pypy3.6-7.0.0
@@ -10,14 +10,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy3.6-v7.0.0-linux64" "https://downloads.python.org/pypy/pypy3.6-v7.0.0-linux64.tar.bz2#8576bde0760c239040706cf4952995eb0e77938b175885392a465a0d1616173d" "pypy" verify_py36 ensurepip
+    install_package "pypy3.6-v7.0.0-linux64" "https://downloads.python.org/pypy/pypy3.6-v7.0.0-linux64.tar.bz2#8576bde0760c239040706cf4952995eb0e77938b175885392a465a0d1616173d" "pypy" verify_py36 ensurepip
   else
-  install_package "pypy3.6-7.0.0-alpha-20190209-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.6-7.0.0-alpha-20190209-linux_x86_64-portable.tar.bz2#ef8a5254b9a082dec23a6e029b1bb674a122a789c29d9c452452a9e97498bcbe" "pypy" verify_py36 ensurepip
+    install_package "pypy3.6-7.0.0-alpha-20190209-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.6-7.0.0-alpha-20190209-linux_x86_64-portable.tar.bz2#ef8a5254b9a082dec23a6e029b1bb674a122a789c29d9c452452a9e97498bcbe" "pypy" verify_py36 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-  install_package "pypy3.6-v7.0.0-osx64" "https://downloads.python.org/pypy/pypy3.6-v7.0.0-osx64.tar.bz2#4a95ffd61fd2d626a9c099db6e44889c2a7eecee9cb1cbc29e06603c218ba8e2" "pypy" verify_py36 ensurepip
+    install_package "pypy3.6-v7.0.0-osx64" "https://downloads.python.org/pypy/pypy3.6-v7.0.0-osx64.tar.bz2#4a95ffd61fd2d626a9c099db6e44889c2a7eecee9cb1cbc29e06603c218ba8e2" "pypy" verify_py36 ensurepip
   else
     { echo
       colorize 1 "ERROR"

--- a/plugins/python-build/share/python-build/pypy3.6-7.0.0
+++ b/plugins/python-build/share/python-build/pypy3.6-7.0.0
@@ -12,7 +12,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
   install_package "pypy3.6-v7.0.0-linux64" "https://downloads.python.org/pypy/pypy3.6-v7.0.0-linux64.tar.bz2#8576bde0760c239040706cf4952995eb0e77938b175885392a465a0d1616173d" "pypy" verify_py36 ensurepip
   else
-    install_package "pypy3.6-7.0.0-alpha-20190209-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.6-7.0.0-alpha-20190209-linux_x86_64-portable.tar.bz2#ef8a5254b9a082dec23a6e029b1bb674a122a789c29d9c452452a9e97498bcbe" "pypy" verify_py36 ensurepip
+  install_package "pypy3.6-7.0.0-alpha-20190209-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.6-7.0.0-alpha-20190209-linux_x86_64-portable.tar.bz2#ef8a5254b9a082dec23a6e029b1bb674a122a789c29d9c452452a9e97498bcbe" "pypy" verify_py36 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy3.6-7.0.0-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3.6-v7.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.0.0-src.tar.bz2#7ccbf81db5c647fa0c27636c7d18d059d2570fff7eaffc03857c67bee84b8a26" "pypy_builder" verify_py36 ensurepip
+  install_package "pypy3.6-v7.0.0-src" "https://downloads.python.org/pypy/pypy3.6-v7.0.0-src.tar.bz2#7ccbf81db5c647fa0c27636c7d18d059d2570fff7eaffc03857c67bee84b8a26" "pypy_builder" verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.0.0-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.0.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3.6-v7.0.0-src" "https://downloads.python.org/pypy/pypy3.6-v7.0.0-src.tar.bz2#7ccbf81db5c647fa0c27636c7d18d059d2570fff7eaffc03857c67bee84b8a26" "pypy_builder" verify_py36 ensurepip
+install_package "pypy3.6-v7.0.0-src" "https://downloads.python.org/pypy/pypy3.6-v7.0.0-src.tar.bz2#7ccbf81db5c647fa0c27636c7d18d059d2570fff7eaffc03857c67bee84b8a26" "pypy_builder" verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.1.0
+++ b/plugins/python-build/share/python-build/pypy3.6-7.1.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy3.6-v7.1.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.0-linux32.tar.bz2#031bfac61210a6e161bace0691b854dc15d01b0e624dc0588c544ee5e1621a83" "pypy" verify_py27 ensurepip
+  install_package "pypy3.6-v7.1.0-linux32" "https://downloads.python.org/pypy/pypy3.6-v7.1.0-linux32.tar.bz2#031bfac61210a6e161bace0691b854dc15d01b0e624dc0588c544ee5e1621a83" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy3.6-v7.1.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.0-linux64.tar.bz2#270dd06633cf03337e6f815d7235e790e90dabba6f4b6345c9745121006925fc" "pypy" verify_py36 ensurepip
+  install_package "pypy3.6-v7.1.0-linux64" "https://downloads.python.org/pypy/pypy3.6-v7.1.0-linux64.tar.bz2#270dd06633cf03337e6f815d7235e790e90dabba6f4b6345c9745121006925fc" "pypy" verify_py36 ensurepip
   else
     install_package "pypy3.6-7.1.0-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.6-7.1.0-beta-linux_x86_64-portable.tar.bz2#d1bde814fb0c3645dfc0bdab67c335c8aa259b83fb39106e2e11b0112bcbb602" "pypy" verify_py36 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy3.6-v7.1.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.0-osx64.tar.bz2#d46e005ba095cb4a7006079ffbf4fe63c18cf5e9d8ce9ce8383efc1a4863ab5b" "pypy" verify_py36 ensurepip
+  install_package "pypy3.6-v7.1.0-osx64" "https://downloads.python.org/pypy/pypy3.6-v7.1.0-osx64.tar.bz2#d46e005ba095cb4a7006079ffbf4fe63c18cf5e9d8ce9ce8383efc1a4863ab5b" "pypy" verify_py36 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -33,7 +33,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "win32" )
-  install_zip "pypy3.6-v7.1.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.0-win32.zip#77a0576a3d518210467f0df2d0d9a1892c664566dc02f25d974c2dbc6b4749e7" "pypy" verify_py36 ensurepip
+  install_zip "pypy3.6-v7.1.0-win32" "https://downloads.python.org/pypy/pypy3.6-v7.1.0-win32.zip#77a0576a3d518210467f0df2d0d9a1892c664566dc02f25d974c2dbc6b4749e7" "pypy" verify_py36 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3.6-7.1.0
+++ b/plugins/python-build/share/python-build/pypy3.6-7.1.0
@@ -16,7 +16,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
   install_package "pypy3.6-v7.1.0-linux64" "https://downloads.python.org/pypy/pypy3.6-v7.1.0-linux64.tar.bz2#270dd06633cf03337e6f815d7235e790e90dabba6f4b6345c9745121006925fc" "pypy" verify_py36 ensurepip
   else
-    install_package "pypy3.6-7.1.0-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.6-7.1.0-beta-linux_x86_64-portable.tar.bz2#d1bde814fb0c3645dfc0bdab67c335c8aa259b83fb39106e2e11b0112bcbb602" "pypy" verify_py36 ensurepip
+  install_package "pypy3.6-7.1.0-beta-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.6-7.1.0-beta-linux_x86_64-portable.tar.bz2#d1bde814fb0c3645dfc0bdab67c335c8aa259b83fb39106e2e11b0112bcbb602" "pypy" verify_py36 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy3.6-7.1.0
+++ b/plugins/python-build/share/python-build/pypy3.6-7.1.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy3.6-v7.1.0-linux32" "https://downloads.python.org/pypy/pypy3.6-v7.1.0-linux32.tar.bz2#031bfac61210a6e161bace0691b854dc15d01b0e624dc0588c544ee5e1621a83" "pypy" verify_py27 ensurepip
+    install_package "pypy3.6-v7.1.0-linux32" "https://downloads.python.org/pypy/pypy3.6-v7.1.0-linux32.tar.bz2#031bfac61210a6e161bace0691b854dc15d01b0e624dc0588c544ee5e1621a83" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy3.6-v7.1.0-linux64" "https://downloads.python.org/pypy/pypy3.6-v7.1.0-linux64.tar.bz2#270dd06633cf03337e6f815d7235e790e90dabba6f4b6345c9745121006925fc" "pypy" verify_py36 ensurepip
+    install_package "pypy3.6-v7.1.0-linux64" "https://downloads.python.org/pypy/pypy3.6-v7.1.0-linux64.tar.bz2#270dd06633cf03337e6f815d7235e790e90dabba6f4b6345c9745121006925fc" "pypy" verify_py36 ensurepip
   else
-  install_package "pypy3.6-7.1.0-beta-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.6-7.1.0-beta-linux_x86_64-portable.tar.bz2#d1bde814fb0c3645dfc0bdab67c335c8aa259b83fb39106e2e11b0112bcbb602" "pypy" verify_py36 ensurepip
+    install_package "pypy3.6-7.1.0-beta-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.6-7.1.0-beta-linux_x86_64-portable.tar.bz2#d1bde814fb0c3645dfc0bdab67c335c8aa259b83fb39106e2e11b0112bcbb602" "pypy" verify_py36 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-  install_package "pypy3.6-v7.1.0-osx64" "https://downloads.python.org/pypy/pypy3.6-v7.1.0-osx64.tar.bz2#d46e005ba095cb4a7006079ffbf4fe63c18cf5e9d8ce9ce8383efc1a4863ab5b" "pypy" verify_py36 ensurepip
+    install_package "pypy3.6-v7.1.0-osx64" "https://downloads.python.org/pypy/pypy3.6-v7.1.0-osx64.tar.bz2#d46e005ba095cb4a7006079ffbf4fe63c18cf5e9d8ce9ce8383efc1a4863ab5b" "pypy" verify_py36 ensurepip
   else
     { echo
       colorize 1 "ERROR"

--- a/plugins/python-build/share/python-build/pypy3.6-7.1.0-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.1.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3.6-v7.1.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.0-src.tar.bz2#faa81f469bb2a7cbd22c64f22d4b4ddc5a1f7c798d43b7919b629b932f9b1c6f" "pypy_builder" verify_py36 ensurepip
+  install_package "pypy3.6-v7.1.0-src" "https://downloads.python.org/pypy/pypy3.6-v7.1.0-src.tar.bz2#faa81f469bb2a7cbd22c64f22d4b4ddc5a1f7c798d43b7919b629b932f9b1c6f" "pypy_builder" verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.1.0-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.1.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3.6-v7.1.0-src" "https://downloads.python.org/pypy/pypy3.6-v7.1.0-src.tar.bz2#faa81f469bb2a7cbd22c64f22d4b4ddc5a1f7c798d43b7919b629b932f9b1c6f" "pypy_builder" verify_py36 ensurepip
+install_package "pypy3.6-v7.1.0-src" "https://downloads.python.org/pypy/pypy3.6-v7.1.0-src.tar.bz2#faa81f469bb2a7cbd22c64f22d4b4ddc5a1f7c798d43b7919b629b932f9b1c6f" "pypy_builder" verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.1.1
+++ b/plugins/python-build/share/python-build/pypy3.6-7.1.1
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy3.6-v7.1.1-linux32" "https://downloads.python.org/pypy/pypy3.6-v7.1.1-linux32.tar.bz2#cb11ef4b0df569c28390b1ee93029159e1b90bfbad98df6abd629d5203b2abd9" "pypy" verify_py27 ensurepip
+    install_package "pypy3.6-v7.1.1-linux32" "https://downloads.python.org/pypy/pypy3.6-v7.1.1-linux32.tar.bz2#cb11ef4b0df569c28390b1ee93029159e1b90bfbad98df6abd629d5203b2abd9" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy3.6-v7.1.1-linux64" "https://downloads.python.org/pypy/pypy3.6-v7.1.1-linux64.tar.bz2#8014f63b1a34b155548852c7bf73aab2d41ebddf2c8fb603dc9dd8509be93db0" "pypy" verify_py36 ensurepip
+    install_package "pypy3.6-v7.1.1-linux64" "https://downloads.python.org/pypy/pypy3.6-v7.1.1-linux64.tar.bz2#8014f63b1a34b155548852c7bf73aab2d41ebddf2c8fb603dc9dd8509be93db0" "pypy" verify_py36 ensurepip
   else
-  install_package "pypy3.6-7.1.1-beta-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.6-7.1.1-beta-linux_x86_64-portable.tar.bz2#82c878b61ad34fc2cf1686fa600a7a002d352e1b33a99a43007eec486ecd068e" "pypy" verify_py36 ensurepip
+    install_package "pypy3.6-7.1.1-beta-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.6-7.1.1-beta-linux_x86_64-portable.tar.bz2#82c878b61ad34fc2cf1686fa600a7a002d352e1b33a99a43007eec486ecd068e" "pypy" verify_py36 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-  install_package "pypy3.6-v7.1.1-osx64" "https://downloads.python.org/pypy/pypy3.6-v7.1.1-osx64.tar.bz2#a5c2f2bfa2b4a4d29e8a67baab95699b169054066df218a14f171bb84a6df0c0" "pypy" verify_py36 ensurepip
+    install_package "pypy3.6-v7.1.1-osx64" "https://downloads.python.org/pypy/pypy3.6-v7.1.1-osx64.tar.bz2#a5c2f2bfa2b4a4d29e8a67baab95699b169054066df218a14f171bb84a6df0c0" "pypy" verify_py36 ensurepip
   else
     { echo
       colorize 1 "ERROR"

--- a/plugins/python-build/share/python-build/pypy3.6-7.1.1
+++ b/plugins/python-build/share/python-build/pypy3.6-7.1.1
@@ -16,7 +16,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
   install_package "pypy3.6-v7.1.1-linux64" "https://downloads.python.org/pypy/pypy3.6-v7.1.1-linux64.tar.bz2#8014f63b1a34b155548852c7bf73aab2d41ebddf2c8fb603dc9dd8509be93db0" "pypy" verify_py36 ensurepip
   else
-    install_package "pypy3.6-7.1.1-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.6-7.1.1-beta-linux_x86_64-portable.tar.bz2#82c878b61ad34fc2cf1686fa600a7a002d352e1b33a99a43007eec486ecd068e" "pypy" verify_py36 ensurepip
+  install_package "pypy3.6-7.1.1-beta-linux_x86_64-portable" "https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.6-7.1.1-beta-linux_x86_64-portable.tar.bz2#82c878b61ad34fc2cf1686fa600a7a002d352e1b33a99a43007eec486ecd068e" "pypy" verify_py36 ensurepip
   fi
   ;;
 "osx64" )

--- a/plugins/python-build/share/python-build/pypy3.6-7.1.1
+++ b/plugins/python-build/share/python-build/pypy3.6-7.1.1
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy3.6-v7.1.1-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.1-linux32.tar.bz2#cb11ef4b0df569c28390b1ee93029159e1b90bfbad98df6abd629d5203b2abd9" "pypy" verify_py27 ensurepip
+  install_package "pypy3.6-v7.1.1-linux32" "https://downloads.python.org/pypy/pypy3.6-v7.1.1-linux32.tar.bz2#cb11ef4b0df569c28390b1ee93029159e1b90bfbad98df6abd629d5203b2abd9" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy3.6-v7.1.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.1-linux64.tar.bz2#8014f63b1a34b155548852c7bf73aab2d41ebddf2c8fb603dc9dd8509be93db0" "pypy" verify_py36 ensurepip
+  install_package "pypy3.6-v7.1.1-linux64" "https://downloads.python.org/pypy/pypy3.6-v7.1.1-linux64.tar.bz2#8014f63b1a34b155548852c7bf73aab2d41ebddf2c8fb603dc9dd8509be93db0" "pypy" verify_py36 ensurepip
   else
     install_package "pypy3.6-7.1.1-beta-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.6-7.1.1-beta-linux_x86_64-portable.tar.bz2#82c878b61ad34fc2cf1686fa600a7a002d352e1b33a99a43007eec486ecd068e" "pypy" verify_py36 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy3.6-v7.1.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.1-osx64.tar.bz2#a5c2f2bfa2b4a4d29e8a67baab95699b169054066df218a14f171bb84a6df0c0" "pypy" verify_py36 ensurepip
+  install_package "pypy3.6-v7.1.1-osx64" "https://downloads.python.org/pypy/pypy3.6-v7.1.1-osx64.tar.bz2#a5c2f2bfa2b4a4d29e8a67baab95699b169054066df218a14f171bb84a6df0c0" "pypy" verify_py36 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -33,7 +33,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "win32" )
-  install_zip "pypy3.6-v7.1.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.1-win32.zip#8b513b254de5f31890f5956569de9aec3a0a91d7aba72fc89d66901f4a8ccf49" "pypy" verify_py36 ensurepip
+  install_zip "pypy3.6-v7.1.1-win32" "https://downloads.python.org/pypy/pypy3.6-v7.1.1-win32.zip#8b513b254de5f31890f5956569de9aec3a0a91d7aba72fc89d66901f4a8ccf49" "pypy" verify_py36 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3.6-7.1.1-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.1.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3.6-v7.1.1-src" "https://downloads.python.org/pypy/pypy3.6-v7.1.1-src.tar.bz2#6a3ef876e3691a54f4cff045028ec3be94ab9beb2e99f051b83175302c1899a8" "pypy_builder" verify_py36 ensurepip
+install_package "pypy3.6-v7.1.1-src" "https://downloads.python.org/pypy/pypy3.6-v7.1.1-src.tar.bz2#6a3ef876e3691a54f4cff045028ec3be94ab9beb2e99f051b83175302c1899a8" "pypy_builder" verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.1.1-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.1.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3.6-v7.1.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.1-src.tar.bz2#6a3ef876e3691a54f4cff045028ec3be94ab9beb2e99f051b83175302c1899a8" "pypy_builder" verify_py36 ensurepip
+  install_package "pypy3.6-v7.1.1-src" "https://downloads.python.org/pypy/pypy3.6-v7.1.1-src.tar.bz2#6a3ef876e3691a54f4cff045028ec3be94ab9beb2e99f051b83175302c1899a8" "pypy_builder" verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.2.0
+++ b/plugins/python-build/share/python-build/pypy3.6-7.2.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy3.6-v7.2.0-linux32" "https://downloads.python.org/pypy/pypy3.6-v7.2.0-linux32.tar.bz2#45e99de197cb3e974cfc8d45e0076ad2066852e61e56b3eafd1237efafd2c43e" "pypy" verify_py27 ensurepip
+    install_package "pypy3.6-v7.2.0-linux32" "https://downloads.python.org/pypy/pypy3.6-v7.2.0-linux32.tar.bz2#45e99de197cb3e974cfc8d45e0076ad2066852e61e56b3eafd1237efafd2c43e" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-  install_package "pypy3.6-v7.2.0-linux64" "https://downloads.python.org/pypy/pypy3.6-v7.2.0-linux64.tar.bz2#aa128e555ad0fe5c4c15104ae0903052bd232b6e3a73f5fe023d27b8fd0d6089" "pypy" verify_py36 ensurepip
+    install_package "pypy3.6-v7.2.0-linux64" "https://downloads.python.org/pypy/pypy3.6-v7.2.0-linux64.tar.bz2#aa128e555ad0fe5c4c15104ae0903052bd232b6e3a73f5fe023d27b8fd0d6089" "pypy" verify_py36 ensurepip
   else
     install_package "pypy3.6-7.2.0-beta-linux_x86_64-portable" "https://github.com/squeaky-pl/portable-pypy/releases/download/pypy3.6-7.2.0/pypy3.6-7.2.0-linux_x86_64-portable.tar.bz2#59099546b4dee56edcde2c9ff706687e35bb2aa94354cd56daa78aca036bd3d8" "pypy" verify_py36 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-  install_package "pypy3.6-v7.2.0-osx64" "https://downloads.python.org/pypy/pypy3.6-v7.2.0-osx64.tar.bz2#836abb0ec303b90a684533711ed3b8269d3e8c64805b595e410920abdea678ac" "pypy" verify_py36 ensurepip
+    install_package "pypy3.6-v7.2.0-osx64" "https://downloads.python.org/pypy/pypy3.6-v7.2.0-osx64.tar.bz2#836abb0ec303b90a684533711ed3b8269d3e8c64805b595e410920abdea678ac" "pypy" verify_py36 ensurepip
   else
     { echo
       colorize 1 "ERROR"

--- a/plugins/python-build/share/python-build/pypy3.6-7.2.0
+++ b/plugins/python-build/share/python-build/pypy3.6-7.2.0
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy3.6-v7.2.0-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.2.0-linux32.tar.bz2#45e99de197cb3e974cfc8d45e0076ad2066852e61e56b3eafd1237efafd2c43e" "pypy" verify_py27 ensurepip
+  install_package "pypy3.6-v7.2.0-linux32" "https://downloads.python.org/pypy/pypy3.6-v7.2.0-linux32.tar.bz2#45e99de197cb3e974cfc8d45e0076ad2066852e61e56b3eafd1237efafd2c43e" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,14 +14,14 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 14.04" "Ubuntu 16.04" 1>/dev/null 2>&1; then
-    install_package "pypy3.6-v7.2.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.2.0-linux64.tar.bz2#aa128e555ad0fe5c4c15104ae0903052bd232b6e3a73f5fe023d27b8fd0d6089" "pypy" verify_py36 ensurepip
+  install_package "pypy3.6-v7.2.0-linux64" "https://downloads.python.org/pypy/pypy3.6-v7.2.0-linux64.tar.bz2#aa128e555ad0fe5c4c15104ae0903052bd232b6e3a73f5fe023d27b8fd0d6089" "pypy" verify_py36 ensurepip
   else
     install_package "pypy3.6-7.2.0-beta-linux_x86_64-portable" "https://github.com/squeaky-pl/portable-pypy/releases/download/pypy3.6-7.2.0/pypy3.6-7.2.0-linux_x86_64-portable.tar.bz2#59099546b4dee56edcde2c9ff706687e35bb2aa94354cd56daa78aca036bd3d8" "pypy" verify_py36 ensurepip
   fi
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy3.6-v7.2.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.2.0-osx64.tar.bz2#836abb0ec303b90a684533711ed3b8269d3e8c64805b595e410920abdea678ac" "pypy" verify_py36 ensurepip
+  install_package "pypy3.6-v7.2.0-osx64" "https://downloads.python.org/pypy/pypy3.6-v7.2.0-osx64.tar.bz2#836abb0ec303b90a684533711ed3b8269d3e8c64805b595e410920abdea678ac" "pypy" verify_py36 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -33,7 +33,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "win32" )
-  install_zip "pypy3.6-v7.2.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.2.0-win32.zip#c926f622bec24a8b348591d631717ace83b3a6c3c2dac02b157b622b97d1fc9c" "pypy" verify_py36 ensurepip
+  install_zip "pypy3.6-v7.2.0-win32" "https://downloads.python.org/pypy/pypy3.6-v7.2.0-win32.zip#c926f622bec24a8b348591d631717ace83b3a6c3c2dac02b157b622b97d1fc9c" "pypy" verify_py36 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3.6-7.2.0-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.2.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3.6-v7.2.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.2.0-src.tar.bz2#0d7c707df5041f1593fe82f29c40056c21e4d6cb66554bbd66769bd80bcbfafc" "pypy_builder" verify_py36 ensurepip
+  install_package "pypy3.6-v7.2.0-src" "https://downloads.python.org/pypy/pypy3.6-v7.2.0-src.tar.bz2#0d7c707df5041f1593fe82f29c40056c21e4d6cb66554bbd66769bd80bcbfafc" "pypy_builder" verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.2.0-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.2.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3.6-v7.2.0-src" "https://downloads.python.org/pypy/pypy3.6-v7.2.0-src.tar.bz2#0d7c707df5041f1593fe82f29c40056c21e4d6cb66554bbd66769bd80bcbfafc" "pypy_builder" verify_py36 ensurepip
+install_package "pypy3.6-v7.2.0-src" "https://downloads.python.org/pypy/pypy3.6-v7.2.0-src.tar.bz2#0d7c707df5041f1593fe82f29c40056c21e4d6cb66554bbd66769bd80bcbfafc" "pypy_builder" verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.3.0
+++ b/plugins/python-build/share/python-build/pypy3.6-7.3.0
@@ -3,17 +3,17 @@ PYVER='3.6'
 
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#7045b295d38ba0b5ee65bd3f078ca249fcf1de73fedeaab2d6ad78de2eab0f0e" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#7045b295d38ba0b5ee65bd3f078ca249fcf1de73fedeaab2d6ad78de2eab0f0e" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 "linux64" )
-  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#d3d549e8f43de820ac3385b698b83fa59b4d7dd6cf3fe34c115f731e26ad8856" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#d3d549e8f43de820ac3385b698b83fa59b4d7dd6cf3fe34c115f731e26ad8856" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 "linux-aarch64" )
-  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#b900241bca7152254c107a632767f49edede99ca6360b9a064141267b47ef598" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#b900241bca7152254c107a632767f49edede99ca6360b9a064141267b47ef598" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#87b2545dad75fe3027b4b2108aceb9fdadcdd24e61ae312ac48b449fdd452bf3" "pypy" "verify_py${PYVER//./}" ensurepip
+    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#87b2545dad75fe3027b4b2108aceb9fdadcdd24e61ae312ac48b449fdd452bf3" "pypy" "verify_py${PYVER//./}" ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -25,7 +25,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "win32" )
-  install_zip "pypy${PYVER}-v${VERSION}-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-win32.zip#30e6870c4f3d8ef91890a6556a98080758000ba7c207cccdd86a8f5d358998c1" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_zip "pypy${PYVER}-v${VERSION}-win32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-win32.zip#30e6870c4f3d8ef91890a6556a98080758000ba7c207cccdd86a8f5d358998c1" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3.6-7.3.0-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.3.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3.6-v7.3.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.3.0-src.tar.bz2#48d12c15fbcbcf4a32882a883195e1f922997cde78e7a16d4342b9b521eefcfa" "pypy_builder" verify_py36 ensurepip
+  install_package "pypy3.6-v7.3.0-src" "https://downloads.python.org/pypy/pypy3.6-v7.3.0-src.tar.bz2#48d12c15fbcbcf4a32882a883195e1f922997cde78e7a16d4342b9b521eefcfa" "pypy_builder" verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.3.0-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.3.0-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3.6-v7.3.0-src" "https://downloads.python.org/pypy/pypy3.6-v7.3.0-src.tar.bz2#48d12c15fbcbcf4a32882a883195e1f922997cde78e7a16d4342b9b521eefcfa" "pypy_builder" verify_py36 ensurepip
+install_package "pypy3.6-v7.3.0-src" "https://downloads.python.org/pypy/pypy3.6-v7.3.0-src.tar.bz2#48d12c15fbcbcf4a32882a883195e1f922997cde78e7a16d4342b9b521eefcfa" "pypy_builder" verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.3.1
+++ b/plugins/python-build/share/python-build/pypy3.6-7.3.1
@@ -3,17 +3,17 @@ PYVER='3.6'
 
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#2e7a818c67f3ac0708e4d8cdf1961f30cf9586b3f3ca2f215d93437c5ea4567b" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#2e7a818c67f3ac0708e4d8cdf1961f30cf9586b3f3ca2f215d93437c5ea4567b" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 "linux64" )
-  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#f67cf1664a336a3e939b58b3cabfe47d893356bdc01f2e17bc912aaa6605db12" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#f67cf1664a336a3e939b58b3cabfe47d893356bdc01f2e17bc912aaa6605db12" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 "linux-aarch64" )
-  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#0069bc3c1570b935f1687f5e128cf050cd7229309e48fad2a2bf2140d43ffcee" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#0069bc3c1570b935f1687f5e128cf050cd7229309e48fad2a2bf2140d43ffcee" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#d9c1778cd1ba37e129b495ea0f35ccdd9b68f5cd9d33ef0ce24e955c16d8840b" "pypy" "verify_py${PYVER//./}" ensurepip
+    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#d9c1778cd1ba37e129b495ea0f35ccdd9b68f5cd9d33ef0ce24e955c16d8840b" "pypy" "verify_py${PYVER//./}" ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -25,7 +25,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "win32" )
-  install_zip "pypy${PYVER}-v${VERSION}-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy${PYVER}-v${VERSION}-win32.zip#752fbe8c4abee6468e5ce22af82818f821daded36faa65f3d69423f9c217007a" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_zip "pypy${PYVER}-v${VERSION}-win32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-win32.zip#752fbe8c4abee6468e5ce22af82818f821daded36faa65f3d69423f9c217007a" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3.6-7.3.1-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.3.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
-  install_package "pypy3.6-v7.3.1-src" "https://downloads.python.org/pypy/pypy3.6-v7.3.1-src.tar.bz2#0c2cc3229da36c6984baee128c8ff8bb4516d69df1d73275dc4622bf249afa83" "pypy_builder" verify_py36 ensurepip
+install_package "pypy3.6-v7.3.1-src" "https://downloads.python.org/pypy/pypy3.6-v7.3.1-src.tar.bz2#0c2cc3229da36c6984baee128c8ff8bb4516d69df1d73275dc4622bf249afa83" "pypy_builder" verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.6-7.3.1-src
+++ b/plugins/python-build/share/python-build/pypy3.6-7.3.1-src
@@ -1,4 +1,4 @@
 #require_gcc
 prefer_openssl11
 install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
-install_package "pypy3.6-v7.3.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.3.1-src.tar.bz2#0c2cc3229da36c6984baee128c8ff8bb4516d69df1d73275dc4622bf249afa83" "pypy_builder" verify_py36 ensurepip
+  install_package "pypy3.6-v7.3.1-src" "https://downloads.python.org/pypy/pypy3.6-v7.3.1-src.tar.bz2#0c2cc3229da36c6984baee128c8ff8bb4516d69df1d73275dc4622bf249afa83" "pypy_builder" verify_py36 ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1681

### Description
- [x] Here are some details about my PR

PyPy has migrated away from Bitbucket hosting to Heptapod. Sources and build
archives are now hosted at downloads.python.org.

### Tests
- [ ] My PR adds the following unit tests (if any)
