### PR TITLE
Add CPython 3.9.0

### DIFF
--- a/plugins/python-build/share/python-build/3.9.0
+++ b/plugins/python-build/share/python-build/3.9.0
@@ -4,8 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.9.0rc2" "https://www.python.org/ftp/python/3.9.0/Python-3.9.0rc2.tar.xz#80b57c11f60dc1f46a408b1543f04ed52e6475ed5e597b4c23f3fd65f0b729ba" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.0" "https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz#9c73e63c99855709b9be0b3cc9e5b072cb60f37311e8c4e50f15576a0bf82854" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
 else
-    install_package "Python-3.9.0rc2" "https://www.python.org/ftp/python/3.9.0/Python-3.9.0rc2.tgz#f49fcaef992d908995afcda93d150c77bd452af4fe8c23ac1b92843fda0b6fb2" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.0" "https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tgz#df796b2dc8ef085edae2597a41c1c0a63625ebd92487adaef2fed22b567873e8" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
 fi
-


### PR DESCRIPTION
Replaces the current latest 3.9.0 (rc2) with 3.9.0 stable, released today.