### PR TITLE
Add CPython 3.8.10

### DIFF
--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7.18, 3.5.10, 3.6.13, 3.7.10, 3.8.9, 3.9.4, 3.10.0b1]  # 2.7.6, 3.4.10, 
+        python-version: [2.7.18, 3.5.10, 3.6.13, 3.7.10, 3.8.10, 3.9.4, 3.10.0b1]  # 2.7.6, 3.4.10, 
     runs-on: Ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/plugins/python-build/share/python-build/3.8.10
+++ b/plugins/python-build/share/python-build/3.8.10
@@ -1,0 +1,10 @@
+#require_gcc
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tar.xz#6af24a66093dd840bcccf371d4044a3027e655cf24591ce26e48022bc79219d9" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+else
+  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz#b37ac74d2cbad2590e7cd0dd2b3826c29afe89a734090a87bf8c03c45066cb65" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description

This adds CPython 3.8.10

### Tests
- [ ] My PR adds the following unit tests (if any)
