### PR TITLE
Fix get-pip which dropped support for legacy Python

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2099,6 +2099,12 @@ if [ -z "${GET_PIP_URL}" ]; then
     3.3 | 3.3.* )
       GET_PIP_URL="https://bootstrap.pypa.io/3.3/get-pip.py"
       ;;
+    3.4 | 3.4.* )
+      GET_PIP_URL="https://bootstrap.pypa.io/3.4/get-pip.py"
+      ;;
+    3.5 | 3.5.* )
+      GET_PIP_URL="https://bootstrap.pypa.io/3.5/get-pip.py"
+      ;;
     * )
       GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"
       ;;

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2090,6 +2090,9 @@ if [ -z "${GET_PIP_URL}" ]; then
     2.6 | 2.6.* )
       GET_PIP_URL="https://bootstrap.pypa.io/2.6/get-pip.py"
       ;;
+    2.7 | 2.7.* )
+      GET_PIP_URL="https://bootstrap.pypa.io/2.7/get-pip.py"
+      ;;
     3.2 | 3.2.* )
       GET_PIP_URL="https://bootstrap.pypa.io/3.2/get-pip.py"
       ;;


### PR DESCRIPTION
The [usage of an f-string](https://github.com/pypa/pip/blob/master/src/pip/_internal/cli/main.py#L60) in `get-pip` breaks pyenv builds of Python 2.7, 3.4, and 3.5 until this PR (or similar) is landed and released.  Fix pyenv to continue to support these legacy Python builds despite the fact that `get-pip` has dropped support for Python 2.7 as discussed in pypa/pip#9520 --> pypa/get-pip#87.

Also, fix Python 3.4 and 3.5 which also do not support f-strings.

https://bootstrap.pypa.io/

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
