### PR TITLE
Use a better PS4 as recommeneded by Bash Hackers Wiki

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -7,7 +7,8 @@ if [ "$1" = "--debug" ]; then
 fi
 
 if [ -n "$PYENV_DEBUG" ]; then
-  export PS4='+ [${BASH_SOURCE##*/}:${LINENO}] '
+  # https://wiki-dev.bash-hackers.org/scripting/debuggingtips#making_xtrace_more_useful
+  export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
   set -x
 fi
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * https://github.com/rbenv/rbenv/pull/1307
* [x] My PR addresses the following pyenv issue (if any)
  N/A

### Description
- [x] Here are some details about my PR

Current PS4 gives incomplete information, making it hard to understand what's happening while tracing Pyenv's execution.

This PR fixes that by using PS4 value recommended by the Bash Hackers Wiki: https://wiki-dev.bash-hackers.org/scripting/debuggingtips#making_xtrace_more_useful

### Tests
- [x] My PR adds the following unit tests (if any)
N/A