### PR TITLE
add CPython 3.9.4

### DIFF
--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7.18, 3.5.10, 3.6.13, 3.7.10, 3.8.9, 3.9.3]  # 2.7.6, 3.4.10, 
+        python-version: [2.7.18, 3.5.10, 3.6.13, 3.7.10, 3.8.9, 3.9.4]  # 2.7.6, 3.4.10, 
     runs-on: Ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/plugins/python-build/share/python-build/3.9.4
+++ b/plugins/python-build/share/python-build/3.9.4
@@ -1,0 +1,10 @@
+#require_gcc
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+    install_package "Python-3.9.4" "https://www.python.org/ftp/python/3.9.4/Python-3.9.4.tar.xz#4b0e6644a76f8df864ae24ac500a51bbf68bd098f6a173e27d3b61cdca9aa134" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+else
+    install_package "Python-3.9.4" "https://www.python.org/ftp/python/3.9.4/Python-3.9.4.tgz#66c4de16daa74a825cf9da9ddae1fe020b72c3854b73b1762011cc33f9e4592f" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A
  - 
### Description
- [x] Here are some details about my PR

Adds CPython 3.9.4 hotfix.

See: https://www.python.org/downloads/release/python-394/

### Tests
- [x] My PR adds the following unit tests (if any)
