### PR TITLE
python-build: Only use explicit path as definition if it's not a plain name

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1871,7 +1871,7 @@ done
 DEFINITION_PATH="${ARGUMENTS[0]}"
 if [ -z "$DEFINITION_PATH" ]; then
   usage 1 >&2
-elif [ ! -f "$DEFINITION_PATH" ]; then
+elif [[ ! "$DEFINITION_PATH" =~ \/ || ! -f "$DEFINITION_PATH" ]]; then
   for DEFINITION_DIR in "${PYTHON_BUILD_DEFINITIONS[@]}"; do
     if [ -f "${DEFINITION_DIR}/${DEFINITION_PATH}" ]; then
       DEFINITION_PATH="${DEFINITION_DIR}/${DEFINITION_PATH}"


### PR DESCRIPTION
This fixes erroneous behavior if there happens to be an entry in the current directory
with the same name as the defnition.
To explicitly use a file in the current directory as a definition, specify it as "./file_name".

I ran into this issue when installing and testing multiple versions, saving test output into a file with the same name as the version for simplicity.

---

Make sure you have checked all steps below.

### Prerequisite
* [X] Please consider implementing the feature as a hook script or plugin as a first step.
  N/A: bugfix
* [X] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  N/A: affects python-build
* [X] My PR addresses the following pyenv issue (if any)
  N/A

### Description
- [X] Here are some details about my PR

This fixes erroneous behavior if there happens to be an entry in the current directory
with the same name as the defnition.
To explicitly use a file in the current directory as a definition, specify it as "./file_name".


### Tests
- [ ] My PR adds the following unit tests (if any)
 There don't seem to be any tests for python-build in tests/. Should there?