### PR TITLE
Bump OpenSSL to 1.1.1x for all Pythons that support MacOS 11

### DIFF
--- a/plugins/python-build/share/python-build/3.10-dev
+++ b/plugins/python-build/share/python-build/3.10-dev
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_git "Python-3.10-dev" "https://github.com/python/cpython" 3.10 standard verify_py310 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.11-dev
+++ b/plugins/python-build/share/python-build/3.11-dev
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_git "Python-3.11-dev" "https://github.com/python/cpython" main standard verify_py311 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.7-dev
+++ b/plugins/python-build/share/python-build/3.7-dev
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_git "Python-3.7-dev" "https://github.com/python/cpython" "3.7" standard verify_py37 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.7.10
+++ b/plugins/python-build/share/python-build/3.7.10
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tar.xz#f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.7.8
+++ b/plugins/python-build/share/python-build/3.7.8
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1j" "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.7.8" "https://www.python.org/ftp/python/3.7.8/Python-3.7.8.tar.xz#43a543404b363f0037f89df8478f19db2dbc0d6f3ffee310bc2997fa71854a63" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.7.9
+++ b/plugins/python-build/share/python-build/3.7.9
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.7.9" "https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tar.xz#91923007b05005b5f9bd46f3b9172248aea5abc1543e8a636d59e629c3331b01" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.8-dev
+++ b/plugins/python-build/share/python-build/3.8-dev
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_git "Python-3.8-dev" "https://github.com/python/cpython" "3.8" standard verify_py38 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.8.4
+++ b/plugins/python-build/share/python-build/3.8.4
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.8.4" "https://www.python.org/ftp/python/3.8.4/Python-3.8.4.tar.xz#5f41968a95afe9bc12192d7e6861aab31e80a46c46fa59d3d837def6a4cd4d37" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.8.5
+++ b/plugins/python-build/share/python-build/3.8.5
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.8.5" "https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tar.xz#e3003ed57db17e617acb382b0cade29a248c6026b1bd8aad1f976e9af66a83b0" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.8.6
+++ b/plugins/python-build/share/python-build/3.8.6
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.8.6" "https://www.python.org/ftp/python/3.8.6/Python-3.8.6.tar.xz#a9e0b79d27aa056eb9cce8d63a427b5f9bab1465dee3f942dcfdb25a82f4ab8a" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.8.7
+++ b/plugins/python-build/share/python-build/3.8.7
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.8.7" "https://www.python.org/ftp/python/3.8.7/Python-3.8.7.tar.xz#ddcc1df16bb5b87aa42ec5d20a5b902f2d088caa269b28e01590f97a798ec50a" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.9-dev
+++ b/plugins/python-build/share/python-build/3.9-dev
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_git "Python-3.9-dev" "https://github.com/python/cpython" 3.9 standard verify_py39 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.9.0
+++ b/plugins/python-build/share/python-build/3.9.0
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.9.0" "https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz#9c73e63c99855709b9be0b3cc9e5b072cb60f37311e8c4e50f15576a0bf82854" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.9.1
+++ b/plugins/python-build/share/python-build/3.9.1
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.9.1" "https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tar.xz#991c3f8ac97992f3d308fefeb03a64db462574eadbff34ce8bc5bb583d9903ff" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/1744

### Description
- [x] Here are some details about my PR

Support building with private OpenSSL for Apple ARM64 architecture which was introduced in MacOS 11.
OpenSSL added support for Apple ARM in 1.1.1
(https://github.com/openssl/openssl/commit/61168b5b8dde03f3b77ddf5e4b1b81c338c01746).
Python added support for MacOS 11 in 3.7.8+, 3.8.4+, 3.9.0+
(https://github.com/python/cpython/pull/21113 and backports).

### Tests
- [ ] My PR adds the following unit tests (if any)
