### PR TITLE
Added arm64 architecture support in python-build for macOS 

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -995,7 +995,13 @@ build_package_activepython() {
 
 anaconda_architecture() {
   case "$(uname -s)" in
-  "Darwin" ) echo "MacOSX-x86_64" ;;
+  "Darwin" )
+    case "$(uname -m)" in
+    "arm64" ) echo "MacOSX-arm64" ;;
+    "i386" | "x86_64" ) echo "MacOSX-x86_64" ;;
+    * ) return 1 ;;
+    esac
+    ;;
   "Linux" )
     case "$(uname -m)" in
     "armv7l" ) echo "Linux-armv7l" ;;

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -998,8 +998,7 @@ anaconda_architecture() {
   "Darwin" )
     case "$(uname -m)" in
     "arm64" ) echo "MacOSX-arm64" ;;
-    "i386" | "x86_64" ) echo "MacOSX-x86_64" ;;
-    * ) return 1 ;;
+    * ) echo "MacOSX-x86_64" ;;
     esac
     ;;
   "Linux" )

--- a/plugins/python-build/share/python-build/anaconda3-2020.11
+++ b/plugins/python-build/share/python-build/anaconda3-2020.11
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Anaconda3-2020.11-Linux-ppc64le" "https://repo.continuum.io/archive/Anaconda3-2020.11-Linux-ppc64le.sh#870535ada0a8ae75eeda8cd2bf7dde853ac9f4949b20e1b5641f1843a655f3b8" "anaconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda3-2020.11-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2020.11-Linux-x86_64.sh#cf2ff493f11eaad5d09ce2b4feaa5ea90db5174303d5b3fe030e16d29aeef7de" "anaconda" verify_py38
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda3-2020.11-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2020.11-MacOSX-x86_64.sh#ec11e325c792a6f49dbdbe5e641991d0a29788689176d7e54da97def9532c762" "anaconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda3 is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
