### PR TITLE
Fix 'sed: RE error: illegal byte sequence'

### DIFF
--- a/libexec/pyenv-help
+++ b/libexec/pyenv-help
@@ -27,8 +27,8 @@ command_path() {
 }
 
 extract_initial_comment_block() {
-  LC_ALL=C
-  LANG=C
+  LC_ALL= \
+  LC_CTYPE=C \
   sed -ne "
     /^#/ !{
       q


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1454

### Description
- [x] Here are some details about my PR
Fix 'sed: RE error: illegal byte sequence' 
by unsetting `LC_ALL` and passing `LC_CTYPE=C` to `sed`.

### Tests
- [x] My PR adds the following unit tests (if any)
