### PR TITLE
Make pyenv path tolerant to brew upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,25 +13,26 @@
 language: c
 
 os:
-- linux
-- osx
+  - linux
+  - osx
 
 dist:
-- focal
+  - focal
 
 # https://docs.travis-ci.com/user/reference/osx/#macos-version
 osx_image:
-- xcode9.4.1  # macOS 10.13.6
-- xcode10.3   # macOS 10.14.4
-- xcode11.6   # macOS 10.15.7
-- xcode12.2   # macOS 10.15.7
+  - xcode9.4.1 # macOS 10.13.6
+  - xcode10.3 # macOS 10.14.4
+  - xcode11.6 # macOS 10.15.7
+  - xcode12.2 # macOS 10.15.7
 
 env:
-- PYTHON_BUILD_VERSION=3.9.1
-- PYTHON_BUILD_VERSION=3.7.5
+  - PYTHON_BUILD_VERSION=3.9.1
+  - PYTHON_BUILD_VERSION=3.7.5
+  - PYENV_DEBUG=true
 
 before_install:
-- date +%Y-%m-%dT%H:%M:%S
+  - date +%Y-%m-%dT%H:%M:%S
 
 install: git clone --depth 1 --branch v1.2.0 https://github.com/bats-core/bats-core.git bats
 
@@ -40,35 +41,35 @@ script: make test-build
 
 jobs:
   include:
-  # Shell-based tests should execute every time.
-  - stage: test shell
-    script: make test
-    env: PYENV_NATIVE_EXT=1
-    after_script: []
-    os: linux
-  - stage: test shell
-    script: make test
-    env: PYENV_NATIVE_EXT=
-    after_script: []
-    os: linux
+    # Shell-based tests should execute every time.
+    - stage: test shell
+      script: make test
+      env: PYENV_NATIVE_EXT=1
+      after_script: []
+      os: linux
+    - stage: test shell
+      script: make test
+      env: PYENV_NATIVE_EXT=
+      after_script: []
+      os: linux
 
   exclude:
-  # For each osx_image but one there should be an entry in the exclude
-  # list, to prevent duplicate Linux builds.
-  - os: linux
-    osx_image: xcode9.4
-  - os: linux
-    osx_image: xcode10
+    # For each osx_image but one there should be an entry in the exclude
+    # list, to prevent duplicate Linux builds.
+    - os: linux
+      osx_image: xcode9.4
+    - os: linux
+      osx_image: xcode10
 
   allow_failures:
-  - env: PYTHON_BUILD_VERSION=3.9.1
+    - env: PYTHON_BUILD_VERSION=3.9.1
 
 stages:
-- test shell
-- name: test
-  if: NOT (commit_message =~ /^\[skip build\]/)
+  - test shell
+  - name: test
+    if: NOT (commit_message =~ /^\[skip build\]/)
 
-# Default 
+# Default
 
 notifications:
   email:

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -62,6 +62,15 @@ fi
 # technique is fast, uses less disk space than unique files, and also
 # serves as a locking mechanism.
 create_prototype_shim() {
+  local pyenv_path brew_prefix
+  pyenv_path="$(command -v pyenv)"
+  brew_prefix="$(brew --prefix 2>/dev/null)"
+  if [ $? -eq 0 ]; then
+    case "$pyenv_path" in "${brew_prefix}/Cellar"*)
+      pyenv_path="${brew_prefix}/opt/pyenv/bin/pyenv"
+      ;;
+    esac
+  fi
   cat > "$PROTOTYPE_SHIM_PATH" <<SH
 #!/usr/bin/env bash
 set -e
@@ -70,7 +79,7 @@ set -e
 program="\${0##*/}"
 
 export PYENV_ROOT="$PYENV_ROOT"
-exec "$(command -v pyenv)" exec "\$program" "\$@"
+exec "$pyenv_path" exec "\$program" "\$@"
 SH
   chmod +x "$PROTOTYPE_SHIM_PATH"
 }

--- a/pyenv.d/rehash/source.bash
+++ b/pyenv.d/rehash/source.bash
@@ -10,10 +10,19 @@ done
 shopt -u nullglob
 eval "source_shim(){ case \"\${1##*/}\" in ${shims[@]} *)return 1;;esac;}"
 
+pyenv_path="$(command -v pyenv)"
+brew_prefix="$(brew --prefix 2>/dev/null)"
+if [ $? -eq 0 ]; then
+  case "$pyenv_path" in "${brew_prefix}/Cellar"*)
+    pyenv_path="${brew_prefix}/opt/pyenv/bin/pyenv"
+    ;;
+  esac
+fi
+
 cat > "${PROTOTYPE_SOURCE_SHIM_PATH}" <<SH
 [ -n "\$PYENV_DEBUG" ] && set -x
 export PYENV_ROOT="${PYENV_ROOT}"
-program="\$("$(command -v pyenv)" which "\${BASH_SOURCE##*/}")"
+program="\$("$pyenv_path" which "\${BASH_SOURCE##*/}")"
 if [ -e "\${program}" ]; then
   . "\${program}" "\$@"
 fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Fixes #1716

### Description

This changes the pyenv path used in the shim from `$(brew --prefix)/Cellar/pyenv/1.2.26/libexec/pyenv` to `$(brew --prefix)/opt/pyenv/bin/pyenv` which will not break when the version number changes.

### Tests

None but maybe it should?