### PR TITLE
Anaconda3-2020.11, Miniforge3-4.9.2-4, and Apple M1 support in anaconda_architecture()

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -995,7 +995,13 @@ build_package_activepython() {
 
 anaconda_architecture() {
   case "$(uname -s)" in
-  "Darwin" ) echo "MacOSX-x86_64" ;;
+  "Darwin" )
+    case "$(uname -m)" in
+    "arm64" ) echo "MacOSX-arm64" ;;
+    "i386" | "x86_64" ) echo "MacOSX-x86_64" ;;
+    * ) return 1 ;;
+    esac
+    ;;
   "Linux" )
     case "$(uname -m)" in
     "armv7l" ) echo "Linux-armv7l" ;;

--- a/plugins/python-build/share/python-build/anaconda3-2020.11
+++ b/plugins/python-build/share/python-build/anaconda3-2020.11
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Anaconda3-2020.11-Linux-ppc64le" "https://repo.continuum.io/archive/Anaconda3-2020.11-Linux-ppc64le.sh#870535ada0a8ae75eeda8cd2bf7dde853ac9f4949b20e1b5641f1843a655f3b8" "anaconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda3-2020.11-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2020.11-Linux-x86_64.sh#cf2ff493f11eaad5d09ce2b4feaa5ea90db5174303d5b3fe030e16d29aeef7de" "anaconda" verify_py38
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda3-2020.11-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2020.11-MacOSX-x86_64.sh#ec11e325c792a6f49dbdbe5e641991d0a29788689176d7e54da97def9532c762" "anaconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda3 is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.9.2-4
+++ b/plugins/python-build/share/python-build/miniforge3-4.9.2-4
@@ -1,0 +1,22 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.9.2-4-Linux-ppc64le" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-4/Miniforge3-4.9.2-4-Linux-ppc64le.sh#d226016334a28fc99912c640fcb52074" "miniconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.9.2-4-Linux-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-4/Miniforge3-4.9.2-4-Linux-x86_64.sh#cdfeb2264de9c77bd9dc4ce8f7dfbad4" "miniconda" verify_py38
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.9.2-4-MacOSX-arm64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-4/Miniforge3-4.9.2-4-MacOSX-arm64.sh#c5f52aa3bf6b5d56469138d4cdcd9079" "miniconda" verify_py38
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.9.2-4-MacOSX-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-4/Miniforge3-4.9.2-4-MacOSX-x86_64.sh#23337bfd70a8099395b1a5c42ac725fd" "miniconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
1. I added support for Anaconda 2020.11. (Linux x86_64, Linux ppc64, macOS x86_64)
2. Added Miniforge3-4.9.2-4 support (Linux x86_64, Linux ppc64, macOS x86_64, macOS arch64), so now we can install and use this python distribution too! This repository holds a minimal installer for conda specific to conda-forge. It is comparable to Miniconda, but with conda-forge set as the default channel and an emphasis on supporting various CPU architectures.
3. I made some changes for supporting new architecture Apple M1 on MacOS in python-build script, specially for Miniforge and future Anaconda installation.

All works fine, tested and using on my Macbook Air M1.

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)
