### PR TITLE
Search for plugins in PYENV_DIR and PYENV_ROOT

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -94,7 +94,7 @@ export PYENV_DIR
 shopt -s nullglob
 
 bin_path="$(abs_dirname "$0")"
-for plugin_bin in "${PYENV_ROOT}/plugins/"*/bin; do
+for plugin_bin in {${PYENV_ROOT},${PYENV_DIR}}/plugins/*/bin; do
   PATH="${plugin_bin}:${PATH}"
 done
 export PATH="${bin_path}:${PATH}"

--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -94,10 +94,10 @@ export PYENV_DIR
 shopt -s nullglob
 
 bin_path="$(abs_dirname "$0")"
-for plugin_bin in ${PYENV_DIR}/plugins/*/bin; do
+for plugin_bin in "${bin_path%/*}"/plugins/*/bin; do
   PATH="${plugin_bin}:${PATH}"
 done
-for plugin_bin in ${PYENV_ROOT}/plugins/*/bin; do
+for plugin_bin in "${PYENV_ROOT}"/plugins/*/bin; do
   PATH="${plugin_bin}:${PATH}"
 done
 export PATH="${bin_path}:${PATH}"

--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -94,7 +94,10 @@ export PYENV_DIR
 shopt -s nullglob
 
 bin_path="$(abs_dirname "$0")"
-for plugin_bin in {${PYENV_ROOT},${PYENV_DIR}}/plugins/*/bin; do
+for plugin_bin in ${PYENV_DIR}/plugins/*/bin; do
+  PATH="${plugin_bin}:${PATH}"
+done
+for plugin_bin in ${PYENV_ROOT}/plugins/*/bin; do
   PATH="${plugin_bin}:${PATH}"
 done
 export PATH="${bin_path}:${PATH}"

--- a/test/pyenv.bats
+++ b/test/pyenv.bats
@@ -48,7 +48,7 @@ load test_helper
 
 @test "adds its own libexec to PATH" {
   run pyenv echo "PATH"
-  assert_success "${BATS_TEST_DIRNAME%/*}/libexec:$PATH"
+  assert_success "${BATS_TEST_DIRNAME%/*}/libexec:${BATS_TEST_DIRNAME%/*}/plugins/python-build/bin:$PATH"
 }
 
 @test "adds plugin bin dirs to PATH" {
@@ -59,6 +59,7 @@ load test_helper
   assert_line 0 "${BATS_TEST_DIRNAME%/*}/libexec"
   assert_line 1 "${PYENV_ROOT}/plugins/python-build/bin"
   assert_line 2 "${PYENV_ROOT}/plugins/pyenv-each/bin"
+  assert_line 3 "${BATS_TEST_DIRNAME%/*}/plugins/python-build/bin"
 }
 
 @test "PYENV_HOOK_PATH preserves value from environment" {


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * _**This solution is not applicable to rbenv because rbenv does not bundle the build plugin (see #913)**_
* [x] My PR addresses the following pyenv issue (if any)
  * fixes https://github.com/pyenv/pyenv/issues/1696

### Description
* [x] Here are some details about my PR

    I ran into this when using [basher](https://github.com/basherpm/basher) to install pyenv and finding that `pyenv install` was failing for not finding pyenv-install, despite the embedded plugin. This matches my experiences with packaging for linux, where [it's common to move `python-build/` into `share/`](https://build.opensuse.org/package/view_file/devel:languages:python/pyenv/pyenv.spec?expand=1).



### Tests
* [x] My PR ~adds~ updates the following unit tests (if any)
  * `adds its own libexec to PATH`
  * `adds plugin bin dirs to PATH`