### PR TITLE
Add a hint for cases when ~/.profile sources ~/.rc

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -128,6 +128,10 @@ function help_() {
       ;;
     esac
     echo
+    echo '# If your ~/.profile sources '"${profile}"','
+    echo '# the lines should be inserted before the part'
+    echo '# that does that.'
+    echo
     echo '# Make sure to restart your entire logon session'
     echo '# for changes to ~/.profile to take effect.'
     echo


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/1911

### Description
- [x] Here are some details about my PR

* Subj

Our ~/.rc logic must run after the ~/.profile one
In some systems (many Linuxes), a stock ~/.profile sources ~/.bashrc at the beginning.
(In MacOS, however, it doesn't, so we can't just move all the logic into ~/.bashrc.)

### Tests
- [x] My PR adds the following unit tests (if any)
