### PR TITLE
Added Miniforge3-4.9.2

### DIFF
--- a/plugins/python-build/share/python-build/miniforge3-4.9.2
+++ b/plugins/python-build/share/python-build/miniforge3-4.9.2
@@ -6,10 +6,10 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
   install_script "Miniforge3-4.9.2-5-Linux-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-Linux-x86_64.sh#73ea193f82d8f3b558b9c2186a147bcf" "miniconda" verify_py38
   ;;
 "MacOSX-arm64" )
-  install_script "Miniforge3-4.9.2-5-MacOSX-arm64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-MacOSX-arm64.sh#cf309b725c8a0b4448e4ee922703bf00" "miniconda" verify_py38
+  install_script "Miniforge3-4.9.2-5-MacOSX-arm64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-MacOSX-arm64.sh#cf309b725c8a0b4448e4ee922703bf00" "miniconda" verify_py39
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniforge3-4.9.2-5-MacOSX-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-MacOSX-x86_64.sh#e66d62e8872bc1548af54063cab7b72e" "miniconda" verify_py39
+  install_script "Miniforge3-4.9.2-5-MacOSX-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-MacOSX-x86_64.sh#e66d62e8872bc1548af54063cab7b72e" "miniconda" verify_py38
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniforge3-4.9.2
+++ b/plugins/python-build/share/python-build/miniforge3-4.9.2
@@ -1,0 +1,22 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.9.2-4-Linux-ppc64le" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-4/Miniforge3-4.9.2-4-Linux-ppc64le.sh#d226016334a28fc99912c640fcb52074" "miniconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.9.2-4-Linux-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-4/Miniforge3-4.9.2-4-Linux-x86_64.sh#cdfeb2264de9c77bd9dc4ce8f7dfbad4" "miniconda" verify_py38
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.9.2-4-MacOSX-arm64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-4/Miniforge3-4.9.2-4-MacOSX-arm64.sh#c5f52aa3bf6b5d56469138d4cdcd9079" "miniconda" verify_py38
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.9.2-4-MacOSX-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-4/Miniforge3-4.9.2-4-MacOSX-x86_64.sh#23337bfd70a8099395b1a5c42ac725fd" "miniconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.9.2
+++ b/plugins/python-build/share/python-build/miniforge3-4.9.2
@@ -1,15 +1,15 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-ppc64le" )
-  install_script "Miniforge3-4.9.2-4-Linux-ppc64le" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-4/Miniforge3-4.9.2-4-Linux-ppc64le.sh#d226016334a28fc99912c640fcb52074" "miniconda" verify_py38
+  install_script "Miniforge3-4.9.2-5-Linux-ppc64le" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-Linux-ppc64le.sh#825b3e5f39f0bdb825323ea23af24ba4" "miniconda" verify_py38
   ;;
 "Linux-x86_64" )
-  install_script "Miniforge3-4.9.2-4-Linux-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-4/Miniforge3-4.9.2-4-Linux-x86_64.sh#cdfeb2264de9c77bd9dc4ce8f7dfbad4" "miniconda" verify_py38
+  install_script "Miniforge3-4.9.2-5-Linux-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-Linux-x86_64.sh#73ea193f82d8f3b558b9c2186a147bcf" "miniconda" verify_py38
   ;;
 "MacOSX-arm64" )
-  install_script "Miniforge3-4.9.2-4-MacOSX-arm64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-4/Miniforge3-4.9.2-4-MacOSX-arm64.sh#c5f52aa3bf6b5d56469138d4cdcd9079" "miniconda" verify_py38
+  install_script "Miniforge3-4.9.2-5-MacOSX-arm64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-MacOSX-arm64.sh#cf309b725c8a0b4448e4ee922703bf00" "miniconda" verify_py38
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniforge3-4.9.2-4-MacOSX-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-4/Miniforge3-4.9.2-4-MacOSX-x86_64.sh#23337bfd70a8099395b1a5c42ac725fd" "miniconda" verify_py39
+  install_script "Miniforge3-4.9.2-5-MacOSX-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-MacOSX-x86_64.sh#e66d62e8872bc1548af54063cab7b72e" "miniconda" verify_py39
   ;;
 * )
   { echo


### PR DESCRIPTION
Added Miniforge3-4.9.2 support for all platforms, including arm64 in macOS for Apple M1 SoC.
Do not merge until the previous ones are merged!

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)
