### PR TITLE
Update CPython 3.10-dev and 3.11-dev

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1748,6 +1748,11 @@ build_package_verify_py310() {
   build_package_verify_py39 "$1" "${2:-3.10}"
 }
 
+# Post-install check for Python 3.11.x
+build_package_verify_py311() {
+  build_package_verify_py310 "$1" "${2:-3.11}"
+}
+
 # Copy Tools/gdb/libpython.py to pythonX.Y-gdb.py (#1190)
 build_package_copy_python_gdb() {
   if [ -e "$BUILD_PATH/$1/Tools/gdb/libpython.py" ]; then

--- a/plugins/python-build/share/python-build/3.11-dev
+++ b/plugins/python-build/share/python-build/3.11-dev
@@ -3,4 +3,4 @@ prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_git "Python-3.10-dev" "https://github.com/python/cpython" 3.10 standard verify_py310 copy_python_gdb ensurepip
+install_git "Python-3.11-dev" "https://github.com/python/cpython" main standard verify_py311 copy_python_gdb ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/XXXX

### Description

I believe there's been an error with how 3.10-dev was defined in this PR: https://github.com/pyenv/pyenv/pull/1896

There was recently a change where the master branch was renamed into main, but there was also a 3.10 branch created. It is my understanding that pyenv's `3.10-dev` version should be taken from this new `3.10` branch and that pyenv's `3.11-dev` version should be taken from the `main` branch.

### Tests
- [ ] My PR adds the following unit tests (if any)
