### PR TITLE
Fix error link

### DIFF
--- a/plugins/python-build/share/python-build/miniconda3-3.7-4.9.2
+++ b/plugins/python-build/share/python-build/miniconda3-3.7-4.9.2
@@ -6,7 +6,7 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
   install_script "Miniconda3-py37_4.9.2-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-x86_64.sh#3143b1116f2d466d9325c206b7de88f7" "miniconda" verify_py37
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-py37_4.9.2-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-MacOSX-x86_64.sh#cfe1b551b169d6386f5f4b7df40cdac4" "miniconda" verify_py37
+  install_script "Miniconda3-py37_4.9.2-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-MacOSX-x86_64.sh#cfe1b551b169d6386f5f4b7df40cdac4" "miniconda" verify_py37
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-3.8-4.9.2
+++ b/plugins/python-build/share/python-build/miniconda3-3.8-4.9.2
@@ -6,7 +6,7 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
   install_script "Miniconda3-py38_4.9.2-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh#122c8c9beb51e124ab32a0fa6426c656" "miniconda" verify_py38
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-py38_4.9.2-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.8.3-MacOSX-x86_64.sh#cb40e2c1a32dccd6cdd8d5e49977a635" "miniconda" verify_py38
+  install_script "Miniconda3-py38_4.9.2-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-MacOSX-x86_64.sh#cb40e2c1a32dccd6cdd8d5e49977a635" "miniconda" verify_py38
   ;;
 * )
   { echo


### PR DESCRIPTION
### Description
- [X] Fix error link for Miniconda3-py37_4.9.2-MacOSX-x86_64
- [X] Fix error link for Miniconda3-py38_4.9.2-MacOSX-x86_64

The link is incorrect but the hash is correct therefore cause checksum mismatched and unable to install these 2 versions.