### PR TITLE
Hook script to add latest suffix for install command

### DIFF
--- a/pyenv.d/install/latest.bash
+++ b/pyenv.d/install/latest.bash
@@ -1,0 +1,7 @@
+DEFINITION_PREFIX="${DEFINITION%%:*}"
+DEFINITION_TYPE="${DEFINITION_PREFIX%%-*}" # TODO: support non-CPython versions
+if [[ "${DEFINITION}" != "${DEFINITION_PREFIX}" ]]; then
+  DEFINITION_CANDIDATES=($(python-build --definitions | grep -F "${DEFINITION_PREFIX}" | grep "^${DEFINITION_TYPE}" | sed -e '/-dev$/d' -e '/-src$/d' | sort -t. -k1,1r -k 2,2nr -k 3,3nr || true))
+  DEFINITION="${DEFINITION_CANDIDATES}"
+  VERSION_NAME="${DEFINITION##*/}"
+fi


### PR DESCRIPTION
The main idea of this PR is to add the ability to install the latest version of python, using such syntax:

`pyenv install 3.9:latest`
`pyenv install 3.8:latest`
`pyenv install 3:latest`
`pyenv install pypy3.7-7.3:latest`
and so on…

As for the `:` symbol, i relied on docker syntax as the most clear and used for its images versioning.

Added code from [yyuu comment](https://github.com/pyenv/pyenv/issues/602#issuecomment-219896567) as a starting point to be able to install the latest version.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1349

### Description
- [x] Despite the recommendation to implement this as a plugin, it seems to me that this functionality should be int the pyenv repo, since it is requested by many users. Also it doesn't change the main logic of pyenv, nor other users workflows.

### Tests
- No tests.
