### PR TITLE
Make test independent of umask

### DIFF
--- a/plugins/python-build/test/installer.bats
+++ b/plugins/python-build/test/installer.bats
@@ -57,5 +57,5 @@ OUT
   assert [ -e share/bananas/docs ]
 
   run ls -ld bin
-  assert_equal "r-x" "${output:4:3}"
+  assert_equal "-" "${output:5:1}"
 }


### PR DESCRIPTION
Only test the permission bit that we're setting

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [N/A] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/853

### Description
- [x] Here are some details about my PR

Only check the bits that the test itself sets thus making user umask not affect the result

### Tests
- [N/A] My PR adds the following unit tests (if any)
