### PR TITLE
Update miniforge3-4.9.2

### DIFF
--- a/plugins/python-build/share/python-build/miniforge3-4.9.2
+++ b/plugins/python-build/share/python-build/miniforge3-4.9.2
@@ -1,15 +1,18 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-ppc64le" )
-  install_script "Miniforge3-4.9.2-5-Linux-ppc64le" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-Linux-ppc64le.sh#825b3e5f39f0bdb825323ea23af24ba4" "miniconda" verify_py38
+  install_script "Miniforge3-4.9.2-7-Linux-ppc64le" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-7/Miniforge3-4.9.2-7-Linux-ppc64le.sh#fb18f348f35328aff5dd7edbd83ea2e2" "miniconda" verify_py38
   ;;
 "Linux-x86_64" )
-  install_script "Miniforge3-4.9.2-5-Linux-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-Linux-x86_64.sh#73ea193f82d8f3b558b9c2186a147bcf" "miniconda" verify_py38
+  install_script "Miniforge3-4.9.2-7-Linux-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-7/Miniforge3-4.9.2-7-Linux-x86_64.sh#d96baf1a0559a1f642528c0e38aad984" "miniconda" verify_py38
+  ;;
+"Linux-aarch64" )
+  install_script "Miniforge3-4.9.2-7-Linux-aarch64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-7/Miniforge3-4.9.2-7-Linux-aarch64.sh#c5bceb970dcff512f35f444397b5ce11" "miniconda" verify_py38
   ;;
 "MacOSX-arm64" )
-  install_script "Miniforge3-4.9.2-5-MacOSX-arm64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-MacOSX-arm64.sh#cf309b725c8a0b4448e4ee922703bf00" "miniconda" verify_py39
+  install_script "Miniforge3-4.9.2-7-MacOSX-arm64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-7/Miniforge3-4.9.2-7-MacOSX-arm64.sh#cca7e2cbbf5734eda475a72e81fe8031" "miniconda" verify_py39
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniforge3-4.9.2-5-MacOSX-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-MacOSX-x86_64.sh#e66d62e8872bc1548af54063cab7b72e" "miniconda" verify_py38
+  install_script "Miniforge3-4.9.2-7-MacOSX-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.9.2-7/Miniforge3-4.9.2-7-MacOSX-x86_64.sh#f270b7bfd721899cb175c10f0b6cfa01" "miniconda" verify_py38
   ;;
 * )
   { echo


### PR DESCRIPTION
Update miniforge3-4.9.2 to the latest patch.

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.

### Description
- 

### Tests
-
