### PR TITLE
test(init): remove misleading detect from parent shell case arg

### DIFF
--- a/test/init.bats
+++ b/test/init.bats
@@ -39,7 +39,7 @@ eval "\$(pyenv-init -)"
 echo \$PYENV_SHELL
 OUT
   chmod +x myscript.sh
-  run ./myscript.sh /bin/zsh
+  run ./myscript.sh
   assert_success "sh"
 }
 


### PR DESCRIPTION

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

The generated script does not take/use any arguments, so passing
/bin/zsh to it serves only to cause confusion.

rbenv PR: https://github.com/rbenv/rbenv/pull/1320

### Tests
- [ ] My PR adds the following unit tests (if any)
