### PR TITLE
New version 1.2.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Version History
 
+## 1.2.25
+
+* bpo-43631: update to openssl 1.1.1k (#1861)
+* Add CPython 3.9.3 and 3.8.9 (#1859)
+* Add micropython 1.14 (#1858)
+* Shell detect improvements (#1835)
+* Test(init): remove misleading detect from parent shell case arg (#1856)
+* Add GraalPython 21.0.0 (#1855)
+
 ## 1.2.24
 
 * GitHub Actions: Add $PYENV_ROOT/shims to $PATH (#1838)

--- a/libexec/pyenv---version
+++ b/libexec/pyenv---version
@@ -12,7 +12,7 @@
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
-version="1.2.24"
+version="1.2.25"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q pyenv; then


### PR DESCRIPTION
* bpo-43631: update to openssl 1.1.1k (#1861)
* Add CPython 3.9.3 and 3.8.9 (#1859)
* Add micropython 1.14 (#1858)
* Shell detect improvements (#1835)
* Test(init): remove misleading detect from parent shell case arg (#1856)
* Add GraalPython 21.0.0 (#1855)