### PR TITLE
Use verify_py38 for anaconda3-2020.07

### DIFF
--- a/plugins/python-build/share/python-build/anaconda3-2020.07
+++ b/plugins/python-build/share/python-build/anaconda3-2020.07
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-ppc64le" )
-  install_script "Anaconda3-2020.07-Linux-ppc64le" "https://repo.continuum.io/archive/Anaconda3-2020.07-Linux-ppc64le.sh#0df7c3784973ab46a9ef9848aced01311d08a71d79a18d5ed79dccdae8c8dea7" "anaconda" verify_py37
+  install_script "Anaconda3-2020.07-Linux-ppc64le" "https://repo.continuum.io/archive/Anaconda3-2020.07-Linux-ppc64le.sh#0df7c3784973ab46a9ef9848aced01311d08a71d79a18d5ed79dccdae8c8dea7" "anaconda" verify_py38
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda3-2020.07-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2020.07-Linux-x86_64.sh#38ce717758b95b3bd0b1797cc6ccfb76f29a90c25bdfa50ee45f11e583edfdbf" "anaconda" verify_py37
+  install_script "Anaconda3-2020.07-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2020.07-Linux-x86_64.sh#38ce717758b95b3bd0b1797cc6ccfb76f29a90c25bdfa50ee45f11e583edfdbf" "anaconda" verify_py38
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda3-2020.07-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2020.07-MacOSX-x86_64.sh#3980c2a57fde5de2ccfdf0d7973f95ac1a3fa63351642e6735c50fc3791ef0f1" "anaconda" verify_py37
+  install_script "Anaconda3-2020.07-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2020.07-MacOSX-x86_64.sh#3980c2a57fde5de2ccfdf0d7973f95ac1a3fa63351642e6735c50fc3791ef0f1" "anaconda" verify_py38
   ;;
 * )
   { echo


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - None

### Description
- [x] Here are some details about my PR

Per the [release notes](https://docs.anaconda.com/anaconda/reference/release-notes/#anaconda-2020-07-july-23-2020) the installer and base environment (which I assume
we'd be verifying here, if anything) is Python 3.8.

### Tests
- [x] My PR adds the following unit tests (if any)

None