### PR TITLE
Add LDFLAGS for zlib on macOS >= 1100

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1493,6 +1493,9 @@ use_xcode_sdk_zlib() {
   if [ -d "$xc_sdk_path" ]; then
     echo "python-build: use zlib from xcode sdk"
     export CFLAGS="-I${xc_sdk_path}/usr/include ${CFLAGS}"
+    if is_mac -ge 1100; then
+      export LDFLAGS="-L${xc_sdk_path}/usr/lib ${LDFLAGS}"
+    fi
   fi
 }
 


### PR DESCRIPTION
Add LDFLAGS for Xcode SDK zlib on macOS >= 1100 to resolve build issues on Big Sur.

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
  n/a
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
  n/a - this code does not appear in rbenv
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1643
Note: The issue is for general macOS 11 Big Sur beta build issues. Users must also have downloaded the Xcode 12.2 beta from Apple and have the macOS 11 SDK installed in addition to the Big Sur beta itself.

### Description
- [x] Here are some details about my PR
This is a 3 line change to python-build that affects macOS 11.0 Big Sur (currently in beta). Big Sur no longer packages dynamic libraries in /usr/lib as detailed in https://github.com/pyenv/pyenv/issues/1643#issuecomment-704223840 . This requires python-build to link against $(xcrun --show-sdk-path)/usr/lib on macOS >= 11.0 when using the macOS-shipped zlib. This allows python-build to correctly build python again on macOS 11 (Big Sur).

### Tests
- [x] My PR adds the following unit tests (if any)
n/a