### PR TITLE
Add GraalPython 20.3

### DIFF
--- a/plugins/python-build/share/python-build/graalpython-20.1.0
+++ b/plugins/python-build/share/python-build/graalpython-20.1.0
@@ -42,7 +42,7 @@ esac
 if [ -n "${BUILD}" ]; then
   urlprefix="https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/${VERSION}-${BUILD}"
 else
-  urlprefix="https://github.com/graalvm/graalpython/releases/download/vm-${VERSION}"
+  urlprefix="https://github.com/oracle/graalpython/releases/download/vm-${VERSION}"
 fi
 
 install_package "graalpython-${VERSION}${BUILD}" "${urlprefix}/graalpython-${VERSION}-${graalpython_arch}-amd64.tar.gz#${checksum}" "graalpython" ensurepip

--- a/plugins/python-build/share/python-build/graalpython-20.2.0
+++ b/plugins/python-build/share/python-build/graalpython-20.2.0
@@ -42,7 +42,7 @@ esac
 if [ -n "${BUILD}" ]; then
   urlprefix="https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/${VERSION}-${BUILD}"
 else
-  urlprefix="https://github.com/graalvm/graalpython/releases/download/vm-${VERSION}"
+  urlprefix="https://github.com/oracle/graalpython/releases/download/vm-${VERSION}"
 fi
 
 install_package "graalpython-${VERSION}${BUILD}" "${urlprefix}/graalpython-${VERSION}-${graalpython_arch}-amd64.tar.gz#${checksum}" "graalpython" ensurepip

--- a/plugins/python-build/share/python-build/graalpython-20.3.0
+++ b/plugins/python-build/share/python-build/graalpython-20.3.0
@@ -42,7 +42,7 @@ esac
 if [ -n "${BUILD}" ]; then
   urlprefix="https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/${VERSION}-${BUILD}"
 else
-  urlprefix="https://github.com/graalvm/graalpython/releases/download/vm-${VERSION}"
+  urlprefix="https://github.com/oracle/graalpython/releases/download/vm-${VERSION}"
 fi
 
 install_package "graalpython-${VERSION}${BUILD}" "${urlprefix}/graalpython-${VERSION}-${graalpython_arch}-amd64.tar.gz#${checksum}" "graalpython" ensurepip

--- a/plugins/python-build/share/python-build/graalpython-20.3.0
+++ b/plugins/python-build/share/python-build/graalpython-20.3.0
@@ -1,0 +1,48 @@
+# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+VERSION='20.3.0'
+BUILD=''
+
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux64" )
+  graalpython_arch="linux"
+  checksum="121508c64c2f18e9a57294d38a4c090c7a9417087f8549e120d0050906e2c82f"
+  ;;
+"osx64" )
+  graalpython_arch="macos"
+  checksum="1a80bf3fde2dc2d0fdc92605176c281835d912c26847346150b3be82d2a250e0"
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": No binary distribution of GraalPython is available for $(pypy_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac
+
+if [ -n "${BUILD}" ]; then
+  urlprefix="https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/${VERSION}-${BUILD}"
+else
+  urlprefix="https://github.com/graalvm/graalpython/releases/download/vm-${VERSION}"
+fi
+
+install_package "graalpython-${VERSION}${BUILD}" "${urlprefix}/graalpython-${VERSION}-${graalpython_arch}-amd64.tar.gz#${checksum}" "graalpython" ensurepip


### PR DESCRIPTION
This adds the recently released GraalPython 20.3 to the available install scripts.
