### PR TITLE
Travis CI: Add Xcode 12 on macOS 10.15.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,10 @@ dist:
 
 # https://docs.travis-ci.com/user/reference/osx/#macos-version
 osx_image:
-- xcode9.4.1
-- xcode10.3
-- xcode11.3
+- xcode9.4.1  # macOS 10.13
+- xcode10.3   # macOS 10.14.4
+- xcode11.3   # macOS 10.14.6
+- xcode12u    # macOS 10.15.5
 
 env:
 - PYTHON_BUILD_VERSION=3.8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,17 @@ os:
 - osx
 
 dist:
-- xenial
+- focal
 
 # https://docs.travis-ci.com/user/reference/osx/#macos-version
 osx_image:
 - xcode9.4.1  # macOS 10.13
 - xcode10.3   # macOS 10.14.4
 - xcode11.3   # macOS 10.14.6
-- xcode12u    # macOS 10.15.5
+- xcode12.2   # macOS 11.0
 
 env:
-- PYTHON_BUILD_VERSION=3.8.0
+- PYTHON_BUILD_VERSION=3.9.1
 - PYTHON_BUILD_VERSION=3.7.5
 
 before_install:
@@ -61,7 +61,7 @@ jobs:
     osx_image: xcode10
 
   allow_failures:
-  - env: PYTHON_BUILD_VERSION=3.8.0
+  - env: PYTHON_BUILD_VERSION=3.9.1
 
 stages:
 - test shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ dist:
 osx_image:
 - xcode9.4.1  # macOS 10.13
 - xcode10.3   # macOS 10.14.4
-- xcode11.3   # macOS 10.14.6
-- xcode12.2   # macOS 11.0
+- xcode11.6   # macOS 10.14.6
+- xcode12.2   # macOS 10.15.7
 
 env:
 - PYTHON_BUILD_VERSION=3.9.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ dist:
 
 # https://docs.travis-ci.com/user/reference/osx/#macos-version
 osx_image:
-- xcode9.4.1  # macOS 10.13
+- xcode9.4.1  # macOS 10.13.6
 - xcode10.3   # macOS 10.14.4
-- xcode11.6   # macOS 10.14.6
+- xcode11.6   # macOS 10.15.7
 - xcode12.2   # macOS 10.15.7
 
 env:


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR
Add the current macOS and current Xcode to the testing.
* https://docs.travis-ci.com/user/reference/osx/#macos-version
### Tests
- [x] My PR adds the following unit tests (if any)
Travis CI
