### PR TITLE
Drop pypy3-dev

### DIFF
--- a/plugins/python-build/share/python-build/pypy3-dev
+++ b/plugins/python-build/share/python-build/pypy3-dev
@@ -1,4 +1,0 @@
-#require_gcc
-prefer_openssl11
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_hg "pypy3-dev" "https://bitbucket.org/pypy/pypy" "py3k" "pypy_builder" verify_py32 ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [X] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [X] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [X] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [X] Here are some details about my PR

PyPy has now only one development tip. The `py3k` branch has been closed in 2016. As such, a separate `pypy3-dev` entry no longer makes sense.

### Tests
- [X] My PR adds the following unit tests (if any)
   N/A