### PR TITLE
Split startup logic into PATH and everything else

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,28 +208,18 @@ easy to fork and contribute any changes back upstream.
    pyenv repo is cloned and add `$PYENV_ROOT/bin` to your `$PATH` for access
    to the `pyenv` command-line utility.
 
-   - For **bash**:
+   - For **bash**/**Zsh**:
      ~~~ bash
-     echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
-     echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
-     ~~~
-
-   - For **Ubuntu Desktop**:
-     ~~~ bash
-     echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
-     echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-     ~~~
-
-   - For **Zsh**:
-     ~~~ zsh
-     echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
-     echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
+     echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.profile
+     echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.profile
+     echo 'eval "$(pyenv init --path)"' >> ~/.profile
      ~~~
 
    - For **Fish shell**:
      ~~~ fish
      set -Ux PYENV_ROOT $HOME/.pyenv
      set -Ux fish_user_paths $PYENV_ROOT/bin $fish_user_paths
+     pyenv init --path | source
      ~~~
 
    - **Proxy note**: If you use a proxy, export `http_proxy` and `https_proxy` too.
@@ -239,11 +229,6 @@ easy to fork and contribute any changes back upstream.
    configuration file since it manipulates `PATH` during the initialization.
 
    - For **bash**:
-     ~~~ bash
-     echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
-     ~~~
-
-   - For **Ubuntu Desktop** and **Fedora**:
      ~~~ bash
      echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
      ~~~

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -43,7 +43,29 @@ fi
 
 root="${0%/*}/.."
 
-if [ -z "$print" ]; then
+function main() {
+  case "$mode" in
+  "help")
+    help_
+    exit 1
+    ;;
+  "path")
+    print_path
+    exit 0
+    ;;
+  "print")
+    init_dirs
+    print_env
+    print_completion
+    print_shell_function
+    exit 0
+    ;;
+  esac
+  # should never get here
+  exit 2
+}
+
+function help_() {
   case "$shell" in
   bash )
     if [ -f "${HOME}/.bashrc" ] && [ ! -f "${HOME}/.bash_profile" ]; then
@@ -79,36 +101,41 @@ if [ -z "$print" ]; then
     esac
     echo
   } >&2
+}
 
-  exit 1
-fi
+function init_dirs() {
+  mkdir -p "${PYENV_ROOT}/"{shims,versions}
+}
 
-mkdir -p "${PYENV_ROOT}/"{shims,versions}
+function print_env() {
+  case "$shell" in
+  fish )
+    echo "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
+    echo "set -gx PYENV_SHELL $shell"
+    ;;
+  * )
+    echo 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
+    echo "export PYENV_SHELL=$shell"
+    ;;
+  esac
+}
 
-case "$shell" in
-fish )
-  echo "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
-  echo "set -gx PYENV_SHELL $shell"
-;;
-* )
-  echo 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
-  echo "export PYENV_SHELL=$shell"
-;;
-esac
+function print_completion() {
+  completion="${root}/completions/pyenv.${shell}"
+  if [ -r "$completion" ]; then
+    echo "source '$completion'"
+  fi
 
-completion="${root}/completions/pyenv.${shell}"
-if [ -r "$completion" ]; then
-  echo "source '$completion'"
-fi
+  if [ -z "$no_rehash" ]; then
+    echo 'command pyenv rehash 2>/dev/null'
+  fi
+}
 
-if [ -z "$no_rehash" ]; then
-  echo 'command pyenv rehash 2>/dev/null'
-fi
-
-commands=(`pyenv-commands --sh`)
-case "$shell" in
-fish )
-  cat <<EOS
+function print_shell_function() {
+  commands=(`pyenv-commands --sh`)
+  case "$shell" in
+  fish )
+    cat <<EOS
 function pyenv
   set command \$argv[1]
   set -e argv[1]
@@ -121,24 +148,24 @@ function pyenv
   end
 end
 EOS
-  ;;
-ksh )
-  cat <<EOS
+    ;;
+  ksh )
+    cat <<EOS
 function pyenv {
   typeset command
 EOS
-  ;;
-* )
-  cat <<EOS
+    ;;
+  * )
+    cat <<EOS
 pyenv() {
   local command
 EOS
-  ;;
-esac
+    ;;
+  esac
 
-if [ "$shell" != "fish" ]; then
-IFS="|"
-cat <<EOS
+  if [ "$shell" != "fish" ]; then
+    IFS="|"
+    cat <<EOS
   command="\${1:-}"
   if [ "\$#" -gt 0 ]; then
     shift
@@ -146,10 +173,15 @@ cat <<EOS
 
   case "\$command" in
   ${commands[*]})
-    eval "\$(pyenv "sh-\$command" "\$@")";;
+    eval "\$(pyenv "sh-\$command" "\$@")"
+    ;;
   *)
-    command pyenv "\$command" "\$@";;
+    command pyenv "\$command" "\$@"
+    ;;
   esac
 }
 EOS
-fi
+  fi
+}
+
+main

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -114,6 +114,9 @@ function help_() {
       ;;
     esac
     echo
+    echo '# Make sure to restart your entire logon session'
+    echo '# for changes to ~/.profile to take effect.'
+    echo
   } >&2
 }
 

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -61,6 +61,7 @@ function main() {
     ;;
   "print")
     init_dirs
+    warn_path
     print_env
     print_completion
     print_shell_function
@@ -130,6 +131,13 @@ function print_path() {
       echo 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
       ;;
   esac
+}
+
+function warn_path() {
+  if ! perl -ls0x3A -e 'while (<>) { chomp; ($_ eq $d) && exit 0; } exit 1' -- -d="${PYENV_ROOT}/shims" <<<"$PATH" ; then
+    echo 'echo '\''WARNING: `pyenv init -` no longer sets PATH.'\'
+    echo 'echo '\''Run `pyenv init` to see the necessary changes to make to your configuration.'\'
+  fi
 }
 
 function print_env() {

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Summary: Configure the shell environment for pyenv
-# Usage: eval "$(pyenv init - [--no-rehash] [<shell>])"
+# Usage: eval "$(pyenv init [-|--path] [--no-rehash] [<shell>])"
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
@@ -8,6 +8,7 @@ set -e
 # Provide pyenv completions
 if [ "$1" = "--complete" ]; then
   echo -
+  echo --path
   echo --no-rehash
   echo bash
   echo fish
@@ -16,15 +17,20 @@ if [ "$1" = "--complete" ]; then
   exit
 fi
 
-print=""
+mode="help"
 no_rehash=""
 for args in "$@"
 do
   if [ "$args" = "-" ]; then
-    print=1
+    mode="print"
     shift
   fi
 
+  if [ "$args" = "--path" ]; then
+    mode="path"
+    shift
+  fi
+  
   if [ "$args" = "--no-rehash" ]; then
     no_rehash=1
     shift
@@ -68,11 +74,7 @@ function main() {
 function help_() {
   case "$shell" in
   bash )
-    if [ -f "${HOME}/.bashrc" ] && [ ! -f "${HOME}/.bash_profile" ]; then
-      profile='~/.bashrc'
-    else
-      profile='~/.bash_profile'
-    fi
+    profile='~/.bashrc'
     ;;
   zsh )
     profile='~/.zshrc'
@@ -100,6 +102,17 @@ function help_() {
       ;;
     esac
     echo
+    echo "# And the following to ~/.profile:"
+    echo
+    case "$shell" in
+    fish )
+      echo 'pyenv init --path | source'
+      ;;
+    * )
+      echo 'eval "$(pyenv init --path)"'
+      ;;
+    esac
+    echo
   } >&2
 }
 
@@ -107,14 +120,24 @@ function init_dirs() {
   mkdir -p "${PYENV_ROOT}/"{shims,versions}
 }
 
+function print_path() {
+  # Need to use the login shell rather than the current one
+  case "$shell" in
+    fish )
+      echo "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
+      ;;
+    * )
+      echo 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
+      ;;
+  esac
+}
+
 function print_env() {
   case "$shell" in
   fish )
-    echo "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
     echo "set -gx PYENV_SHELL $shell"
     ;;
   * )
-    echo 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
     echo "export PYENV_SHELL=$shell"
     ;;
   esac

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -90,7 +90,7 @@ OUT
   assert_success "${system_python}"
 }
 
-@test '$PATH is not modified with system Python' {
+@test 'PATH is not modified with system Python' {
   # Create a wrapper executable that verifies PATH.
   PYENV_VERSION="custom"
   create_executable "python" '[[ "$PATH" == "${PYENV_TEST_DIR}/root/versions/custom/bin:"* ]] || { echo "unexpected:$PATH"; exit 2;}'

--- a/test/init.bats
+++ b/test/init.bats
@@ -64,28 +64,28 @@ OUT
 
 @test "adds shims to PATH" {
   export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
-  run pyenv-init - bash
+  run pyenv-init --path bash
   assert_success
   assert_line 0 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
 }
 
 @test "adds shims to PATH (fish)" {
   export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
-  run pyenv-init - fish
+  run pyenv-init --path fish
   assert_success
   assert_line 0 "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
 }
 
 @test "can add shims to PATH more than once" {
   export PATH="${PYENV_ROOT}/shims:$PATH"
-  run pyenv-init - bash
+  run pyenv-init --path bash
   assert_success
   assert_line 0 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
 }
 
 @test "can add shims to PATH more than once (fish)" {
   export PATH="${PYENV_ROOT}/shims:$PATH"
-  run pyenv-init - fish
+  run pyenv-init --path fish
   assert_success
   assert_line 0 "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
 }

--- a/test/init.bats
+++ b/test/init.bats
@@ -90,6 +90,13 @@ OUT
   assert_line 0 "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
 }
 
+@test "prints a warning if shims not in PATH" {
+  export PATH="$(perl -0x3A -ls -e 'while (<>) { chomp; ($_ ne $d) && print; }' -- -d="${PYENV_ROOT}/shims" <<<"$PATH")"
+  run pyenv-init -
+  assert_success
+  assert_line 0 'echo '\''WARNING: `pyenv init -` no longer sets PATH.'\'
+}
+
 @test "outputs sh-compatible syntax" {
   run pyenv-init - bash
   assert_success


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/1649

### Description
- [x] Here are some details about my PR

* Implements https://github.com/pyenv/pyenv/issues/1649#issuecomment-694388530 .
* Adds a warning on shell startup if ~./profile` entry is not present -- to facilitate migration
* (unrelated) fixes expanding `PATH` in one of test descriptions

### Tests
- [x] My PR adds the following unit tests (if any)

* Test for the added warning