### PR TITLE
README section on using pyenv without "pyenv init"

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,11 @@ opposed to this idea. Here's what `pyenv init` actually does:
 
 To see exactly what happens under the hood for yourself, run `pyenv init -`.
 
+If you don't want to use `pyenv init` and shims, you can still benefit
+from pyenv's ability to install Python versions for you. Just run 
+`pyenv install` and you will find versions installed in 
+`$(pyenv root)/versions`, which you can manually execute or symlink 
+as required.
 
 ### Uninstalling Python Versions
 


### PR DESCRIPTION
I find pyenv extremely useful (thanks!), but I prefer not to use any automatic path mangling. Instead
- I use pyenv to install the Python versions I need (and can't easily get from my distro)
- I manually add a symlink to different Python versions into a folder on my PATH
- I use these Python versions to create different virtualenvs

I then use `workon` from virtualenvwrapper to switch virtualenvs.

This is a simple setup that I'd like to be able to recommend to other people easily. For that reason I think it is helpful to have a note like the one I'm adding in the docs - I can then just link to that section. People who prefer not to use the shims, like me, will then be able to benefit from pyenv like I do.

Thanks for your consideration.