### PR TITLE
Use associative arrays for performance on bash >= 4

### DIFF
--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -123,34 +123,62 @@ make_shims() {
   done
 }
 
-registered_shims=" "
+if ((${BASH_VERSINFO[0]} > 3)); then
 
-# Registers the name of a shim to be generated.
-register_shim() {
-  registered_shims="${registered_shims}${1} "
-}
+  declare -A registered_shims
 
-# Install all the shims registered via `make_shims` or `register_shim` directly.
-install_registered_shims() {
-  local shim file
-  for shim in $registered_shims; do
-    file="${SHIM_PATH}/${shim}"
-    [ -e "$file" ] || cp "$PROTOTYPE_SHIM_PATH" "$file"
-  done
-}
+  # Registers the name of a shim to be generated.
+  register_shim() {
+    registered_shims["$1"]=1
+  }
 
-# Once the registered shims have been installed, we make a second pass
-# over the contents of the shims directory. Any file that is present
-# in the directory but has not been registered as a shim should be
-# removed.
-remove_stale_shims() {
-  local shim
-  for shim in "$SHIM_PATH"/*; do
-    if [[ "$registered_shims" != *" ${shim##*/} "* ]]; then
-      rm -f "$shim"
-    fi
-  done
-}
+  # Install all shims registered via `make_shims` or `register_shim` directly.
+  install_registered_shims() {
+    local shim file
+    for shim in "${!registered_shims[@]}"; do
+      file="${SHIM_PATH}/${shim}"
+      [ -e "$file" ] || cp "$PROTOTYPE_SHIM_PATH" "$file"
+    done
+  }
+
+  # Once the registered shims have been installed, we make a second pass
+  # over the contents of the shims directory. Any file that is present
+  # in the directory but has not been registered as a shim should be
+  # removed.
+  remove_stale_shims() {
+    local shim
+    for shim in "$SHIM_PATH"/*; do
+      if [[ ! ${registered_shims["${shim##*/}"]} ]]; then
+        rm -f "$shim"
+      fi
+    done
+  }
+
+else # Same for bash < 4.
+
+    registered_shims=" "
+
+    register_shim() {
+      registered_shims="${registered_shims}${1} "
+    }
+
+    install_registered_shims() {
+      local shim file
+      for shim in $registered_shims; do
+        file="${SHIM_PATH}/${shim}"
+        [ -e "$file" ] || cp "$PROTOTYPE_SHIM_PATH" "$file"
+      done
+    }
+
+    remove_stale_shims() {
+      local shim
+      for shim in "$SHIM_PATH"/*; do
+        if [[ "$registered_shims" != *" ${shim##*/} "* ]]; then
+          rm -f "$shim"
+        fi
+      done
+    }
+fi
 
 shopt -s nullglob
 

--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -64,16 +64,27 @@ if [ -d "$versions_dir" ]; then
   versions_dir="$(realpath "$versions_dir")"
 fi
 
+if ((${BASH_VERSINFO[0]} > 3)); then
+  declare -A current_versions
+else
+  current_versions=()
+fi
 if [ -n "$bare" ]; then
   hit_prefix=""
   miss_prefix=""
-  current_versions=()
   include_system=""
 else
   hit_prefix="* "
   miss_prefix="  "
   OLDIFS="$IFS"
-  IFS=: current_versions=($(pyenv-version-name || true))
+  IFS=:
+  if ((${BASH_VERSINFO[0]} > 3)); then
+    for i in $(pyenv-version-name || true); do
+      current_versions["$i"]="1"
+    done
+  else
+    current_versions=($(pyenv-version-name || true))
+  fi
   IFS="$OLDIFS"
   include_system="1"
 fi
@@ -93,7 +104,9 @@ exists() {
 }
 
 print_version() {
-  if exists "$1" "${current_versions[@]}"; then
+  if [[ ${BASH_VERSINFO[0]} -ge 4 && ${current_versions["$1"]} ]]; then
+    echo "${hit_prefix}$1 (set by $(pyenv-version-origin))"
+  elif (( ${BASH_VERSINFO[0]} < 3 )) && exists "$1" "${current_versions[@]}"; then
     echo "${hit_prefix}$1 (set by $(pyenv-version-origin))"
   else
     echo "${miss_prefix}$1"


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

This makes use of bash associative arrays for speedups, see individual commit messages for details. These are quite noticeable at shell startup.

Will submit the same PR's to rbenv.

~Note: associative arrays are available starting from bash 4.0. I didn't find a reference which bash versions should pyenv work with, but bash 4.0 is already pretty old. If that's a no go, the implementation could be reworked so that it defines different function implementations for different bash versions.~ Reworked.

### Tests
- [x] My PR adds the following unit tests (if any)

N/A