### PR TITLE
Drop inferring version to install from `pyenv local`

### DIFF
--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -115,12 +115,7 @@ done
 
 unset VERSION_NAME
 
-# The first argument contains the definition to install. If the
-# argument is missing, try to install whatever local app-specific
-# version is specified by pyenv. Show usage instructions if a local
-# version is not specified.
 DEFINITION="${ARGUMENTS[0]}"
-[ -n "$DEFINITION" ] || DEFINITION="$(pyenv-local 2>/dev/null || true)"
 [ -n "$DEFINITION" ] || usage 1 >&2
 
 # Define `before_install` and `after_install` functions that allow

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -23,17 +23,6 @@ stub_python_build() {
   unstub pyenv-rehash
 }
 
-@test "install pyenv local version by default" {
-  stub_python_build 'echo python-build "$1"'
-  stub pyenv-local 'echo 3.4.2'
-
-  run pyenv-install
-  assert_success "python-build 3.4.2"
-
-  unstub python-build
-  unstub pyenv-local
-}
-
 @test "list available versions" {
   stub_python_build \
     "--definitions : echo 2.6.9 2.7.9-rc1 2.7.9-rc2 3.4.2 | tr ' ' $'\\n'"


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/919

### Description
- [x] Here are some details about my PR

https://github.com/pyenv/pyenv/issues/919#issuecomment-834835025

### Tests
- [x] My PR adds the following unit tests (if any)
