### PR TITLE
Make work in nounset (-u) mode

### DIFF
--- a/libexec/pyenv-sh-shell
+++ b/libexec/pyenv-sh-shell
@@ -49,7 +49,7 @@ if [ "$versions" = "--unset" ]; then
     echo "set -e PYENV_VERSION"
     ;;
   * )
-    echo 'PYENV_VERSION_OLD="$PYENV_VERSION"'
+    echo 'PYENV_VERSION_OLD="${PYENV_VERSION-}"'
     echo "unset PYENV_VERSION"
     ;;
   esac
@@ -110,7 +110,7 @@ if pyenv-prefix "${versions[@]}" >/dev/null; then
       echo "set -gx PYENV_VERSION \"$version\""
       ;;
     * )
-      echo 'PYENV_VERSION_OLD="$PYENV_VERSION"'
+      echo 'PYENV_VERSION_OLD="${PYENV_VERSION-}"'
       echo "export PYENV_VERSION=\"${version}\""
       ;;
     esac

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -47,7 +47,7 @@ load test_helper
   PYENV_SHELL=bash run pyenv-sh-shell --unset
   assert_success
   assert_output <<OUT
-PYENV_VERSION_OLD="\$PYENV_VERSION"
+PYENV_VERSION_OLD="\${PYENV_VERSION-}"
 unset PYENV_VERSION
 OUT
 }
@@ -75,7 +75,7 @@ SH
   PYENV_SHELL=bash run pyenv-sh-shell 1.2.3
   assert_success
   assert_output <<OUT
-PYENV_VERSION_OLD="\$PYENV_VERSION"
+PYENV_VERSION_OLD="\${PYENV_VERSION-}"
 export PYENV_VERSION="1.2.3"
 OUT
 }


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

Makes pyenv work in bash set to `nounset` (`-u`) mode. I have been using this for 9 months or so in that mode and have found no problems. Submitted to rbenv too in Apr 2020, https://github.com/rbenv/rbenv/pull/1243 

### Tests
- [ ] My PR adds the following unit tests (if any)

None, see https://github.com/rbenv/rbenv/pull/1243#issuecomment-626656010