### PR TITLE
Put prerequisite for installation before install

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ We'd recommend to install pyenv-virtualenv as well if you have some plan to play
 
 ## Installation
 
+### Prerequisites:
+
+For pyenv to install python correctly you should [**install the Python build dependencies**](https://github.com/pyenv/pyenv/wiki#suggested-build-environment).
+
 ### Homebrew on macOS
 
    1. Consider installing with [Homebrew](https://brew.sh)


### PR DESCRIPTION
This prevents people from jumping the gun and trying to install a python version right after brew install.

### Prerequisite
* [N/A] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [N/A] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [X] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1136

### Description
- [X] Here are some details about my PR
See top

### Tests
- [N/A] My PR adds the following unit tests (if any)
