### PR TITLE
rehash: try to sleep in 0.1 sec steps when acquiring lock

### DIFF
--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -45,8 +45,8 @@ for (( i=1; i<="${PYENV_REHASH_TIMEOUT:-60}"; i++ )); do
     acquired=1
     break
   else
-    # POSIX sleep(1) doesn't provides time precision of subsecond
-    sleep 1
+    # POSIX sleep(1) doesn't provide subsecond precision, but many others do
+    sleep 0.1 2>/dev/null || sleep 1
   fi
 done
 

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -40,7 +40,8 @@ if [ ! -w "$SHIM_PATH" ]; then
 fi
 
 unset acquired
-for (( i=1; i<="${PYENV_REHASH_TIMEOUT:-60}"; i++ )); do
+start=$SECONDS
+while (( SECONDS <= start + ${PYENV_REHASH_TIMEOUT:-60} )); do
   if acquire_lock 2>/dev/null; then
     acquired=1
     break


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

POSIX sleep(1) doesn't provide subsecond precision, but many others do. I looked around (Ubuntu, FreeBSD, Solaris, BusyBox) and failed to find one that actually doesn't.

Doesn't apply to rbenv, touches pyenv specific code.

Not sure if 0.1 is the amount we want by default, open to changing it.

### Tests
- [ ] My PR adds the following unit tests (if any)
N/A