### PR TITLE
Create 3.10.0a5

### DIFF
--- a/plugins/python-build/share/python-build/3.10.0a5
+++ b/plugins/python-build/share/python-build/3.10.0a5
@@ -1,0 +1,10 @@
+#require_gcc
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1h" "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+    install_package "Python-3.10.0a5" "https://www.python.org/ftp/python/3.10.0/Python-3.10.0a5.tar.xz#0418e57e7036e219f1e6b6303b21e711f64cfd0fddb0894d8f19f37afffc5d4d" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+else
+    install_package "Python-3.10.0a5" "https://www.python.org/ftp/python/3.10.0/Python-3.10.0a5.tgz#5799026acafeeac9f583bfae81048e4515304ba04c46e1cc602caf0e5e67b0f7" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Added python 3.10.0a5

### Tests
- [ ] My PR adds the following unit tests (if any)
