### PR TITLE
feat: support (skip) commented lines in version-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ executable path to each of these using `pyenv which`, e.g. `pyenv which python2.
 (should display `$(pyenv root)/versions/2.5/bin/python2.5`), or `pyenv which
 python3.4` (should display path to system Python3). You can also specify multiple
 versions in a `.python-version` file, separated by newlines or any whitespace.
+Lines starting with a `#` are ignored.
 
 ### Locating the Python Installation
 

--- a/libexec/pyenv-version-file-read
+++ b/libexec/pyenv-version-file-read
@@ -9,7 +9,7 @@ if [ -e "$VERSION_FILE" ]; then
   # Read the first non-whitespace word from the specified version file.
   # Be careful not to load it whole in case there's something crazy in it.
   IFS="${IFS}"$'\r'
-  words=($(cut -b 1-1024 "$VERSION_FILE" | sed 's/[[:space:]]*\([^[:space:]^[:space:]]*\).*/\1/'))
+  words=($(cut -b 1-1024 "$VERSION_FILE" | sed -n 's/^[[:space:]]*\([^[:space:]#][^[:space:]]*\).*/\1/p'))
   versions=("${words[@]}")
 
   if [ -n "$versions" ]; then

--- a/test/version-file-read.bats
+++ b/test/version-file-read.bats
@@ -70,3 +70,15 @@ IN
   run pyenv-version-file-read my-version
   assert_success "3.3.5"
 }
+
+@test "skips comment lines" {
+  cat > my-version <<IN
+3.9.3
+3.8.9
+  # 3.4.0
+#3.3.7
+2.7.16
+IN
+  run pyenv-version-file-read my-version
+  assert_success "3.9.3:3.8.9:2.7.16"
+}


### PR DESCRIPTION

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

Sometimes it is convenient to be able to temporarily disable something
in a version-file. Because these files often aren't necessarily tracked
in a SCM, especially when working with virtualenvs, the SCM diffs won't
help with showing removed lines which are currently the only way to
disable something.

Not applicable as a plugin.

Not submitted/applicable to rbenv, because they don't support multiple envs in the first place.

### Tests
- [x] My PR adds the following unit tests (if any)

test/version-file-read.bats, "skips comment lines"