### PR TITLE
Add CPython v3.5.10.

### DIFF
--- a/plugins/python-build/share/python-build/3.5.10
+++ b/plugins/python-build/share/python-build/3.5.10
@@ -1,0 +1,9 @@
+#require_gcc
+prefer_openssl11
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-3.5.10" "https://www.python.org/ftp/python/3.5.10/Python-3.5.10.tar.xz#0f0fa8685c1dc1f1dacb0b4e7779796b90aef99dc1fa4967a71b9da7b57d4a28" ldflags_dirs standard verify_py35 ensurepip
+else
+  install_package "Python-3.5.10" "https://www.python.org/ftp/python/3.5.10/Python-3.5.10.tgz#3496a0daf51913718a6f10e3eda51fa43634cb6151cb096f312d48bdbeff7d3a" ldflags_dirs standard verify_py35 ensurepip
+fi


### PR DESCRIPTION
Closes #1689 

Adding the Python v3.5.10 release. Bats tests still pass, tested the install in Ubuntu 20.04.