### PR TITLE
bpo-43631: update to openssl 1.1.1k

### DIFF
--- a/plugins/python-build/share/python-build/3.8.9
+++ b/plugins/python-build/share/python-build/3.8.9
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.1j" "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.8.9" "https://www.python.org/ftp/python/3.8.9/Python-3.8.9.tar.xz#5e391f3ec45da2954419cab0beaefd8be38895ea5ce33577c3ec14940c4b9572" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.9.3
+++ b/plugins/python-build/share/python-build/3.9.3
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.1j" "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.9.3" "https://www.python.org/ftp/python/3.9.3/Python-3.9.3.tar.xz#30811039c65e04c14fc698e423947e464f9316e69fb44610bd38446046bb82b5" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

According to the [Python 3.9.3 release notes](https://www.python.org/downloads/release/python-393/) and [bpo-43461](https://bugs.python.org/issue43631), several high CVE vulnerabilities were fixed in OpenSSL 1.1.1k, so this updates pyenv to pull the recommended library version.

### Tests
- [x] My PR adds the following unit tests (if any)
