### PR TITLE
Remove the "Using script's directory as PYENV_DIR if shim is invoked with a script argument" feature

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -61,24 +61,6 @@ else
 fi
 export PYENV_ROOT
 
-# Transfer PYENV_FILE_ARG (from shims) into PYENV_DIR.
-if [ -z "${PYENV_DIR}" ]; then
-  if [ -n "${PYENV_FILE_ARG}" ]; then
-    if [ -L "${PYENV_FILE_ARG}" ]; then
-      PYENV_DIR="$(abs_dirname "${PYENV_FILE_ARG}")"
-    else
-      PYENV_DIR="${PYENV_FILE_ARG%/*}"
-    fi
-    export PYENV_DIR
-    unset PYENV_FILE_ARG
-  fi
-else
-  [[ $PYENV_DIR == /* ]] || PYENV_DIR="$PWD/$PYENV_DIR"
-  cd "$PYENV_DIR" 2>/dev/null || abort "cannot change working directory to \`$PYENV_DIR'"
-  PYENV_DIR="$PWD"
-  cd "$OLDPWD"
-fi
-
 if [ -z "${PYENV_DIR}" ]; then
   PYENV_DIR="$PWD"
 fi

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -73,7 +73,7 @@ if [[ "\$program" = "python"* ]]; then
     -c* | -- ) break ;;
     */* )
       if [ -f "\$arg" ]; then
-        export PYENV_FILE_ARG="\$arg"
+        export PYENV_DIR="\${arg%/*}"
         break
       fi
       ;;

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -67,19 +67,6 @@ set -e
 [ -n "\$PYENV_DEBUG" ] && set -x
 
 program="\${0##*/}"
-if [[ "\$program" = "python"* ]]; then
-  for arg; do
-    case "\$arg" in
-    -c* | -- ) break ;;
-    */* )
-      if [ -f "\$arg" ]; then
-        export PYENV_DIR="\${arg%/*}"
-        break
-      fi
-      ;;
-    esac
-  done
-fi
 
 export PYENV_ROOT="$PYENV_ROOT"
 exec "$(command -v pyenv)" exec "\$program" "\$@"

--- a/test/pyenv_ext.bats
+++ b/test/pyenv_ext.bats
@@ -12,28 +12,3 @@ load test_helper
   PYENV_VERSION="2.7.10:system" run pyenv-prefix
   assert_success "${PYENV_ROOT}/versions/2.7.10:${PYENV_TEST_DIR}"
 }
-
-@test "should use dirname of file argument as PYENV_DIR" {
-  mkdir -p "${PYENV_TEST_DIR}/dir1"
-  touch "${PYENV_TEST_DIR}/dir1/file.py"
-  PYENV_FILE_ARG="${PYENV_TEST_DIR}/dir1/file.py" run pyenv echo PYENV_DIR
-  assert_output "${PYENV_TEST_DIR}/dir1"
-}
-
-@test "should follow symlink of file argument (#379, #404)" {
-  mkdir -p "${PYENV_TEST_DIR}/dir1"
-  mkdir -p "${PYENV_TEST_DIR}/dir2"
-  touch "${PYENV_TEST_DIR}/dir1/file.py"
-  ln -s "${PYENV_TEST_DIR}/dir1/file.py" "${PYENV_TEST_DIR}/dir2/symlink.py"
-  PYENV_FILE_ARG="${PYENV_TEST_DIR}/dir2/symlink.py" run pyenv echo PYENV_DIR
-  assert_output "${PYENV_TEST_DIR}/dir1"
-}
-
-@test "should handle relative symlinks for file argument (#580)" {
-  mkdir -p "${PYENV_TEST_DIR}"
-  cd "${PYENV_TEST_DIR}"
-  touch file.py
-  ln -s file.py symlink.py
-  PYENV_FILE_ARG="symlink.py" run pyenv echo PYENV_DIR
-  assert_output "${PYENV_TEST_DIR}"
-}


### PR DESCRIPTION
### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * For Ruby and its usecases which are different than Python, the feature may be not breaking things so much. I involved the feature's author in the issue below.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/1813

### Description
- [x] Here are some details about my PR

Deletes the subj feature. This is one of the alternatives.

### Tests
- [x] My PR adds the following unit tests (if any)
 N/A