### PR TITLE
add definition for pypy3.7 nightly binary

### DIFF
--- a/plugins/python-build/share/python-build/pypy3.7-c-jit-latest
+++ b/plugins/python-build/share/python-build/pypy3.7-c-jit-latest
@@ -1,0 +1,39 @@
+echo
+colorize 1 "WARNING"
+echo ": This may eat your kittens/ affect timespace in alternate dimensions/"
+echo "cause you to complain more. Nightly builds are meant for testing only."
+echo "Current pypy py3.7 development status:"
+echo
+echo "https://foss.heptapod.net/pypy/pypy/-/wikis/py3.7%20status"
+echo
+echo "for the latest status updates. To report bugs/regressions, please see:"
+echo
+echo "https://doc.pypy.org/en/latest/faq.html#how-should-i-report-a-bug"
+echo
+
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux" )
+  install_nightly_package "pypy-c-jit-latest-linux" "https://buildbot.pypy.org/nightly/py3.7/pypy-c-jit-latest-linux.tar.bz2" "pypy-c-jit-*-linux" "pypy" verify_py27 ensurepip
+  ;;
+"linux64" )
+  install_nightly_package "pypy3.7-c-jit-latest-linux64" "https://buildbot.pypy.org/nightly/py3.7/pypy-c-jit-latest-linux64.tar.bz2" "pypy-c-jit-*-linux64" "pypy" verify_py35 ensurepip
+  ;;
+"linux-aarch64" )
+  install_nightly_package "pypy3.7-c-jit-latest-aarch64" "https://buildbot.pypy.org/nightly/py3.7/pypy-c-jit-latest-aarch64.tar.bz2" "pypy-c-jit-*-aarch64" "pypy" verify_py35 ensurepip
+  ;;
+"osx64" )
+  install_nightly_package "pypy-c-jit-latest-osx64" "https://buildbot.pypy.org/nightly/py3.7/pypy-c-jit-latest-osx64.tar.bz2" "pypy-c-jit-*-osx64" "pypy" verify_py27 ensurepip
+  ;;
+"win32" )
+  install_zip "pypy-c-jit-latest-win32" "https://buildbot.pypy.org/nightly/py3.7/pypy-c-jit-latest-win32.zip" "pypy" verify_py27 ensurepip
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The latest nightly build of PyPy 3.7 is not available for $(pypy_architecture 2>/dev/null || true),"
+    echo "Please check https://buildbot.pypy.org/nightly/py3.7/ for previous builds."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [X] ~Please consider implementing the feature as a hook script or plugin as a first step.~
* [X] ~Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.~
* [X] ~My PR addresses the following pyenv issue (if any)~

above irrelevant as this PR simply adds to the existing version definitions

### Description
- [X] Here are some details about my PR

below, after checklists

### Tests
- [x] My PR adds the following unit tests (if any)

---

Adds build file for `pypy3.7-c-jit-latest`. see  
https://buildbot.pypy.org/nightly/py3.7/

This is based on the `pypy3.5-c-jit-latest` file, with modifications to match the architectures that are currently configured in the `pypy3.6-7.3.1` file. This build definition also uses **https** for buildbot.pypy.org URLs; existing pypy definitions were pointing to plain http: `http://buildbot.pypy.org`

I put this together as I'm running into [this error that's been noted in upstream pypy](https://foss.heptapod.net/pypy/pypy/-/issues/3314) (see also [stackoverflow thread](https://stackoverflow.com/a/66058861)), which breaks `pip` entirely when using the latest pypy3 release versions on MacOS Big Sur. (`AttributeError: No symbol SCDynamicStoreCopyProxies found in library <None>`, etc etc)

Per that [upstream pypy ticket](https://foss.heptapod.net/pypy/pypy/-/issues/3314), the fix has been merged into nightlies and is confirmed working (as of 5 days ago, Feb 6), but they have not yet pushed out a version release.

I noticed that `pyenv` didn't yet have definitions for the pypy3.7 nightlies (containing that fix), so here we are.