### PR TITLE
docs(README): fix info about version-file separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ global system 3.3.6 3.2 2.5`. At this point, one should be able to find the full
 executable path to each of these using `pyenv which`, e.g. `pyenv which python2.5`
 (should display `$(pyenv root)/versions/2.5/bin/python2.5`), or `pyenv which
 python3.4` (should display path to system Python3). You can also specify multiple
-versions in a `.python-version` file, separated by newlines or any whitespace.
+versions in a `.python-version` file, separated by newlines.
 Lines starting with a `#` are ignored.
 
 ### Locating the Python Installation


### PR DESCRIPTION

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

Any whitespace doesn't work, need version per line.

### Tests
- [ ] My PR adds the following unit tests (if any)
