### PR TITLE
Added --nosystem argument

### DIFF
--- a/libexec/pyenv-which
+++ b/libexec/pyenv-which
@@ -2,10 +2,12 @@
 #
 # Summary: Display the full path to an executable
 #
-# Usage: pyenv which <command>
+# Usage: pyenv which <command> [--nosystem]
 #
 # Displays the full path to the executable that pyenv will invoke when
 # you run the given command.
+# Use --nosystem argument in case when you don't need to search command in the 
+# system environment.
 #
 
 set -e
@@ -14,6 +16,12 @@ set -e
 # Provide pyenv completions
 if [ "$1" = "--complete" ]; then
   exec pyenv-shims --short
+fi
+
+if [ "$2" = "--nosystem" ]; then
+  system=""
+else
+  system="system"
 fi
 
 remove_from_path() {
@@ -39,7 +47,7 @@ OLDIFS="$IFS"
 IFS=: versions=(${PYENV_VERSION:-$(pyenv-version-name)})
 IFS="$OLDIFS"
 
-for version in "${versions[@]}" "system"; do
+for version in "${versions[@]}" "$system"; do
   if [ "$version" = "system" ]; then
     PATH="$(remove_from_path "${PYENV_ROOT}/shims")"
     PYENV_COMMAND_PATH="$(command -v "$PYENV_COMMAND" || true)"


### PR DESCRIPTION
Added --nosystem argument to skip the system environment when searching for an executable.

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1827

### Description
- In this [PR](https://github.com/pyenv/pyenv/pull/1797) a new feature was added : if pyenv doesn't find an executable for the current version/virtualenv, then this searches the "system" version as a fallback. But, in some use cases, it is required some mechanism for detecting if the current env provides a given executable. So, in that case, need to exclude system from search, to get relevant result - only commands, provided by pyenv.

### Tests
- No
