### PR TITLE
Fix not printing asterisk for current version in Bash 3

### DIFF
--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -106,7 +106,7 @@ exists() {
 print_version() {
   if [[ ${BASH_VERSINFO[0]} -ge 4 && ${current_versions["$1"]} ]]; then
     echo "${hit_prefix}$1 (set by $(pyenv-version-origin))"
-  elif (( ${BASH_VERSINFO[0]} < 3 )) && exists "$1" "${current_versions[@]}"; then
+  elif (( ${BASH_VERSINFO[0]} <= 3 )) && exists "$1" "${current_versions[@]}"; then
     echo "${hit_prefix}$1 (set by $(pyenv-version-origin))"
   else
     echo "${miss_prefix}$1"


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/1808

### Description
- [x] Here are some details about my PR

Current printing logic erroneously excluded Bash 3 when checking Bash version. OSX uses that version as of this writing.

### Tests
- [x] My PR adds the following unit tests (if any)
 N/A