### PR TITLE
Update OpenSSL to the supported version

### DIFF
--- a/plugins/python-build/share/python-build/3.9.0
+++ b/plugins/python-build/share/python-build/3.9.0
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.9.0" "https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz#9c73e63c99855709b9be0b3cc9e5b072cb60f37311e8c4e50f15576a0bf82854" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip


### PR DESCRIPTION
Updates OpenSSL to the supported version 1.1.1h as 1.1.0 has several [issues](https://www.openssl.org/news/vulnerabilities-1.1.1.html)