### PR TITLE
GitHub Actions: Add $PYENV_ROOT/shims to $PATH

### DIFF
--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -20,16 +20,13 @@ jobs:
               xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
       # https://github.com/pyenv/pyenv#installation
       - run: pwd
-      - env:
-          PYENV_ROOT: /home/runner/work/pyenv/pyenv
-        run: |
-          echo $PYENV_ROOT
-          echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
-          echo $GITHUB_PATH
-          bin/pyenv install ${{ matrix.python-version }}
-          bin/pyenv global ${{ matrix.python-version }}
-          bin/pyenv rehash
-          python --version
-          python -m pip --version
+      #- env:
+      #    PYENV_ROOT: /home/runner/work/pyenv/pyenv
+      #  run: |
+      #    echo $PYENV_ROOT
+      - run: PYENV_ROOT=$(pwd) echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
+      - run: bin/pyenv install ${{ matrix.python-version }}
+      - run: bin/pyenv global ${{ matrix.python-version }}
+      - run: bin/pyenv rehash
       - run: python --version
       - run: python -m pip --version

--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -24,7 +24,7 @@ jobs:
           PYENV_ROOT: /home/runner/work/pyenv/pyenv
         run: |
           echo $PYENV_ROOT
-          echo "$HOME/bin" >> $GITHUB_PATH
+          echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
           bin/pyenv install ${{ matrix.python-version }}
           bin/pyenv global ${{ matrix.python-version }}
           bin/pyenv rehash

--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -20,12 +20,11 @@ jobs:
               xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
       # https://github.com/pyenv/pyenv#installation
       - run: pwd
-      #- env:
-      #    PYENV_ROOT: /home/runner/work/pyenv/pyenv
-      #  run: |
-      #    echo $PYENV_ROOT
-      #    echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
-      - run: PYENV_ROOT=$(pwd) echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
+      - env:
+          PYENV_ROOT: /home/runner/work/pyenv/pyenv
+        run: |
+          echo $PYENV_ROOT
+          echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
       - run: |
           bin/pyenv install ${{ matrix.python-version }}
           bin/pyenv global ${{ matrix.python-version }}

--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -20,11 +20,11 @@ jobs:
               xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
       # https://github.com/pyenv/pyenv#installation
       - run: pwd
-      #- env:
-      #    PYENV_ROOT: /home/runner/work/pyenv/pyenv
-      #  run: |
-      #    echo $PYENV_ROOT
-      - run: PYENV_ROOT=$(pwd) echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
+      - env:
+          PYENV_ROOT: /home/runner/work/pyenv/pyenv
+        run: |
+          echo $PYENV_ROOT
+          echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
       - run: bin/pyenv install ${{ matrix.python-version }}
       - run: bin/pyenv global ${{ matrix.python-version }}
       - run: bin/pyenv rehash

--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -19,39 +19,7 @@ jobs:
               libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
               xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
       # https://github.com/pyenv/pyenv#installation
-      - run: pwdname: ubuntu_tests
-on: [pull_request, push]
-jobs:
-  ubuntu_tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [2.7.18, 3.5.10, 3.6.13, 3.7.10, 3.8.8, 3.9.2]  # 2.7.6, 3.4.10, 
-    runs-on: Ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      # Normally, we would use the superbly maintained...
-      # - uses: actions/setup-python@v2
-      #   with:
-      #    python-version: ${{ matrix.python-version }}
-      # ... but in the repo, we want to test pyenv builds on Ubuntu
-      - run: |
-          sudo apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
-              libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-              xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
-      # https://github.com/pyenv/pyenv#installation
       - run: pwd
-      - env:
-          PYENV_ROOT: /home/runner/work/pyenv/pyenv
-        run: |
-          echo $PYENV_ROOT
-          echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
-          bin/pyenv install ${{ matrix.python-version }}
-          bin/pyenv global ${{ matrix.python-version }}
-          bin/pyenv rehash
-      - run: python --version
-      - run: python -m pip --version
-
       - env:
           PYENV_ROOT: /home/runner/work/pyenv/pyenv
         run: |

--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -25,8 +25,11 @@ jobs:
         run: |
           echo $PYENV_ROOT
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
+          echo $GITHUB_PATH
           bin/pyenv install ${{ matrix.python-version }}
           bin/pyenv global ${{ matrix.python-version }}
           bin/pyenv rehash
           python --version
           python -m pip --version
+      - run: python --version
+      - run: python -m pip --version

--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -30,3 +30,7 @@ jobs:
           bin/pyenv rehash
       - run: python --version
       - run: python -m pip --version
+      - shell: python  # Prove that actual Python == expected Python
+        env:
+          EXPECTED_PYTHON: ${{ matrix.python-version }}
+        run: import os, sys ; assert sys.version.startswith(os.getenv("EXPECTED_PYTHON"))

--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -20,13 +20,15 @@ jobs:
               xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
       # https://github.com/pyenv/pyenv#installation
       - run: pwd
-      - env:
-          PYENV_ROOT: /home/runner/work/pyenv/pyenv
-        run: |
-          echo $PYENV_ROOT
-          echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
-      - run: bin/pyenv install ${{ matrix.python-version }}
-      - run: bin/pyenv global ${{ matrix.python-version }}
-      - run: bin/pyenv rehash
+      #- env:
+      #    PYENV_ROOT: /home/runner/work/pyenv/pyenv
+      #  run: |
+      #    echo $PYENV_ROOT
+      #    echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
+      - run: PYENV_ROOT=$(pwd) echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
+      - run: |
+          bin/pyenv install ${{ matrix.python-version }}
+          bin/pyenv global ${{ matrix.python-version }}
+          bin/pyenv rehash
       - run: python --version
       - run: python -m pip --version

--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -25,7 +25,6 @@ jobs:
         run: |
           echo $PYENV_ROOT
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
-      - run: |
           bin/pyenv install ${{ matrix.python-version }}
           bin/pyenv global ${{ matrix.python-version }}
           bin/pyenv rehash

--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -19,7 +19,39 @@ jobs:
               libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
               xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
       # https://github.com/pyenv/pyenv#installation
+      - run: pwdname: ubuntu_tests
+on: [pull_request, push]
+jobs:
+  ubuntu_tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [2.7.18, 3.5.10, 3.6.13, 3.7.10, 3.8.8, 3.9.2]  # 2.7.6, 3.4.10, 
+    runs-on: Ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      # Normally, we would use the superbly maintained...
+      # - uses: actions/setup-python@v2
+      #   with:
+      #    python-version: ${{ matrix.python-version }}
+      # ... but in the repo, we want to test pyenv builds on Ubuntu
+      - run: |
+          sudo apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
+              libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+              xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
+      # https://github.com/pyenv/pyenv#installation
       - run: pwd
+      - env:
+          PYENV_ROOT: /home/runner/work/pyenv/pyenv
+        run: |
+          echo $PYENV_ROOT
+          echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
+          bin/pyenv install ${{ matrix.python-version }}
+          bin/pyenv global ${{ matrix.python-version }}
+          bin/pyenv rehash
+      - run: python --version
+      - run: python -m pip --version
+
       - env:
           PYENV_ROOT: /home/runner/work/pyenv/pyenv
         run: |


### PR DESCRIPTION
Make sure you have checked all steps below.

```python
import os
import sys

EXPECTED_PYTHON = ${{ matrix.python-version }}
# Ensure that the actual Python is the expected Python.
assert sys.version.startswith(os.getenv("EXPECTED_PYTHON"))
```

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR
The goal of this PR was to ensure that `python` and `pip` are pointing to the pyenv installed versions.  That goal has been achieved in the current code.  Sorry for all the tweaking but the GitHub Actions code is touchy.  

### Tests
- [x] My PR adds the following unit tests (if any)
