### PR TITLE
static shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ name | default | description
 `PYENV_HOOK_PATH` | [_see wiki_][hooks] | Colon-separated list of paths searched for pyenv hooks.
 `PYENV_DIR` | `$PWD` | Directory to start searching for `.python-version` files.
 `PYTHON_BUILD_ARIA2_OPTS` | | Used to pass additional parameters to [`aria2`](https://aria2.github.io/).<br>If the `aria2c` binary is available on PATH, pyenv uses `aria2c` instead of `curl` or `wget` to download the Python Source code. If you have an unstable internet connection, you can use this variable to instruct `aria2` to accelerate the download.<br>In most cases, you will only need to use `-x 10 -k 1M` as value to `PYTHON_BUILD_ARIA2_OPTS` environment variable
+`PYENV_SHIM_VERSION_LOCK` | | set to `y` to create shim will auto use same version as install.<br>set to `n` record that version in comment.<br>set to empty or not set, to avoid this behavior.
 
 
 

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -62,13 +62,30 @@ fi
 # technique is fast, uses less disk space than unique files, and also
 # serves as a locking mechanism.
 create_prototype_shim() {
+  local PYENV_VERSION_LOCK_DECLARATION
+  case "$PYENV_VERSION_LOCK" in
+    "")
+      # fully backward compact
+      PYENV_VERSION_LOCK_DECLARATION=""
+      ;;
+    y|Y|yes|Yes|YES|1)
+      PYENV_VERSION_LOCK_DECLARATION="export PYENV_VERSION=\"${PYENV_VERSION}\""
+      ;;
+    n|N|no|No|NO|0)
+      PYENV_VERSION_LOCK_DECLARATION="# export PYENV_VERSION=\"${PYENV_VERSION}\""
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+  
   cat > "$PROTOTYPE_SHIM_PATH" <<SH
 #!/usr/bin/env bash
 set -e
 [ -n "\$PYENV_DEBUG" ] && set -x
 
 program="\${0##*/}"
-
+${PYENV_VERSION_LOCK_DECLARATION}
 export PYENV_ROOT="$PYENV_ROOT"
 exec "$(command -v pyenv)" exec "\$program" "\$@"
 SH

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -62,17 +62,17 @@ fi
 # technique is fast, uses less disk space than unique files, and also
 # serves as a locking mechanism.
 create_prototype_shim() {
-  local PYENV_VERSION_LOCK_DECLARATION
-  case "$PYENV_VERSION_LOCK" in
+  local PYENV_SHIM_VERSION_LOCK_DECLARATION
+  case "$PYENV_SHIM_VERSION_LOCK" in
     "")
       # fully backward compact
-      PYENV_VERSION_LOCK_DECLARATION=""
+      PYENV_SHIM_VERSION_LOCK_DECLARATION=""
       ;;
     y|Y|yes|Yes|YES|1)
-      PYENV_VERSION_LOCK_DECLARATION="export PYENV_VERSION=\"${PYENV_VERSION}\""
+      PYENV_SHIM_VERSION_LOCK_DECLARATION="export PYENV_VERSION=\"${PYENV_VERSION}\""
       ;;
     n|N|no|No|NO|0)
-      PYENV_VERSION_LOCK_DECLARATION="# export PYENV_VERSION=\"${PYENV_VERSION}\""
+      PYENV_SHIM_VERSION_LOCK_DECLARATION="# export PYENV_VERSION=\"${PYENV_VERSION}\""
       ;;
     *)
       exit 1
@@ -85,7 +85,7 @@ set -e
 [ -n "\$PYENV_DEBUG" ] && set -x
 
 program="\${0##*/}"
-${PYENV_VERSION_LOCK_DECLARATION}
+${PYENV_SHIM_VERSION_LOCK_DECLARATION}
 export PYENV_ROOT="$PYENV_ROOT"
 exec "$(command -v pyenv)" exec "\$program" "\$@"
 SH


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1918

### Description
- [x] Here are some details about my PR
if `PYENV_SHIM_VERSION_LOCK`
1) not set or empty, generate 100% same shim
2) set to y, shim will use same version as install.
3) set to n, shim will record the version using while install.

### Tests
- [] My PR adds the following unit tests (if any)
