### PR TITLE
ldflags_dirs is not needed for Python and causes failures

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1516,21 +1516,6 @@ use_xcode_sdk_zlib() {
   fi
 }
 
-# Ensure that directories listed in LDFLAGS exist
-build_package_ldflags_dirs() {
-  local arg dir
-  set - $LDFLAGS
-  while [ $# -gt 0 ]; do
-    dir=""
-    case "$1" in
-    -L  ) dir="$2" ;;
-    -L* ) dir="${1#-L}" ;;
-    esac
-    [ -z "$dir" ] || mkdir -p "$dir"
-    shift 1
-  done
-}
-
 build_package_enable_shared() {
     package_option python configure --enable-shared
 }

--- a/plugins/python-build/share/python-build/2.1.3
+++ b/plugins/python-build/share/python-build/2.1.3
@@ -1,5 +1,5 @@
 require_gcc
 install_package "readline-6.2" "https://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#79a696070a058c233c72dd6ac697021cc64abd5ed51e59db867d66d196a89381" mac_readline --if has_broken_mac_readline
-install_package "Python-2.1.3" "https://www.python.org/ftp/python/2.1.3/Python-2.1.3.tgz#1bcb5bb587948bc38f36db60e15c376009c56c66570e563a08a82bf7f227afb9" ldflags_dirs standard verify_py21
+install_package "Python-2.1.3" "https://www.python.org/ftp/python/2.1.3/Python-2.1.3.tgz#1bcb5bb587948bc38f36db60e15c376009c56c66570e563a08a82bf7f227afb9" standard verify_py21
 #install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 #install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.2.3
+++ b/plugins/python-build/share/python-build/2.2.3
@@ -1,5 +1,5 @@
 require_gcc
 install_package "readline-6.2" "https://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#79a696070a058c233c72dd6ac697021cc64abd5ed51e59db867d66d196a89381" mac_readline --if has_broken_mac_readline
-install_package "Python-2.2.3" "https://www.python.org/ftp/python/2.2.3/Python-2.2.3.tgz#a8f92e6b89d47359fff0d1fbfe47f104afc77fd1cd5143e7332758b7bc100188" ldflags_dirs standard verify_py22
+install_package "Python-2.2.3" "https://www.python.org/ftp/python/2.2.3/Python-2.2.3.tgz#a8f92e6b89d47359fff0d1fbfe47f104afc77fd1cd5143e7332758b7bc100188" standard verify_py22
 #install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 #install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.3.7
+++ b/plugins/python-build/share/python-build/2.3.7
@@ -1,5 +1,5 @@
 require_gcc
 install_package "readline-6.2" "https://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#79a696070a058c233c72dd6ac697021cc64abd5ed51e59db867d66d196a89381" mac_readline --if has_broken_mac_readline
-install_package "Python-2.3.7" "https://www.python.org/ftp/python/2.3.7/Python-2.3.7.tgz#969a9891dce9f50b13e54f9890acaf2be66715a5895bf9b11111f320c205b90e" ldflags_dirs standard verify_py23
+install_package "Python-2.3.7" "https://www.python.org/ftp/python/2.3.7/Python-2.3.7.tgz#969a9891dce9f50b13e54f9890acaf2be66715a5895bf9b11111f320c205b90e" standard verify_py23
 #install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 #install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.4.0
+++ b/plugins/python-build/share/python-build/2.4.0
@@ -1,5 +1,5 @@
 require_gcc
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.4" "https://www.python.org/ftp/python/2.4/Python-2.4.tgz#ff746de0fae8691c082414b42a2bb172da8797e6e8ff66c9a39d2e452f7034e9" ldflags_dirs standard verify_py24
+install_package "Python-2.4" "https://www.python.org/ftp/python/2.4/Python-2.4.tgz#ff746de0fae8691c082414b42a2bb172da8797e6e8ff66c9a39d2e452f7034e9" standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.4.1
+++ b/plugins/python-build/share/python-build/2.4.1
@@ -1,5 +1,5 @@
 require_gcc
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.4.1" "https://www.python.org/ftp/python/2.4.1/Python-2.4.1.tgz#f449c3b167389324c525ad99d02376c518ac11e163dbbbc13bc88a5c7101fd00" ldflags_dirs standard verify_py24
+install_package "Python-2.4.1" "https://www.python.org/ftp/python/2.4.1/Python-2.4.1.tgz#f449c3b167389324c525ad99d02376c518ac11e163dbbbc13bc88a5c7101fd00" standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.4.2
+++ b/plugins/python-build/share/python-build/2.4.2
@@ -1,5 +1,5 @@
 require_gcc
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.4.2" "https://www.python.org/ftp/python/2.4.2/Python-2.4.2.tgz#2653e1846e87fd9b3ee287fefc965c80c54646548b4913a22265b0dd54493adf" ldflags_dirs standard verify_py24
+install_package "Python-2.4.2" "https://www.python.org/ftp/python/2.4.2/Python-2.4.2.tgz#2653e1846e87fd9b3ee287fefc965c80c54646548b4913a22265b0dd54493adf" standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.4.3
+++ b/plugins/python-build/share/python-build/2.4.3
@@ -1,5 +1,5 @@
 require_gcc
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.4.3" "https://www.python.org/ftp/python/2.4.3/Python-2.4.3.tgz#985a413932f5e31e6280b37da6b285a3a0b2748c6786643989ed9b23de97e2d5" ldflags_dirs standard verify_py24
+install_package "Python-2.4.3" "https://www.python.org/ftp/python/2.4.3/Python-2.4.3.tgz#985a413932f5e31e6280b37da6b285a3a0b2748c6786643989ed9b23de97e2d5" standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.4.4
+++ b/plugins/python-build/share/python-build/2.4.4
@@ -1,5 +1,5 @@
 require_gcc
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.4.4" "https://www.python.org/ftp/python/2.4.4/Python-2.4.4.tgz#92be6e20cbc3111d9dd0c016d72ef7914c23b879dc52df7ba28df97afbf12e2e" ldflags_dirs standard verify_py24
+install_package "Python-2.4.4" "https://www.python.org/ftp/python/2.4.4/Python-2.4.4.tgz#92be6e20cbc3111d9dd0c016d72ef7914c23b879dc52df7ba28df97afbf12e2e" standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.4.5
+++ b/plugins/python-build/share/python-build/2.4.5
@@ -1,5 +1,5 @@
 require_gcc
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.4.5" "https://www.python.org/ftp/python/2.4.5/Python-2.4.5.tgz#6ae6f67a388a7f70ed3a20eebab5aae995ee433089d1f1724095c62f4b7389a1" ldflags_dirs standard verify_py24
+install_package "Python-2.4.5" "https://www.python.org/ftp/python/2.4.5/Python-2.4.5.tgz#6ae6f67a388a7f70ed3a20eebab5aae995ee433089d1f1724095c62f4b7389a1" standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.4.6
+++ b/plugins/python-build/share/python-build/2.4.6
@@ -1,5 +1,5 @@
 require_gcc
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.4.6" "https://www.python.org/ftp/python/2.4.6/Python-2.4.6.tgz#b03f269e826927f05c966cf4f4414f3c93ee2314960859e7f8375e24e82f8b02" ldflags_dirs standard verify_py24
+install_package "Python-2.4.6" "https://www.python.org/ftp/python/2.4.6/Python-2.4.6.tgz#b03f269e826927f05c966cf4f4414f3c93ee2314960859e7f8375e24e82f8b02" standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.5.0
+++ b/plugins/python-build/share/python-build/2.5.0
@@ -1,5 +1,5 @@
 #require_gcc
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.5" "https://www.python.org/ftp/python/2.5/Python-2.5.tgz#d7bbf42e36003c6065cd19f3e67d283521858515ee923220f654131cebe1d8f2" ldflags_dirs standard verify_py25
+install_package "Python-2.5" "https://www.python.org/ftp/python/2.5/Python-2.5.tgz#d7bbf42e36003c6065cd19f3e67d283521858515ee923220f654131cebe1d8f2" standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.3.1" "https://pypi.python.org/packages/source/p/pip/pip-1.3.1.tar.gz#145eaa5d1ea1b062663da1f3a97780d7edea4c63c68a37c463b1deedf7bb4957" python

--- a/plugins/python-build/share/python-build/2.5.1
+++ b/plugins/python-build/share/python-build/2.5.1
@@ -1,5 +1,5 @@
 #require_gcc
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.5.1" "https://www.python.org/ftp/python/2.5.1/Python-2.5.1.tgz#1f5caee846049ca30d996f9403eefdb996295c4af664867e35dcc5eb36e4e7e8" ldflags_dirs standard verify_py25
+install_package "Python-2.5.1" "https://www.python.org/ftp/python/2.5.1/Python-2.5.1.tgz#1f5caee846049ca30d996f9403eefdb996295c4af664867e35dcc5eb36e4e7e8" standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.3.1" "https://pypi.python.org/packages/source/p/pip/pip-1.3.1.tar.gz#145eaa5d1ea1b062663da1f3a97780d7edea4c63c68a37c463b1deedf7bb4957" python

--- a/plugins/python-build/share/python-build/2.5.2
+++ b/plugins/python-build/share/python-build/2.5.2
@@ -1,5 +1,5 @@
 #require_gcc
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.5.2" "https://www.python.org/ftp/python/2.5.2/Python-2.5.2.tgz#834afe8a88adaf623b05ac5dd6700dd5bb5d0d5553fc74ad529359a3496e4ae3" ldflags_dirs standard verify_py25
+install_package "Python-2.5.2" "https://www.python.org/ftp/python/2.5.2/Python-2.5.2.tgz#834afe8a88adaf623b05ac5dd6700dd5bb5d0d5553fc74ad529359a3496e4ae3" standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.3.1" "https://pypi.python.org/packages/source/p/pip/pip-1.3.1.tar.gz#145eaa5d1ea1b062663da1f3a97780d7edea4c63c68a37c463b1deedf7bb4957" python

--- a/plugins/python-build/share/python-build/2.5.3
+++ b/plugins/python-build/share/python-build/2.5.3
@@ -1,5 +1,5 @@
 #require_gcc
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.5.3" "https://www.python.org/ftp/python/2.5.3/Python-2.5.3.tgz#c3fee607d20a77dfb72ea2e627eb4d95d25c735603435abde62c57015a0445bd" ldflags_dirs standard verify_py25
+install_package "Python-2.5.3" "https://www.python.org/ftp/python/2.5.3/Python-2.5.3.tgz#c3fee607d20a77dfb72ea2e627eb4d95d25c735603435abde62c57015a0445bd" standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.3.1" "https://pypi.python.org/packages/source/p/pip/pip-1.3.1.tar.gz#145eaa5d1ea1b062663da1f3a97780d7edea4c63c68a37c463b1deedf7bb4957" python

--- a/plugins/python-build/share/python-build/2.5.4
+++ b/plugins/python-build/share/python-build/2.5.4
@@ -1,5 +1,5 @@
 #require_gcc
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.5.4" "https://www.python.org/ftp/python/2.5.4/Python-2.5.4.tgz#3d3b205611ee503a38a9433d5645a571668420bb219242c7f51af85f05664da6" ldflags_dirs standard verify_py25
+install_package "Python-2.5.4" "https://www.python.org/ftp/python/2.5.4/Python-2.5.4.tgz#3d3b205611ee503a38a9433d5645a571668420bb219242c7f51af85f05664da6" standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.3.1" "https://pypi.python.org/packages/source/p/pip/pip-1.3.1.tar.gz#145eaa5d1ea1b062663da1f3a97780d7edea4c63c68a37c463b1deedf7bb4957" python

--- a/plugins/python-build/share/python-build/2.5.5
+++ b/plugins/python-build/share/python-build/2.5.5
@@ -1,5 +1,5 @@
 #require_gcc
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.5.5" "https://www.python.org/ftp/python/2.5.5/Python-2.5.5.tgz#03be1019c4fe93daeb53ba9e4294bf22a8ed4cb854cbd57e24e16f6bf63e2392" ldflags_dirs standard verify_py25
+install_package "Python-2.5.5" "https://www.python.org/ftp/python/2.5.5/Python-2.5.5.tgz#03be1019c4fe93daeb53ba9e4294bf22a8ed4cb854cbd57e24e16f6bf63e2392" standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.3.1" "https://pypi.python.org/packages/source/p/pip/pip-1.3.1.tar.gz#145eaa5d1ea1b062663da1f3a97780d7edea4c63c68a37c463b1deedf7bb4957" python

--- a/plugins/python-build/share/python-build/2.5.6
+++ b/plugins/python-build/share/python-build/2.5.6
@@ -1,5 +1,5 @@
 #require_gcc
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.5.6" "https://www.python.org/ftp/python/2.5.6/Python-2.5.6.tgz#c2e4377597241b1065677d23327c04d0f41945d370c61a491cc88be367234c5d" ldflags_dirs standard verify_py25
+install_package "Python-2.5.6" "https://www.python.org/ftp/python/2.5.6/Python-2.5.6.tgz#c2e4377597241b1065677d23327c04d0f41945d370c61a491cc88be367234c5d" standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.3.1" "https://pypi.python.org/packages/source/p/pip/pip-1.3.1.tar.gz#145eaa5d1ea1b062663da1f3a97780d7edea4c63c68a37c463b1deedf7bb4957" python

--- a/plugins/python-build/share/python-build/2.6.6
+++ b/plugins/python-build/share/python-build/2.6.6
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.6.6" "https://www.python.org/ftp/python/2.6.6/Python-2.6.6.tgz#372f66db46d773214e4619df1794a26449158f626138d4d2141a64c2f017fae1" ldflags_dirs standard verify_py26 ensurepip
+install_package "Python-2.6.6" "https://www.python.org/ftp/python/2.6.6/Python-2.6.6.tgz#372f66db46d773214e4619df1794a26449158f626138d4d2141a64c2f017fae1" standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.7
+++ b/plugins/python-build/share/python-build/2.6.7
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.6.7" "https://www.python.org/ftp/python/2.6.7/Python-2.6.7.tgz#a8093eace4cfd3e06b05f0deb5d765e3c6cec65908048640a8cadd7a948b3826" ldflags_dirs standard verify_py26 ensurepip
+install_package "Python-2.6.7" "https://www.python.org/ftp/python/2.6.7/Python-2.6.7.tgz#a8093eace4cfd3e06b05f0deb5d765e3c6cec65908048640a8cadd7a948b3826" standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.8
+++ b/plugins/python-build/share/python-build/2.6.8
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.6.8" "https://www.python.org/ftp/python/2.6.8/Python-2.6.8.tgz#5bf02a75ffa2fcaa5a3cabb8201998519b045541975622316888ea468d9512f7" ldflags_dirs standard verify_py26 ensurepip
+install_package "Python-2.6.8" "https://www.python.org/ftp/python/2.6.8/Python-2.6.8.tgz#5bf02a75ffa2fcaa5a3cabb8201998519b045541975622316888ea468d9512f7" standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.9
+++ b/plugins/python-build/share/python-build/2.6.9
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.6.9" "https://www.python.org/ftp/python/2.6.9/Python-2.6.9.tgz#7277b1285d8a82f374ef6ebaac85b003266f7939b3f2a24a3af52f9523ac94db" ldflags_dirs standard verify_py26 ensurepip
+install_package "Python-2.6.9" "https://www.python.org/ftp/python/2.6.9/Python-2.6.9.tgz#7277b1285d8a82f374ef6ebaac85b003266f7939b3f2a24a3af52f9523ac94db" standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.7.0
+++ b/plugins/python-build/share/python-build/2.7.0
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.7" "https://www.python.org/ftp/python/2.7/Python-2.7.tgz#5670dd6c0c93b0b529781d070852f7b51ce6855615b16afcd318341af2910fb5" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+install_package "Python-2.7" "https://www.python.org/ftp/python/2.7/Python-2.7.tgz#5670dd6c0c93b0b529781d070852f7b51ce6855615b16afcd318341af2910fb5" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.1
+++ b/plugins/python-build/share/python-build/2.7.1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.7.1" "https://www.python.org/ftp/python/2.7.1/Python-2.7.1.tgz#ca13e7b1860821494f70de017202283ad73b1fb7bd88586401c54ef958226ec8" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+install_package "Python-2.7.1" "https://www.python.org/ftp/python/2.7.1/Python-2.7.1.tgz#ca13e7b1860821494f70de017202283ad73b1fb7bd88586401c54ef958226ec8" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.10
+++ b/plugins/python-build/share/python-build/2.7.10
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.10" "https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tar.xz#1cd3730781b91caf0fa1c4d472dc29274186480161a150294c42ce9b5c5effc0" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.10" "https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tar.xz#1cd3730781b91caf0fa1c4d472dc29274186480161a150294c42ce9b5c5effc0" standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.10" "https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tgz#eda8ce6eec03e74991abb5384170e7c65fcd7522e409b8e83d7e6372add0f12a" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.10" "https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tgz#eda8ce6eec03e74991abb5384170e7c65fcd7522e409b8e83d7e6372add0f12a" standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.11
+++ b/plugins/python-build/share/python-build/2.7.11
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.11" "https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tar.xz#962b4c45af50124ea61f11a30deb4342fc0bc21126790fa1d7f6c79809413f46" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.11" "https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tar.xz#962b4c45af50124ea61f11a30deb4342fc0bc21126790fa1d7f6c79809413f46" standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.11" "https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz#82929b96fd6afc8da838b149107078c02fa1744b7e60999a8babbc0d3fa86fc6" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.11" "https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz#82929b96fd6afc8da838b149107078c02fa1744b7e60999a8babbc0d3fa86fc6" standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.12
+++ b/plugins/python-build/share/python-build/2.7.12
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.12" "https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tar.xz#d7837121dd5652a05fef807c361909d255d173280c4e1a4ded94d73d80a1f978" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.12" "https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tar.xz#d7837121dd5652a05fef807c361909d255d173280c4e1a4ded94d73d80a1f978" standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.12" "https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tgz#3cb522d17463dfa69a155ab18cffa399b358c966c0363d6c8b5b3bf1384da4b6" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.12" "https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tgz#3cb522d17463dfa69a155ab18cffa399b358c966c0363d6c8b5b3bf1384da4b6" standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.13
+++ b/plugins/python-build/share/python-build/2.7.13
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.13" "https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tar.xz#35d543986882f78261f97787fd3e06274bfa6df29fac9b4a94f73930ff98f731" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.13" "https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tar.xz#35d543986882f78261f97787fd3e06274bfa6df29fac9b4a94f73930ff98f731" standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.13" "https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz#a4f05a0720ce0fd92626f0278b6b433eee9a6173ddf2bced7957dfb599a5ece1" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.13" "https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz#a4f05a0720ce0fd92626f0278b6b433eee9a6173ddf2bced7957dfb599a5ece1" standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.14
+++ b/plugins/python-build/share/python-build/2.7.14
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.14" "https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tar.xz#71ffb26e09e78650e424929b2b457b9c912ac216576e6bd9e7d204ed03296a66" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.14" "https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tar.xz#71ffb26e09e78650e424929b2b457b9c912ac216576e6bd9e7d204ed03296a66" standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.14" "https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tgz#304c9b202ea6fbd0a4a8e0ad3733715fbd4749f2204a9173a58ec53c32ea73e8" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.14" "https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tgz#304c9b202ea6fbd0a4a8e0ad3733715fbd4749f2204a9173a58ec53c32ea73e8" standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.15
+++ b/plugins/python-build/share/python-build/2.7.15
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.15" "https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tar.xz#22d9b1ac5b26135ad2b8c2901a9413537e08749a753356ee913c84dbd2df5574" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.15" "https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tar.xz#22d9b1ac5b26135ad2b8c2901a9413537e08749a753356ee913c84dbd2df5574" standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.15" "https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tgz#18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.15" "https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tgz#18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db" standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.16
+++ b/plugins/python-build/share/python-build/2.7.16
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.16" "https://www.python.org/ftp/python/2.7.16/Python-2.7.16.tar.xz#f222ef602647eecb6853681156d32de4450a2c39f4de93bd5b20235f2e660ed7" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.16" "https://www.python.org/ftp/python/2.7.16/Python-2.7.16.tar.xz#f222ef602647eecb6853681156d32de4450a2c39f4de93bd5b20235f2e660ed7" standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.16" "https://www.python.org/ftp/python/2.7.16/Python-2.7.16.tgz#01da813a3600876f03f46db11cc5c408175e99f03af2ba942ef324389a83bad5" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.16" "https://www.python.org/ftp/python/2.7.16/Python-2.7.16.tgz#01da813a3600876f03f46db11cc5c408175e99f03af2ba942ef324389a83bad5" standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.17
+++ b/plugins/python-build/share/python-build/2.7.17
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.17" "https://www.python.org/ftp/python/2.7.17/Python-2.7.17.tar.xz#4d43f033cdbd0aa7b7023c81b0e986fd11e653b5248dac9144d508f11812ba41" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.17" "https://www.python.org/ftp/python/2.7.17/Python-2.7.17.tar.xz#4d43f033cdbd0aa7b7023c81b0e986fd11e653b5248dac9144d508f11812ba41" standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.17" "https://www.python.org/ftp/python/2.7.17/Python-2.7.17.tgz#f22059d09cdf9625e0a7284d24a13062044f5bf59d93a7f3382190dfa94cecde" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.17" "https://www.python.org/ftp/python/2.7.17/Python-2.7.17.tgz#f22059d09cdf9625e0a7284d24a13062044f5bf59d93a7f3382190dfa94cecde" standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.18
+++ b/plugins/python-build/share/python-build/2.7.18
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.18" "https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tar.xz#b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.18" "https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tar.xz#b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43" standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.18" "https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tgz#da3080e3b488f648a3d7a4560ddee895284c3380b11d6de75edb986526b9a814" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.18" "https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tgz#da3080e3b488f648a3d7a4560ddee895284c3380b11d6de75edb986526b9a814" standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.2
+++ b/plugins/python-build/share/python-build/2.7.2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.7.2" "https://www.python.org/ftp/python/2.7.2/Python-2.7.2.tgz#1d54b7096c17902c3f40ffce7e5b84e0072d0144024184fff184a84d563abbb3" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+install_package "Python-2.7.2" "https://www.python.org/ftp/python/2.7.2/Python-2.7.2.tgz#1d54b7096c17902c3f40ffce7e5b84e0072d0144024184fff184a84d563abbb3" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.3
+++ b/plugins/python-build/share/python-build/2.7.3
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.7.3" "https://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz#d4c20f2b5faf95999fd5fecb3f7d32071b0820516224a6d2b72932ab47a1cb8e" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+install_package "Python-2.7.3" "https://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz#d4c20f2b5faf95999fd5fecb3f7d32071b0820516224a6d2b72932ab47a1cb8e" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.4
+++ b/plugins/python-build/share/python-build/2.7.4
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.7.4" "https://www.python.org/ftp/python/2.7.4/Python-2.7.4.tgz#98c5eb9c8e65effcc0122112ba17a0bce880aa23ecb560af56b55eb55632b81a" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+install_package "Python-2.7.4" "https://www.python.org/ftp/python/2.7.4/Python-2.7.4.tgz#98c5eb9c8e65effcc0122112ba17a0bce880aa23ecb560af56b55eb55632b81a" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.5
+++ b/plugins/python-build/share/python-build/2.7.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.7.5" "https://www.python.org/ftp/python/2.7.5/Python-2.7.5.tgz#8e1b5fa87b91835afb376a9c0d319d41feca07ffebc0288d97ab08d64f48afbf" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+install_package "Python-2.7.5" "https://www.python.org/ftp/python/2.7.5/Python-2.7.5.tgz#8e1b5fa87b91835afb376a9c0d319d41feca07ffebc0288d97ab08d64f48afbf" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.6
+++ b/plugins/python-build/share/python-build/2.7.6
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-2.7.6" "https://www.python.org/ftp/python/2.7.6/Python-2.7.6.tgz#99c6860b70977befa1590029fae092ddb18db1d69ae67e8b9385b66ed104ba58" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+install_package "Python-2.7.6" "https://www.python.org/ftp/python/2.7.6/Python-2.7.6.tgz#99c6860b70977befa1590029fae092ddb18db1d69ae67e8b9385b66ed104ba58" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.7
+++ b/plugins/python-build/share/python-build/2.7.7
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.7" "https://www.python.org/ftp/python/2.7.7/Python-2.7.7.tar.xz#2983e3cd089b30c50e2b2234f07c2ac4fb8a5df230ab8f2e1133a1d8b208da78" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.7" "https://www.python.org/ftp/python/2.7.7/Python-2.7.7.tar.xz#2983e3cd089b30c50e2b2234f07c2ac4fb8a5df230ab8f2e1133a1d8b208da78" standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.7" "https://www.python.org/ftp/python/2.7.7/Python-2.7.7.tgz#7f49c0a6705ad89d925181e27d0aaa025ee4731ce0de64776c722216c3e66c42" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.7" "https://www.python.org/ftp/python/2.7.7/Python-2.7.7.tgz#7f49c0a6705ad89d925181e27d0aaa025ee4731ce0de64776c722216c3e66c42" standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.8
+++ b/plugins/python-build/share/python-build/2.7.8
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.8" "https://www.python.org/ftp/python/2.7.8/Python-2.7.8.tar.xz#edde10a0cb7d14e2735e682882d5b287028d1485c456758154c19573db68075a" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.8" "https://www.python.org/ftp/python/2.7.8/Python-2.7.8.tar.xz#edde10a0cb7d14e2735e682882d5b287028d1485c456758154c19573db68075a" standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.8" "https://www.python.org/ftp/python/2.7.8/Python-2.7.8.tgz#74d70b914da4487aa1d97222b29e9554d042f825f26cb2b93abd20fdda56b557" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.8" "https://www.python.org/ftp/python/2.7.8/Python-2.7.8.tgz#74d70b914da4487aa1d97222b29e9554d042f825f26cb2b93abd20fdda56b557" standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/2.7.9
+++ b/plugins/python-build/share/python-build/2.7.9
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-2.7.9" "https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tar.xz#90d27e14ea7e03570026850e2e50ba71ad20b7eb31035aada1cf3def8f8d4916" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.9" "https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tar.xz#90d27e14ea7e03570026850e2e50ba71ad20b7eb31035aada1cf3def8f8d4916" standard verify_py27 copy_python_gdb ensurepip
 else
-  install_package "Python-2.7.9" "https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tgz#c8bba33e66ac3201dabdc556f0ea7cfe6ac11946ec32d357c4c6f9b018c12c5b" ldflags_dirs standard verify_py27 copy_python_gdb ensurepip
+  install_package "Python-2.7.9" "https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tgz#c8bba33e66ac3201dabdc556f0ea7cfe6ac11946ec32d357c4c6f9b018c12c5b" standard verify_py27 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.0.1
+++ b/plugins/python-build/share/python-build/3.0.1
@@ -1,7 +1,7 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.0.1" "https://www.python.org/ftp/python/3.0.1/Python-3.0.1.tgz#7d5f2feae9035f1d3d9e6bb7f092dbf374d6bb4b25abd0d2d11f13bba1cb04de" ldflags_dirs standard verify_py30
+install_package "Python-3.0.1" "https://www.python.org/ftp/python/3.0.1/Python-3.0.1.tgz#7d5f2feae9035f1d3d9e6bb7f092dbf374d6bb4b25abd0d2d11f13bba1cb04de" standard verify_py30
 if [[ "Darwin" == "$(uname -s)" ]]; then
   # https://github.com/pyenv/pyenv/issues/456
   { echo

--- a/plugins/python-build/share/python-build/3.1.0
+++ b/plugins/python-build/share/python-build/3.1.0
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.1" "https://www.python.org/ftp/python/3.1/Python-3.1.tgz#99a034cf574ea3c26412b0a0728126d7fd6ea9593d099d807a25d216ed031e6a" ldflags_dirs standard verify_py31
+install_package "Python-3.1" "https://www.python.org/ftp/python/3.1/Python-3.1.tgz#99a034cf574ea3c26412b0a0728126d7fd6ea9593d099d807a25d216ed031e6a" standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.1.1
+++ b/plugins/python-build/share/python-build/3.1.1
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.1.1" "https://www.python.org/ftp/python/3.1.1/Python-3.1.1.tgz#5d85d7bff11c4db44920af99f64f4227c816f897f6bfa9dd8a2611165ca5f0a1" ldflags_dirs standard verify_py31
+install_package "Python-3.1.1" "https://www.python.org/ftp/python/3.1.1/Python-3.1.1.tgz#5d85d7bff11c4db44920af99f64f4227c816f897f6bfa9dd8a2611165ca5f0a1" standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.1.2
+++ b/plugins/python-build/share/python-build/3.1.2
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.1.2" "https://www.python.org/ftp/python/3.1.2/Python-3.1.2.tgz#dffbc0561a161a4a576c6059e6990a9859a0be16ba9b5736eabe4abbb2700d1c" ldflags_dirs standard verify_py31
+install_package "Python-3.1.2" "https://www.python.org/ftp/python/3.1.2/Python-3.1.2.tgz#dffbc0561a161a4a576c6059e6990a9859a0be16ba9b5736eabe4abbb2700d1c" standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.1.3
+++ b/plugins/python-build/share/python-build/3.1.3
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.1.3" "https://www.python.org/ftp/python/3.1.3/Python-3.1.3.tgz#6311823aeda8be6a7a2b67caaeff48abce6626c9940ba7ed81f9c978666a36bd" ldflags_dirs standard verify_py31
+install_package "Python-3.1.3" "https://www.python.org/ftp/python/3.1.3/Python-3.1.3.tgz#6311823aeda8be6a7a2b67caaeff48abce6626c9940ba7ed81f9c978666a36bd" standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.1.4
+++ b/plugins/python-build/share/python-build/3.1.4
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.1.4" "https://www.python.org/ftp/python/3.1.4/Python-3.1.4.tgz#fadc05ea6d05360cff189944a85ecd2180bbc308784d168b350450e70bbdd846" ldflags_dirs standard verify_py31
+install_package "Python-3.1.4" "https://www.python.org/ftp/python/3.1.4/Python-3.1.4.tgz#fadc05ea6d05360cff189944a85ecd2180bbc308784d168b350450e70bbdd846" standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.1.5
+++ b/plugins/python-build/share/python-build/3.1.5
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.1.5" "https://www.python.org/ftp/python/3.1.5/Python-3.1.5.tgz#d12dae6d06f52ef6bf1271db4d5b4d14b5dd39813e324314e72b648ef1bc0103" ldflags_dirs standard verify_py31
+install_package "Python-3.1.5" "https://www.python.org/ftp/python/3.1.5/Python-3.1.5.tgz#d12dae6d06f52ef6bf1271db4d5b4d14b5dd39813e324314e72b648ef1bc0103" standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.10.0b1
+++ b/plugins/python-build/share/python-build/3.10.0b1
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.10.0b1" "https://www.python.org/ftp/python/3.10.0/Python-3.10.0b1.tar.xz#a30c55b26a91f4c76392ba2b2e87c2d591fdb2b36f7b58d39fe90bd400fef1a3" ldflags_dirs standard verify_py310 copy_python_gdb ensurepip
+    install_package "Python-3.10.0b1" "https://www.python.org/ftp/python/3.10.0/Python-3.10.0b1.tar.xz#a30c55b26a91f4c76392ba2b2e87c2d591fdb2b36f7b58d39fe90bd400fef1a3" standard verify_py310 copy_python_gdb ensurepip
 else
-    install_package "Python-3.10.0b1" "https://www.python.org/ftp/python/3.10.0/Python-3.10.0b1.tgz#a44c4726948689fe22f3edf30f11bf361d4536b38738ca955747eb5860c2dc93" ldflags_dirs standard verify_py310 copy_python_gdb ensurepip
+    install_package "Python-3.10.0b1" "https://www.python.org/ftp/python/3.10.0/Python-3.10.0b1.tgz#a44c4726948689fe22f3edf30f11bf361d4536b38738ca955747eb5860c2dc93" standard verify_py310 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.2.0
+++ b/plugins/python-build/share/python-build/3.2.0
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.2" "https://www.python.org/ftp/python/3.2/Python-3.2.tgz#27b35bfcbbf01de9564c0265d72b58ba3ff3d56df0615765372f2aa09dc20da9" ldflags_dirs standard verify_py32
+install_package "Python-3.2" "https://www.python.org/ftp/python/3.2/Python-3.2.tgz#27b35bfcbbf01de9564c0265d72b58ba3ff3d56df0615765372f2aa09dc20da9" standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/3.2.1
+++ b/plugins/python-build/share/python-build/3.2.1
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.2.1" "https://www.python.org/ftp/python/3.2.1/Python-3.2.1.tgz#7cff29d984696d9fe8c7bea54da5b9ad36acef33ff5cf0d3e37e4d12fb21c572" ldflags_dirs standard verify_py32
+install_package "Python-3.2.1" "https://www.python.org/ftp/python/3.2.1/Python-3.2.1.tgz#7cff29d984696d9fe8c7bea54da5b9ad36acef33ff5cf0d3e37e4d12fb21c572" standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/3.2.2
+++ b/plugins/python-build/share/python-build/3.2.2
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.2.2" "https://www.python.org/ftp/python/3.2.2/Python-3.2.2.tgz#acc6a13cb4fed0b7e86716324a8437e326645b8076177eede5a0cad99ec0313c" ldflags_dirs standard verify_py32
+install_package "Python-3.2.2" "https://www.python.org/ftp/python/3.2.2/Python-3.2.2.tgz#acc6a13cb4fed0b7e86716324a8437e326645b8076177eede5a0cad99ec0313c" standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/3.2.3
+++ b/plugins/python-build/share/python-build/3.2.3
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.2.3" "https://www.python.org/ftp/python/3.2.3/Python-3.2.3.tgz#74c33e165edef7532cef95fd9a325a06878b5bfc8a5d038161573f283eaf9809" ldflags_dirs standard verify_py32
+install_package "Python-3.2.3" "https://www.python.org/ftp/python/3.2.3/Python-3.2.3.tgz#74c33e165edef7532cef95fd9a325a06878b5bfc8a5d038161573f283eaf9809" standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/3.2.4
+++ b/plugins/python-build/share/python-build/3.2.4
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.2.4" "https://www.python.org/ftp/python/3.2.4/Python-3.2.4.tgz#71c3139908ccc1c544ba1e331a3c22b3f1c09f562438a054fd6f4e2628de8b9a" ldflags_dirs standard verify_py32
+install_package "Python-3.2.4" "https://www.python.org/ftp/python/3.2.4/Python-3.2.4.tgz#71c3139908ccc1c544ba1e331a3c22b3f1c09f562438a054fd6f4e2628de8b9a" standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/3.2.5
+++ b/plugins/python-build/share/python-build/3.2.5
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.2.5" "https://www.python.org/ftp/python/3.2.5/Python-3.2.5.tgz#5eae0ab92a0bb9e3a1bf9c7cd046bc3de58996b049bd894d095978b6b085099f" ldflags_dirs standard verify_py32
+install_package "Python-3.2.5" "https://www.python.org/ftp/python/3.2.5/Python-3.2.5.tgz#5eae0ab92a0bb9e3a1bf9c7cd046bc3de58996b049bd894d095978b6b085099f" standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/3.2.6
+++ b/plugins/python-build/share/python-build/3.2.6
@@ -2,9 +2,9 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.2.6" "https://www.python.org/ftp/python/3.2.6/Python-3.2.6.tar.xz#1d12b501819fd26afafbf8459be1aa279b56f032b4c15412de0a713ce0de7bdc" ldflags_dirs standard verify_py32
+  install_package "Python-3.2.6" "https://www.python.org/ftp/python/3.2.6/Python-3.2.6.tar.xz#1d12b501819fd26afafbf8459be1aa279b56f032b4c15412de0a713ce0de7bdc" standard verify_py32
 else
-  install_package "Python-3.2.6" "https://www.python.org/ftp/python/3.2.6/Python-3.2.6.tgz#fc1e41296e29d476f696303acae293ae7a2310f0f9d0d637905e722a3f16163e" ldflags_dirs standard verify_py32
+  install_package "Python-3.2.6" "https://www.python.org/ftp/python/3.2.6/Python-3.2.6.tgz#fc1e41296e29d476f696303acae293ae7a2310f0f9d0d637905e722a3f16163e" standard verify_py32
 fi
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/3.3.0
+++ b/plugins/python-build/share/python-build/3.3.0
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.3.0" "https://www.python.org/ftp/python/3.3.0/Python-3.3.0.tgz#cfe531eaace2503e13a74addc7f4a89482e99f8b8fca51b469ae5c83f450604e" ldflags_dirs standard verify_py33 ensurepip
+install_package "Python-3.3.0" "https://www.python.org/ftp/python/3.3.0/Python-3.3.0.tgz#cfe531eaace2503e13a74addc7f4a89482e99f8b8fca51b469ae5c83f450604e" standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.1
+++ b/plugins/python-build/share/python-build/3.3.1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.3.1" "https://www.python.org/ftp/python/3.3.1/Python-3.3.1.tgz#671dc3632f311e63c6733703aa0a1ad90c99277ddc8299d39e487718a50319bd" ldflags_dirs standard verify_py33 ensurepip
+install_package "Python-3.3.1" "https://www.python.org/ftp/python/3.3.1/Python-3.3.1.tgz#671dc3632f311e63c6733703aa0a1ad90c99277ddc8299d39e487718a50319bd" standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.2
+++ b/plugins/python-build/share/python-build/3.3.2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.3.2" "https://www.python.org/ftp/python/3.3.2/Python-3.3.2.tgz#de664fca3b8e0ab20fb42bfed1a36e26f116f1853e88ada12dbc938761036172" ldflags_dirs standard verify_py33 ensurepip
+install_package "Python-3.3.2" "https://www.python.org/ftp/python/3.3.2/Python-3.3.2.tgz#de664fca3b8e0ab20fb42bfed1a36e26f116f1853e88ada12dbc938761036172" standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.3
+++ b/plugins/python-build/share/python-build/3.3.3
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.3.3" "https://www.python.org/ftp/python/3.3.3/Python-3.3.3.tgz#30b60839bfe0ae8a2dba11e909328459bb8ee4a258afe7494b06b2ceda080efc" ldflags_dirs standard verify_py33 ensurepip
+install_package "Python-3.3.3" "https://www.python.org/ftp/python/3.3.3/Python-3.3.3.tgz#30b60839bfe0ae8a2dba11e909328459bb8ee4a258afe7494b06b2ceda080efc" standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.4
+++ b/plugins/python-build/share/python-build/3.3.4
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.3.4" "https://www.python.org/ftp/python/3.3.4/Python-3.3.4.tgz#ea055db9dd004a6ecd7690abc9734573763686dd768122316bae2dfd026412af" ldflags_dirs standard verify_py33 ensurepip
+install_package "Python-3.3.4" "https://www.python.org/ftp/python/3.3.4/Python-3.3.4.tgz#ea055db9dd004a6ecd7690abc9734573763686dd768122316bae2dfd026412af" standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.5
+++ b/plugins/python-build/share/python-build/3.3.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.3.5" "https://www.python.org/ftp/python/3.3.5/Python-3.3.5.tgz#916bc57dd8524dc27429bebae7b39d6942742cf9699b875b2b496a3d960c7168" ldflags_dirs standard verify_py33 ensurepip
+install_package "Python-3.3.5" "https://www.python.org/ftp/python/3.3.5/Python-3.3.5.tgz#916bc57dd8524dc27429bebae7b39d6942742cf9699b875b2b496a3d960c7168" standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.6
+++ b/plugins/python-build/share/python-build/3.3.6
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.3.6" "https://www.python.org/ftp/python/3.3.6/Python-3.3.6.tar.xz#5226e4bf7a530c3ff2bcde0c94e0e09e59a8bcde0114fe0268bc925bdabb5d3f" ldflags_dirs standard verify_py33 ensurepip
+  install_package "Python-3.3.6" "https://www.python.org/ftp/python/3.3.6/Python-3.3.6.tar.xz#5226e4bf7a530c3ff2bcde0c94e0e09e59a8bcde0114fe0268bc925bdabb5d3f" standard verify_py33 ensurepip
 else
-  install_package "Python-3.3.6" "https://www.python.org/ftp/python/3.3.6/Python-3.3.6.tgz#0a58ad1f1def4ecc90b18b0c410a3a0e1a48cf7692c75d1f83d0af080e5d2034" ldflags_dirs standard verify_py33 ensurepip
+  install_package "Python-3.3.6" "https://www.python.org/ftp/python/3.3.6/Python-3.3.6.tgz#0a58ad1f1def4ecc90b18b0c410a3a0e1a48cf7692c75d1f83d0af080e5d2034" standard verify_py33 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.3.7
+++ b/plugins/python-build/share/python-build/3.3.7
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.3.7" "https://www.python.org/ftp/python/3.3.7/Python-3.3.7.tar.xz#85f60c327501c36bc18c33370c14d472801e6af2f901dafbba056f61685429fe" ldflags_dirs standard verify_py33 ensurepip
+  install_package "Python-3.3.7" "https://www.python.org/ftp/python/3.3.7/Python-3.3.7.tar.xz#85f60c327501c36bc18c33370c14d472801e6af2f901dafbba056f61685429fe" standard verify_py33 ensurepip
 else
-  install_package "Python-3.3.7" "https://www.python.org/ftp/python/3.3.7/Python-3.3.7.tgz#992461a9598e85a45323512d4e60fa6c1d5aaef0956bf9db98733cc5aa9b05e1" ldflags_dirs standard verify_py33 ensurepip
+  install_package "Python-3.3.7" "https://www.python.org/ftp/python/3.3.7/Python-3.3.7.tgz#992461a9598e85a45323512d4e60fa6c1d5aaef0956bf9db98733cc5aa9b05e1" standard verify_py33 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.4.0
+++ b/plugins/python-build/share/python-build/3.4.0
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.4.0" "https://www.python.org/ftp/python/3.4.0/Python-3.4.0.tar.xz#f13686c0a2d45e7146759e9d5d1cbd8097a0606483c0cf7730e1e13f58b14cbe" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.0" "https://www.python.org/ftp/python/3.4.0/Python-3.4.0.tar.xz#f13686c0a2d45e7146759e9d5d1cbd8097a0606483c0cf7730e1e13f58b14cbe" standard verify_py34 ensurepip
 else
-  install_package "Python-3.4.0" "https://www.python.org/ftp/python/3.4.0/Python-3.4.0.tgz#d2c83ea0217769a73e8b1ee33ffbca814903f8568e30f8d13e68e3d1f743449c" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.0" "https://www.python.org/ftp/python/3.4.0/Python-3.4.0.tgz#d2c83ea0217769a73e8b1ee33ffbca814903f8568e30f8d13e68e3d1f743449c" standard verify_py34 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.4.1
+++ b/plugins/python-build/share/python-build/3.4.1
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.4.1" "https://www.python.org/ftp/python/3.4.1/Python-3.4.1.tar.xz#c595a163104399041fcbe1c5c04db4c1da94f917b82ce89e8944c8edff7aedc4" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.1" "https://www.python.org/ftp/python/3.4.1/Python-3.4.1.tar.xz#c595a163104399041fcbe1c5c04db4c1da94f917b82ce89e8944c8edff7aedc4" standard verify_py34 ensurepip
 else
-  install_package "Python-3.4.1" "https://www.python.org/ftp/python/3.4.1/Python-3.4.1.tgz#8d007e3ef80b128a292be101201e75dec5480e5632e994771e7c231d17720b66" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.1" "https://www.python.org/ftp/python/3.4.1/Python-3.4.1.tgz#8d007e3ef80b128a292be101201e75dec5480e5632e994771e7c231d17720b66" standard verify_py34 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.4.10
+++ b/plugins/python-build/share/python-build/3.4.10
@@ -4,4 +4,4 @@ install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.
 has_tar_xz_support \
   && src="https://www.python.org/ftp/python/3.4.10/Python-3.4.10.tar.xz#d46a8f6fe91679e199c671b1b0a30aaf172d2acb5bcab25beb35f16c3d195b4e" \
   || src="https://www.python.org/ftp/python/3.4.10/Python-3.4.10.tgz#217757699249ab432571b381386d441e12b433100ab5f908051fcb7cced2539d"
-install_package "Python-3.4.10" "$src" ldflags_dirs standard verify_py34 ensurepip
+install_package "Python-3.4.10" "$src" standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.2
+++ b/plugins/python-build/share/python-build/3.4.2
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.4.2" "https://www.python.org/ftp/python/3.4.2/Python-3.4.2.tar.xz#1c6d9682d145c056537e477bbfa060ce727f9edd38df1827e0f970dcf04b2def" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.2" "https://www.python.org/ftp/python/3.4.2/Python-3.4.2.tar.xz#1c6d9682d145c056537e477bbfa060ce727f9edd38df1827e0f970dcf04b2def" standard verify_py34 ensurepip
 else
-  install_package "Python-3.4.2" "https://www.python.org/ftp/python/3.4.2/Python-3.4.2.tgz#44a3c1ef1c7ca3e4fd25242af80ed72da941203cb4ed1a8c1b724d9078965dd8" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.2" "https://www.python.org/ftp/python/3.4.2/Python-3.4.2.tgz#44a3c1ef1c7ca3e4fd25242af80ed72da941203cb4ed1a8c1b724d9078965dd8" standard verify_py34 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.4.3
+++ b/plugins/python-build/share/python-build/3.4.3
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.4.3" "https://www.python.org/ftp/python/3.4.3/Python-3.4.3.tar.xz#b5b3963533768d5fc325a4d7a6bd6f666726002d696f1d399ec06b043ea996b8" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.3" "https://www.python.org/ftp/python/3.4.3/Python-3.4.3.tar.xz#b5b3963533768d5fc325a4d7a6bd6f666726002d696f1d399ec06b043ea996b8" standard verify_py34 ensurepip
 else
-  install_package "Python-3.4.3" "https://www.python.org/ftp/python/3.4.3/Python-3.4.3.tgz#8b743f56e9e50bf0923b9e9c45dd927c071d7aa56cd46569d8818add8cf01147" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.3" "https://www.python.org/ftp/python/3.4.3/Python-3.4.3.tgz#8b743f56e9e50bf0923b9e9c45dd927c071d7aa56cd46569d8818add8cf01147" standard verify_py34 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.4.4
+++ b/plugins/python-build/share/python-build/3.4.4
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.4.4" "https://www.python.org/ftp/python/3.4.4/Python-3.4.4.tar.xz#a797d3820155ec6cb654a652b9acfb11792d4e7d568eef1f9199009e042b6ba2" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.4" "https://www.python.org/ftp/python/3.4.4/Python-3.4.4.tar.xz#a797d3820155ec6cb654a652b9acfb11792d4e7d568eef1f9199009e042b6ba2" standard verify_py34 ensurepip
 else
-  install_package "Python-3.4.4" "https://www.python.org/ftp/python/3.4.4/Python-3.4.4.tgz#bc93e944025816ec360712b4c42d8d5f729eaed2b26585e9bc8844f93f0c382e" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.4" "https://www.python.org/ftp/python/3.4.4/Python-3.4.4.tgz#bc93e944025816ec360712b4c42d8d5f729eaed2b26585e9bc8844f93f0c382e" standard verify_py34 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.4.5
+++ b/plugins/python-build/share/python-build/3.4.5
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.4.5" "https://www.python.org/ftp/python/3.4.5/Python-3.4.5.tar.xz#ee64b1c8a47461009abf25252332d29a4e587cb4f0c1c96aa793a3732e9d898a" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.5" "https://www.python.org/ftp/python/3.4.5/Python-3.4.5.tar.xz#ee64b1c8a47461009abf25252332d29a4e587cb4f0c1c96aa793a3732e9d898a" standard verify_py34 ensurepip
 else
-  install_package "Python-3.4.5" "https://www.python.org/ftp/python/3.4.5/Python-3.4.5.tgz#997aca4dd8692f3c954658a3db11c1d0862bcbf8eadd6a164746eb33d317c034" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.5" "https://www.python.org/ftp/python/3.4.5/Python-3.4.5.tgz#997aca4dd8692f3c954658a3db11c1d0862bcbf8eadd6a164746eb33d317c034" standard verify_py34 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.4.6
+++ b/plugins/python-build/share/python-build/3.4.6
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.4.6" "https://www.python.org/ftp/python/3.4.6/Python-3.4.6.tar.xz#f13428bbe6aa9e3b9b6499502dc488c26096349ed7a21f7a0c1db90911115f40" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.6" "https://www.python.org/ftp/python/3.4.6/Python-3.4.6.tar.xz#f13428bbe6aa9e3b9b6499502dc488c26096349ed7a21f7a0c1db90911115f40" standard verify_py34 ensurepip
 else
-  install_package "Python-3.4.6" "https://www.python.org/ftp/python/3.4.6/Python-3.4.6.tgz#fe59daced99549d1d452727c050ae486169e9716a890cffb0d468b376d916b48" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.6" "https://www.python.org/ftp/python/3.4.6/Python-3.4.6.tgz#fe59daced99549d1d452727c050ae486169e9716a890cffb0d468b376d916b48" standard verify_py34 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.4.7
+++ b/plugins/python-build/share/python-build/3.4.7
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.4.7" "https://www.python.org/ftp/python/3.4.7/Python-3.4.7.tar.xz#8714cf2b56dd36922dec8fa184d4936e1001c22fb439798cb73dda069e129d1b" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.7" "https://www.python.org/ftp/python/3.4.7/Python-3.4.7.tar.xz#8714cf2b56dd36922dec8fa184d4936e1001c22fb439798cb73dda069e129d1b" standard verify_py34 ensurepip
 else
-  install_package "Python-3.4.7" "https://www.python.org/ftp/python/3.4.7/Python-3.4.7.tgz#1614734847fd07e2a1ab1c65ae841db2433f8b845f49b34b7b5cabcb1c3f491f" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.7" "https://www.python.org/ftp/python/3.4.7/Python-3.4.7.tgz#1614734847fd07e2a1ab1c65ae841db2433f8b845f49b34b7b5cabcb1c3f491f" standard verify_py34 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.4.8
+++ b/plugins/python-build/share/python-build/3.4.8
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.4.8" "https://www.python.org/ftp/python/3.4.8/Python-3.4.8.tar.xz#29a472fa902c7b2add152f5e1e82e0885a8d360645689c1db5d1949a7e8ac3ea" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.8" "https://www.python.org/ftp/python/3.4.8/Python-3.4.8.tar.xz#29a472fa902c7b2add152f5e1e82e0885a8d360645689c1db5d1949a7e8ac3ea" standard verify_py34 ensurepip
 else
-  install_package "Python-3.4.8" "https://www.python.org/ftp/python/3.4.8/Python-3.4.8.tgz#8b1a1ce043e132082d29a5d09f2841f193c77b631282a82f98895a5dbaba1639" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.8" "https://www.python.org/ftp/python/3.4.8/Python-3.4.8.tgz#8b1a1ce043e132082d29a5d09f2841f193c77b631282a82f98895a5dbaba1639" standard verify_py34 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.4.9
+++ b/plugins/python-build/share/python-build/3.4.9
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.4.9" "https://www.python.org/ftp/python/3.4.9/Python-3.4.9.tar.xz#59629676ba2b01a798f5211d8f63c26ee52f1d5133cf37583e0bf1bad50c2bd9" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.9" "https://www.python.org/ftp/python/3.4.9/Python-3.4.9.tar.xz#59629676ba2b01a798f5211d8f63c26ee52f1d5133cf37583e0bf1bad50c2bd9" standard verify_py34 ensurepip
 else
-  install_package "Python-3.4.9" "https://www.python.org/ftp/python/3.4.9/Python-3.4.9.tgz#e02e565372750a6678efe35ddecbe5ccd5330a8a2e8bbe38d3060713492e3dab" ldflags_dirs standard verify_py34 ensurepip
+  install_package "Python-3.4.9" "https://www.python.org/ftp/python/3.4.9/Python-3.4.9.tgz#e02e565372750a6678efe35ddecbe5ccd5330a8a2e8bbe38d3060713492e3dab" standard verify_py34 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.0
+++ b/plugins/python-build/share/python-build/3.5.0
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.0" "https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tar.xz#d6d7aa1634a5eeeca6ed4fca266982a04f84bd8f3945a9179e20b24ad2e2be91" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
+  install_package "Python-3.5.0" "https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tar.xz#d6d7aa1634a5eeeca6ed4fca266982a04f84bd8f3945a9179e20b24ad2e2be91" standard verify_py35 copy_python_gdb ensurepip
 else
-  install_package "Python-3.5.0" "https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tgz#584e3d5a02692ca52fce505e68ecd77248a6f2c99adf9db144a39087336b0fe0" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
+  install_package "Python-3.5.0" "https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tgz#584e3d5a02692ca52fce505e68ecd77248a6f2c99adf9db144a39087336b0fe0" standard verify_py35 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.1
+++ b/plugins/python-build/share/python-build/3.5.1
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.1" "https://www.python.org/ftp/python/3.5.1/Python-3.5.1.tar.xz#c6d57c0c366d9060ab6c0cdf889ebf3d92711d466cc0119c441dbf2746f725c9" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
+  install_package "Python-3.5.1" "https://www.python.org/ftp/python/3.5.1/Python-3.5.1.tar.xz#c6d57c0c366d9060ab6c0cdf889ebf3d92711d466cc0119c441dbf2746f725c9" standard verify_py35 copy_python_gdb ensurepip
 else
-  install_package "Python-3.5.1" "https://www.python.org/ftp/python/3.5.1/Python-3.5.1.tgz#687e067d9f391da645423c7eda8205bae9d35edc0c76ef5218dcbe4cc770d0d7" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
+  install_package "Python-3.5.1" "https://www.python.org/ftp/python/3.5.1/Python-3.5.1.tgz#687e067d9f391da645423c7eda8205bae9d35edc0c76ef5218dcbe4cc770d0d7" standard verify_py35 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.10
+++ b/plugins/python-build/share/python-build/3.5.10
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.10" "https://www.python.org/ftp/python/3.5.10/Python-3.5.10.tar.xz#0f0fa8685c1dc1f1dacb0b4e7779796b90aef99dc1fa4967a71b9da7b57d4a28" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.10" "https://www.python.org/ftp/python/3.5.10/Python-3.5.10.tar.xz#0f0fa8685c1dc1f1dacb0b4e7779796b90aef99dc1fa4967a71b9da7b57d4a28" standard verify_py35 ensurepip
 else
-  install_package "Python-3.5.10" "https://www.python.org/ftp/python/3.5.10/Python-3.5.10.tgz#3496a0daf51913718a6f10e3eda51fa43634cb6151cb096f312d48bdbeff7d3a" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.10" "https://www.python.org/ftp/python/3.5.10/Python-3.5.10.tgz#3496a0daf51913718a6f10e3eda51fa43634cb6151cb096f312d48bdbeff7d3a" standard verify_py35 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.2
+++ b/plugins/python-build/share/python-build/3.5.2
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.2" "https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tar.xz#0010f56100b9b74259ebcd5d4b295a32324b58b517403a10d1a2aa7cb22bca40" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
+  install_package "Python-3.5.2" "https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tar.xz#0010f56100b9b74259ebcd5d4b295a32324b58b517403a10d1a2aa7cb22bca40" standard verify_py35 copy_python_gdb ensurepip
 else
-  install_package "Python-3.5.2" "https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tgz#1524b840e42cf3b909e8f8df67c1724012c7dc7f9d076d4feef2d3eff031e8a0" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
+  install_package "Python-3.5.2" "https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tgz#1524b840e42cf3b909e8f8df67c1724012c7dc7f9d076d4feef2d3eff031e8a0" standard verify_py35 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.3
+++ b/plugins/python-build/share/python-build/3.5.3
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.3" "https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tar.xz#eefe2ad6575855423ab630f5b51a8ef6e5556f774584c06beab4926f930ddbb0" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
+  install_package "Python-3.5.3" "https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tar.xz#eefe2ad6575855423ab630f5b51a8ef6e5556f774584c06beab4926f930ddbb0" standard verify_py35 copy_python_gdb ensurepip
 else
-  install_package "Python-3.5.3" "https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tgz#d8890b84d773cd7059e597dbefa510340de8336ec9b9e9032bf030f19291565a" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
+  install_package "Python-3.5.3" "https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tgz#d8890b84d773cd7059e597dbefa510340de8336ec9b9e9032bf030f19291565a" standard verify_py35 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.4
+++ b/plugins/python-build/share/python-build/3.5.4
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.4" "https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tar.xz#94d93bfabb3b109f8a10365a325f920f9ec98c6e2380bf228f9700a14054c84c" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
+  install_package "Python-3.5.4" "https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tar.xz#94d93bfabb3b109f8a10365a325f920f9ec98c6e2380bf228f9700a14054c84c" standard verify_py35 copy_python_gdb ensurepip
 else
-  install_package "Python-3.5.4" "https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tgz#6ed87a8b6c758cc3299a8b433e8a9a9122054ad5bc8aad43299cff3a53d8ca44" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
+  install_package "Python-3.5.4" "https://www.python.org/ftp/python/3.5.4/Python-3.5.4.tgz#6ed87a8b6c758cc3299a8b433e8a9a9122054ad5bc8aad43299cff3a53d8ca44" standard verify_py35 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.5
+++ b/plugins/python-build/share/python-build/3.5.5
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.5" "https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tar.xz#063d2c3b0402d6191b90731e0f735c64830e7522348aeb7ed382a83165d45009" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
+  install_package "Python-3.5.5" "https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tar.xz#063d2c3b0402d6191b90731e0f735c64830e7522348aeb7ed382a83165d45009" standard verify_py35 copy_python_gdb ensurepip
 else
-  install_package "Python-3.5.5" "https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tgz#2f988db33913dcef17552fd1447b41afb89dbc26e3cdfc068ea6c62013a3a2a5" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
+  install_package "Python-3.5.5" "https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tgz#2f988db33913dcef17552fd1447b41afb89dbc26e3cdfc068ea6c62013a3a2a5" standard verify_py35 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.6
+++ b/plugins/python-build/share/python-build/3.5.6
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.6" "https://www.python.org/ftp/python/3.5.6/Python-3.5.6.tar.xz#f55cde04f521f273c7cba08912921cc5642cfc15ca7b22d5829f0aff4371155f" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
+  install_package "Python-3.5.6" "https://www.python.org/ftp/python/3.5.6/Python-3.5.6.tar.xz#f55cde04f521f273c7cba08912921cc5642cfc15ca7b22d5829f0aff4371155f" standard verify_py35 copy_python_gdb ensurepip
 else
-  install_package "Python-3.5.6" "https://www.python.org/ftp/python/3.5.6/Python-3.5.6.tgz#30d2ff093988e74283e1abfee823292c6b59590796b9827e95ba4940b27d26f8" ldflags_dirs standard verify_py35 copy_python_gdb ensurepip
+  install_package "Python-3.5.6" "https://www.python.org/ftp/python/3.5.6/Python-3.5.6.tgz#30d2ff093988e74283e1abfee823292c6b59590796b9827e95ba4940b27d26f8" standard verify_py35 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.7
+++ b/plugins/python-build/share/python-build/3.5.7
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.7" "https://www.python.org/ftp/python/3.5.7/Python-3.5.7.tar.xz#285892899bf4d5737fd08482aa6171c6b2564a45b9102dfacfb72826aebdc7dc" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.7" "https://www.python.org/ftp/python/3.5.7/Python-3.5.7.tar.xz#285892899bf4d5737fd08482aa6171c6b2564a45b9102dfacfb72826aebdc7dc" standard verify_py35 ensurepip
 else
-  install_package "Python-3.5.7" "https://www.python.org/ftp/python/3.5.7/Python-3.5.7.tgz#542d94920a2a06a471a73b51614805ad65366af98145b0369bc374cf248b521b" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.7" "https://www.python.org/ftp/python/3.5.7/Python-3.5.7.tgz#542d94920a2a06a471a73b51614805ad65366af98145b0369bc374cf248b521b" standard verify_py35 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.8
+++ b/plugins/python-build/share/python-build/3.5.8
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.8" "https://www.python.org/ftp/python/3.5.8/Python-3.5.8.tar.xz#55a345c78ee3afbc2e60678442aad7bcc384ddea5bb95f8d66edc4868d4847d4" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.8" "https://www.python.org/ftp/python/3.5.8/Python-3.5.8.tar.xz#55a345c78ee3afbc2e60678442aad7bcc384ddea5bb95f8d66edc4868d4847d4" standard verify_py35 ensurepip
 else
-  install_package "Python-3.5.8" "https://www.python.org/ftp/python/3.5.8/Python-3.5.8.tgz#18c88dfd260147bc7247e6356010e5d4916dfbfc480f6434917f88e61228177a" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.8" "https://www.python.org/ftp/python/3.5.8/Python-3.5.8.tgz#18c88dfd260147bc7247e6356010e5d4916dfbfc480f6434917f88e61228177a" standard verify_py35 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.5.9
+++ b/plugins/python-build/share/python-build/3.5.9
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.5.9" "https://www.python.org/ftp/python/3.5.9/Python-3.5.9.tar.xz#c24a37c63a67f53bdd09c5f287b5cff8e8b98f857bf348c577d454d3f74db049" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.9" "https://www.python.org/ftp/python/3.5.9/Python-3.5.9.tar.xz#c24a37c63a67f53bdd09c5f287b5cff8e8b98f857bf348c577d454d3f74db049" standard verify_py35 ensurepip
 else
-  install_package "Python-3.5.9" "https://www.python.org/ftp/python/3.5.9/Python-3.5.9.tgz#67a1d4fc6e4540d6a092cadc488e533afa961b3c9becc74dc3d6b55cb56e0cc1" ldflags_dirs standard verify_py35 ensurepip
+  install_package "Python-3.5.9" "https://www.python.org/ftp/python/3.5.9/Python-3.5.9.tgz#67a1d4fc6e4540d6a092cadc488e533afa961b3c9becc74dc3d6b55cb56e0cc1" standard verify_py35 ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.0
+++ b/plugins/python-build/share/python-build/3.6.0
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.0" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tar.xz#b0c5f904f685e32d9232f7bdcbece9819a892929063b6e385414ad2dd6a23622" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
+  install_package "Python-3.6.0" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tar.xz#b0c5f904f685e32d9232f7bdcbece9819a892929063b6e385414ad2dd6a23622" standard verify_py36 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.0" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tgz#aa472515800d25a3739833f76ca3735d9f4b2fe77c3cb21f69275e0cce30cb2b" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
+  install_package "Python-3.6.0" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tgz#aa472515800d25a3739833f76ca3735d9f4b2fe77c3cb21f69275e0cce30cb2b" standard verify_py36 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.1
+++ b/plugins/python-build/share/python-build/3.6.1
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.1" "https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tar.xz#a01810ddfcec216bcdb357a84bfaafdfaa0ca42bbdaa4cb7ff74f5a9961e4041" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
+  install_package "Python-3.6.1" "https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tar.xz#a01810ddfcec216bcdb357a84bfaafdfaa0ca42bbdaa4cb7ff74f5a9961e4041" standard verify_py36 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.1" "https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tgz#aa50b0143df7c89ce91be020fe41382613a817354b33acdc6641b44f8ced3828" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
+  install_package "Python-3.6.1" "https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tgz#aa50b0143df7c89ce91be020fe41382613a817354b33acdc6641b44f8ced3828" standard verify_py36 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.10
+++ b/plugins/python-build/share/python-build/3.6.10
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.10" "https://www.python.org/ftp/python/3.6.10/Python-3.6.10.tar.xz#0a833c398ac8cd7c5538f7232d8531afef943c60495c504484f308dac3af40de" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.6.10" "https://www.python.org/ftp/python/3.6.10/Python-3.6.10.tar.xz#0a833c398ac8cd7c5538f7232d8531afef943c60495c504484f308dac3af40de" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.10" "https://www.python.org/ftp/python/3.6.10/Python-3.6.10.tgz#7034dd7cba98d4f94c74f9edd7345bac71c8814c41672c64d9044fa2f96f334d" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.6.10" "https://www.python.org/ftp/python/3.6.10/Python-3.6.10.tgz#7034dd7cba98d4f94c74f9edd7345bac71c8814c41672c64d9044fa2f96f334d" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.11
+++ b/plugins/python-build/share/python-build/3.6.11
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.11" "https://www.python.org/ftp/python/3.6.11/Python-3.6.11.tar.xz#741ebdcbc4e3937a5ff23517dd455ebf7d543ea9fef6f5cf6f46e575d6c4fda4" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.6.11" "https://www.python.org/ftp/python/3.6.11/Python-3.6.11.tar.xz#741ebdcbc4e3937a5ff23517dd455ebf7d543ea9fef6f5cf6f46e575d6c4fda4" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.11" "https://www.python.org/ftp/python/3.6.11/Python-3.6.11.tgz#96621902f89746fffc22f39749c07da7c2917b232e72352e6837d41850f7b90c" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.6.11" "https://www.python.org/ftp/python/3.6.11/Python-3.6.11.tgz#96621902f89746fffc22f39749c07da7c2917b232e72352e6837d41850f7b90c" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.12
+++ b/plugins/python-build/share/python-build/3.6.12
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.12" "https://www.python.org/ftp/python/3.6.12/Python-3.6.12.tar.xz#70953a9b5d6891d92e65d184c3512126a15814bee15e1eff2ddcce04334e9a99" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.6.12" "https://www.python.org/ftp/python/3.6.12/Python-3.6.12.tar.xz#70953a9b5d6891d92e65d184c3512126a15814bee15e1eff2ddcce04334e9a99" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.12" "https://www.python.org/ftp/python/3.6.12/Python-3.6.12.tgz#12dddbe52385a0f702fb8071e12dcc6b3cb2dde07cd8db3ed60e90d90ab78693" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.6.12" "https://www.python.org/ftp/python/3.6.12/Python-3.6.12.tgz#12dddbe52385a0f702fb8071e12dcc6b3cb2dde07cd8db3ed60e90d90ab78693" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.13
+++ b/plugins/python-build/share/python-build/3.6.13
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.13" "https://www.python.org/ftp/python/3.6.13/Python-3.6.13.tar.xz#a47a43a53abb42286a2c11965343ff56711b9e64e8d11bf2c6701a4fb8ce1a0f" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.6.13" "https://www.python.org/ftp/python/3.6.13/Python-3.6.13.tar.xz#a47a43a53abb42286a2c11965343ff56711b9e64e8d11bf2c6701a4fb8ce1a0f" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.13" "https://www.python.org/ftp/python/3.6.13/Python-3.6.13.tgz#614950d3d54f6e78dac651b49c64cfe2ceefea5af3aff3371a9e4b27a53b2669" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.6.13" "https://www.python.org/ftp/python/3.6.13/Python-3.6.13.tgz#614950d3d54f6e78dac651b49c64cfe2ceefea5af3aff3371a9e4b27a53b2669" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.2
+++ b/plugins/python-build/share/python-build/3.6.2
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.2" "https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tar.xz#9229773be41ed144370f47f0f626a1579931f5a390f1e8e3853174d52edd64a9" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
+  install_package "Python-3.6.2" "https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tar.xz#9229773be41ed144370f47f0f626a1579931f5a390f1e8e3853174d52edd64a9" standard verify_py36 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.2" "https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz#7919489310a5f17f7acbab64d731e46dca0702874840dadce8bd4b2b3b8e7a82" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
+  install_package "Python-3.6.2" "https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz#7919489310a5f17f7acbab64d731e46dca0702874840dadce8bd4b2b3b8e7a82" standard verify_py36 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.3
+++ b/plugins/python-build/share/python-build/3.6.3
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.3" "https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tar.xz#cda7d967c9a4bfa52337cdf551bcc5cff026b6ac50a8834e568ce4a794ca81da" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
+  install_package "Python-3.6.3" "https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tar.xz#cda7d967c9a4bfa52337cdf551bcc5cff026b6ac50a8834e568ce4a794ca81da" standard verify_py36 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.3" "https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tgz#ab6193af1921b30f587b302fe385268510e80187ca83ca82d2bfe7ab544c6f91" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
+  install_package "Python-3.6.3" "https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tgz#ab6193af1921b30f587b302fe385268510e80187ca83ca82d2bfe7ab544c6f91" standard verify_py36 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.4
+++ b/plugins/python-build/share/python-build/3.6.4
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.4" "https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tar.xz#159b932bf56aeaa76fd66e7420522d8c8853d486b8567c459b84fe2ed13bcaba" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
+  install_package "Python-3.6.4" "https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tar.xz#159b932bf56aeaa76fd66e7420522d8c8853d486b8567c459b84fe2ed13bcaba" standard verify_py36 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.4" "https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tgz#7dc453e1a93c083388eb1a23a256862407f8234a96dc4fae0fc7682020227486" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
+  install_package "Python-3.6.4" "https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tgz#7dc453e1a93c083388eb1a23a256862407f8234a96dc4fae0fc7682020227486" standard verify_py36 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.5
+++ b/plugins/python-build/share/python-build/3.6.5
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.5" "https://www.python.org/ftp/python/3.6.5/Python-3.6.5.tar.xz#f434053ba1b5c8a5cc597e966ead3c5143012af827fd3f0697d21450bb8d87a6" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
+  install_package "Python-3.6.5" "https://www.python.org/ftp/python/3.6.5/Python-3.6.5.tar.xz#f434053ba1b5c8a5cc597e966ead3c5143012af827fd3f0697d21450bb8d87a6" standard verify_py36 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.5" "https://www.python.org/ftp/python/3.6.5/Python-3.6.5.tgz#53a3e17d77cd15c5230192b6a8c1e031c07cd9f34a2f089a731c6f6bd343d5c6" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
+  install_package "Python-3.6.5" "https://www.python.org/ftp/python/3.6.5/Python-3.6.5.tgz#53a3e17d77cd15c5230192b6a8c1e031c07cd9f34a2f089a731c6f6bd343d5c6" standard verify_py36 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.6
+++ b/plugins/python-build/share/python-build/3.6.6
@@ -2,7 +2,7 @@
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.6" "https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tar.xz#d79bc15d456e73a3173a2938f18a17e5149c850ebdedf84a78067f501ee6e16f" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
+  install_package "Python-3.6.6" "https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tar.xz#d79bc15d456e73a3173a2938f18a17e5149c850ebdedf84a78067f501ee6e16f" standard verify_py36 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.6" "https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tgz#7d56dadf6c7d92a238702389e80cfe66fbfae73e584189ed6f89c75bbf3eda58" ldflags_dirs standard verify_py36 copy_python_gdb ensurepip
+  install_package "Python-3.6.6" "https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tgz#7d56dadf6c7d92a238702389e80cfe66fbfae73e584189ed6f89c75bbf3eda58" standard verify_py36 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.7
+++ b/plugins/python-build/share/python-build/3.6.7
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.7" "https://www.python.org/ftp/python/3.6.7/Python-3.6.7.tar.xz#81fd1401a9d66533b0a3e9e3f4ea1c7c6702d57d5b90d659f971e6f1b745f77d" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.6.7" "https://www.python.org/ftp/python/3.6.7/Python-3.6.7.tar.xz#81fd1401a9d66533b0a3e9e3f4ea1c7c6702d57d5b90d659f971e6f1b745f77d" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.7" "https://www.python.org/ftp/python/3.6.7/Python-3.6.7.tgz#b7c36f7ed8f7143b2c46153b7332db2227669f583ea0cce753facf549d1a4239" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.6.7" "https://www.python.org/ftp/python/3.6.7/Python-3.6.7.tgz#b7c36f7ed8f7143b2c46153b7332db2227669f583ea0cce753facf549d1a4239" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.8
+++ b/plugins/python-build/share/python-build/3.6.8
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.8" "https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tar.xz#35446241e995773b1bed7d196f4b624dadcadc8429f26282e756b2fb8a351193" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.6.8" "https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tar.xz#35446241e995773b1bed7d196f4b624dadcadc8429f26282e756b2fb8a351193" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.8" "https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tgz#7f5b1f08b3b0a595387ef6c64c85b1b13b38abef0dd871835ee923262e4f32f0" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.6.8" "https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tgz#7f5b1f08b3b0a595387ef6c64c85b1b13b38abef0dd871835ee923262e4f32f0" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.6.9
+++ b/plugins/python-build/share/python-build/3.6.9
@@ -3,7 +3,7 @@ prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.6.9" "https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tar.xz#5e2f5f554e3f8f7f0296f7e73d8600c4e9acbaee6b2555b83206edf5153870da" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.6.9" "https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tar.xz#5e2f5f554e3f8f7f0296f7e73d8600c4e9acbaee6b2555b83206edf5153870da" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.6.9" "https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz#47fc92a1dcb946b9ed0abc311d3767b7215c54e655b17fd1d3f9b538195525aa" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.6.9" "https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz#47fc92a1dcb946b9ed0abc311d3767b7215c54e655b17fd1d3f9b538195525aa" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.7.0
+++ b/plugins/python-build/share/python-build/3.7.0
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.0" "https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tar.xz#0382996d1ee6aafe59763426cf0139ffebe36984474d0ec4126dd1c40a8b3549" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.0" "https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tar.xz#0382996d1ee6aafe59763426cf0139ffebe36984474d0ec4126dd1c40a8b3549" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.0" "https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tgz#85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.0" "https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tgz#85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.7.1
+++ b/plugins/python-build/share/python-build/3.7.1
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.1" "https://www.python.org/ftp/python/3.7.1/Python-3.7.1.tar.xz#fa7e2b8e8c9402f192ad56dc4f814089d1c4466c97d780f5e5acc02c04243d6d" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.1" "https://www.python.org/ftp/python/3.7.1/Python-3.7.1.tar.xz#fa7e2b8e8c9402f192ad56dc4f814089d1c4466c97d780f5e5acc02c04243d6d" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.1" "https://www.python.org/ftp/python/3.7.1/Python-3.7.1.tgz#36c1b81ac29d0f8341f727ef40864d99d8206897be96be73dc34d4739c9c9f06" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.1" "https://www.python.org/ftp/python/3.7.1/Python-3.7.1.tgz#36c1b81ac29d0f8341f727ef40864d99d8206897be96be73dc34d4739c9c9f06" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.7.10
+++ b/plugins/python-build/share/python-build/3.7.10
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tar.xz#f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tar.xz#f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz#c9649ad84dc3a434c8637df6963100b2e5608697f9ba56d82e3809e4148e0975" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.10" "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz#c9649ad84dc3a434c8637df6963100b2e5608697f9ba56d82e3809e4148e0975" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.7.2
+++ b/plugins/python-build/share/python-build/3.7.2
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.2" "https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tar.xz#d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.2" "https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tar.xz#d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.2" "https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tgz#f09d83c773b9cc72421abba2c317e4e6e05d919f9bcf34468e192b6a6c8e328d" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.2" "https://www.python.org/ftp/python/3.7.2/Python-3.7.2.tgz#f09d83c773b9cc72421abba2c317e4e6e05d919f9bcf34468e192b6a6c8e328d" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.7.3
+++ b/plugins/python-build/share/python-build/3.7.3
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.3" "https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tar.xz#da60b54064d4cfcd9c26576f6df2690e62085123826cff2e667e72a91952d318" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.3" "https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tar.xz#da60b54064d4cfcd9c26576f6df2690e62085123826cff2e667e72a91952d318" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.3" "https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tgz#d62e3015f2f89c970ac52343976b406694931742fbde2fed8d1ce8ebb4e1f8ff" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.3" "https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tgz#d62e3015f2f89c970ac52343976b406694931742fbde2fed8d1ce8ebb4e1f8ff" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.7.4
+++ b/plugins/python-build/share/python-build/3.7.4
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.4" "https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tar.xz#fb799134b868199930b75f26678f18932214042639cd52b16da7fd134cd9b13f" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.4" "https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tar.xz#fb799134b868199930b75f26678f18932214042639cd52b16da7fd134cd9b13f" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.4" "https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz#d63e63e14e6d29e17490abbe6f7d17afb3db182dbd801229f14e55f4157c4ba3" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.4" "https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz#d63e63e14e6d29e17490abbe6f7d17afb3db182dbd801229f14e55f4157c4ba3" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.7.5
+++ b/plugins/python-build/share/python-build/3.7.5
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.5" "https://www.python.org/ftp/python/3.7.5/Python-3.7.5.tar.xz#e85a76ea9f3d6c485ec1780fca4e500725a4a7bbc63c78ebc44170de9b619d94" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.5" "https://www.python.org/ftp/python/3.7.5/Python-3.7.5.tar.xz#e85a76ea9f3d6c485ec1780fca4e500725a4a7bbc63c78ebc44170de9b619d94" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.5" "https://www.python.org/ftp/python/3.7.5/Python-3.7.5.tgz#8ecc681ea0600bbfb366f2b173f727b205bb825d93d2f0b286bc4e58d37693da" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.5" "https://www.python.org/ftp/python/3.7.5/Python-3.7.5.tgz#8ecc681ea0600bbfb366f2b173f727b205bb825d93d2f0b286bc4e58d37693da" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.7.6
+++ b/plugins/python-build/share/python-build/3.7.6
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tar.xz#55a2cce72049f0794e9a11a84862e9039af9183603b78bc60d89539f82cf533f" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tar.xz#55a2cce72049f0794e9a11a84862e9039af9183603b78bc60d89539f82cf533f" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tgz#aeee681c235ad336af116f08ab6563361a0c81c537072c1b309d6e4050aa2114" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.6" "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tgz#aeee681c235ad336af116f08ab6563361a0c81c537072c1b309d6e4050aa2114" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.7.7
+++ b/plugins/python-build/share/python-build/3.7.7
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.7" "https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tar.xz#06a0a9f1bf0d8cd1e4121194d666c4e28ddae4dd54346de6c343206599f02136" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.7" "https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tar.xz#06a0a9f1bf0d8cd1e4121194d666c4e28ddae4dd54346de6c343206599f02136" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.7" "https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tgz#8c8be91cd2648a1a0c251f04ea0bb4c2a5570feb9c45eaaa2241c785585b475a" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.7" "https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tgz#8c8be91cd2648a1a0c251f04ea0bb4c2a5570feb9c45eaaa2241c785585b475a" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.7.8
+++ b/plugins/python-build/share/python-build/3.7.8
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1j" "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.8" "https://www.python.org/ftp/python/3.7.8/Python-3.7.8.tar.xz#43a543404b363f0037f89df8478f19db2dbc0d6f3ffee310bc2997fa71854a63" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.8" "https://www.python.org/ftp/python/3.7.8/Python-3.7.8.tar.xz#43a543404b363f0037f89df8478f19db2dbc0d6f3ffee310bc2997fa71854a63" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.8" "https://www.python.org/ftp/python/3.7.8/Python-3.7.8.tgz#0e25835614dc221e3ecea5831b38fa90788b5389b99b675a751414c858789ab0" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.8" "https://www.python.org/ftp/python/3.7.8/Python-3.7.8.tgz#0e25835614dc221e3ecea5831b38fa90788b5389b99b675a751414c858789ab0" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.7.9
+++ b/plugins/python-build/share/python-build/3.7.9
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.7.9" "https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tar.xz#91923007b05005b5f9bd46f3b9172248aea5abc1543e8a636d59e629c3331b01" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.9" "https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tar.xz#91923007b05005b5f9bd46f3b9172248aea5abc1543e8a636d59e629c3331b01" standard verify_py37 copy_python_gdb ensurepip
 else
-  install_package "Python-3.7.9" "https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tgz#39b018bc7d8a165e59aa827d9ae45c45901739b0bbb13721e4f973f3521c166a" ldflags_dirs standard verify_py37 copy_python_gdb ensurepip
+  install_package "Python-3.7.9" "https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tgz#39b018bc7d8a165e59aa827d9ae45c45901739b0bbb13721e4f973f3521c166a" standard verify_py37 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.8.0
+++ b/plugins/python-build/share/python-build/3.8.0
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.0" "https://www.python.org/ftp/python/3.8.0/Python-3.8.0.tar.xz#b356244e13fb5491da890b35b13b2118c3122977c2cd825e3eb6e7d462030d84" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.0" "https://www.python.org/ftp/python/3.8.0/Python-3.8.0.tar.xz#b356244e13fb5491da890b35b13b2118c3122977c2cd825e3eb6e7d462030d84" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.0" "https://www.python.org/ftp/python/3.8.0/Python-3.8.0.tgz#f1069ad3cae8e7ec467aa98a6565a62a48ef196cb8f1455a245a08db5e1792df" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.0" "https://www.python.org/ftp/python/3.8.0/Python-3.8.0.tgz#f1069ad3cae8e7ec467aa98a6565a62a48ef196cb8f1455a245a08db5e1792df" standard verify_py38 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.8.1
+++ b/plugins/python-build/share/python-build/3.8.1
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tar.xz#75894117f6db7051c1b34f37410168844bbb357c139a8a10a352e9bf8be594e8" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tar.xz#75894117f6db7051c1b34f37410168844bbb357c139a8a10a352e9bf8be594e8" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tgz#c7cfa39a43b994621b245e029769e9126caa2a93571cee2e743b213cceac35fb" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.1" "https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tgz#c7cfa39a43b994621b245e029769e9126caa2a93571cee2e743b213cceac35fb" standard verify_py38 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.8.10
+++ b/plugins/python-build/share/python-build/3.8.10
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tar.xz#6af24a66093dd840bcccf371d4044a3027e655cf24591ce26e48022bc79219d9" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tar.xz#6af24a66093dd840bcccf371d4044a3027e655cf24591ce26e48022bc79219d9" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz#b37ac74d2cbad2590e7cd0dd2b3826c29afe89a734090a87bf8c03c45066cb65" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz#b37ac74d2cbad2590e7cd0dd2b3826c29afe89a734090a87bf8c03c45066cb65" standard verify_py38 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.8.2
+++ b/plugins/python-build/share/python-build/3.8.2
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.2" "https://www.python.org/ftp/python/3.8.2/Python-3.8.2.tar.xz#2646e7dc233362f59714c6193017bb2d6f7b38d6ab4a0cb5fbac5c36c4d845df" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.2" "https://www.python.org/ftp/python/3.8.2/Python-3.8.2.tar.xz#2646e7dc233362f59714c6193017bb2d6f7b38d6ab4a0cb5fbac5c36c4d845df" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.2" "https://www.python.org/ftp/python/3.8.2/Python-3.8.2.tgz#e634a7a74776c2b89516b2e013dda1728c89c8149b9863b8cea21946daf9d561" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.2" "https://www.python.org/ftp/python/3.8.2/Python-3.8.2.tgz#e634a7a74776c2b89516b2e013dda1728c89c8149b9863b8cea21946daf9d561" standard verify_py38 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.8.3
+++ b/plugins/python-build/share/python-build/3.8.3
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.3" "https://www.python.org/ftp/python/3.8.3/Python-3.8.3.tar.xz#dfab5ec723c218082fe3d5d7ae17ecbdebffa9a1aea4d64aa3a2ecdd2e795864" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.3" "https://www.python.org/ftp/python/3.8.3/Python-3.8.3.tar.xz#dfab5ec723c218082fe3d5d7ae17ecbdebffa9a1aea4d64aa3a2ecdd2e795864" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.3" "https://www.python.org/ftp/python/3.8.3/Python-3.8.3.tgz#6af6d4d2e010f9655518d0fc6738c7ff7069f10a4d2fbd55509e467f092a8b90" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.3" "https://www.python.org/ftp/python/3.8.3/Python-3.8.3.tgz#6af6d4d2e010f9655518d0fc6738c7ff7069f10a4d2fbd55509e467f092a8b90" standard verify_py38 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.8.4
+++ b/plugins/python-build/share/python-build/3.8.4
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.4" "https://www.python.org/ftp/python/3.8.4/Python-3.8.4.tar.xz#5f41968a95afe9bc12192d7e6861aab31e80a46c46fa59d3d837def6a4cd4d37" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.4" "https://www.python.org/ftp/python/3.8.4/Python-3.8.4.tar.xz#5f41968a95afe9bc12192d7e6861aab31e80a46c46fa59d3d837def6a4cd4d37" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.4" "https://www.python.org/ftp/python/3.8.4/Python-3.8.4.tgz#32c4d9817ef11793da4d0d95b3191c4db81d2e45544614e8449255ca9ae3cc18" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.4" "https://www.python.org/ftp/python/3.8.4/Python-3.8.4.tgz#32c4d9817ef11793da4d0d95b3191c4db81d2e45544614e8449255ca9ae3cc18" standard verify_py38 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.8.5
+++ b/plugins/python-build/share/python-build/3.8.5
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.5" "https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tar.xz#e3003ed57db17e617acb382b0cade29a248c6026b1bd8aad1f976e9af66a83b0" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.5" "https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tar.xz#e3003ed57db17e617acb382b0cade29a248c6026b1bd8aad1f976e9af66a83b0" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.5" "https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tgz#015115023c382eb6ab83d512762fe3c5502fa0c6c52ffebc4831c4e1a06ffc49" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.5" "https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tgz#015115023c382eb6ab83d512762fe3c5502fa0c6c52ffebc4831c4e1a06ffc49" standard verify_py38 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.8.6
+++ b/plugins/python-build/share/python-build/3.8.6
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.6" "https://www.python.org/ftp/python/3.8.6/Python-3.8.6.tar.xz#a9e0b79d27aa056eb9cce8d63a427b5f9bab1465dee3f942dcfdb25a82f4ab8a" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.6" "https://www.python.org/ftp/python/3.8.6/Python-3.8.6.tar.xz#a9e0b79d27aa056eb9cce8d63a427b5f9bab1465dee3f942dcfdb25a82f4ab8a" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.6" "https://www.python.org/ftp/python/3.8.6/Python-3.8.6.tgz#313562ee9986dc369cd678011bdfd9800ef62fbf7b1496228a18f86b36428c21" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.6" "https://www.python.org/ftp/python/3.8.6/Python-3.8.6.tgz#313562ee9986dc369cd678011bdfd9800ef62fbf7b1496228a18f86b36428c21" standard verify_py38 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.8.7
+++ b/plugins/python-build/share/python-build/3.8.7
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.7" "https://www.python.org/ftp/python/3.8.7/Python-3.8.7.tar.xz#ddcc1df16bb5b87aa42ec5d20a5b902f2d088caa269b28e01590f97a798ec50a" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.7" "https://www.python.org/ftp/python/3.8.7/Python-3.8.7.tar.xz#ddcc1df16bb5b87aa42ec5d20a5b902f2d088caa269b28e01590f97a798ec50a" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.7" "https://www.python.org/ftp/python/3.8.7/Python-3.8.7.tgz#20e5a04262f0af2eb9c19240d7ec368f385788bba2d8dfba7e74b20bab4d2bac" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.7" "https://www.python.org/ftp/python/3.8.7/Python-3.8.7.tgz#20e5a04262f0af2eb9c19240d7ec368f385788bba2d8dfba7e74b20bab4d2bac" standard verify_py38 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.8.8
+++ b/plugins/python-build/share/python-build/3.8.8
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1i" "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tar.xz#7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tar.xz#7c664249ff77e443d6ea0e4cf0e587eae918ca3c48d081d1915fe2a1f1bcc5cc" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tgz#76c0763f048e4f9b861d24da76b7dd5c7a3ba7ec086f40caedeea359263276f7" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.8" "https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tgz#76c0763f048e4f9b861d24da76b7dd5c7a3ba7ec086f40caedeea359263276f7" standard verify_py38 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.8.9
+++ b/plugins/python-build/share/python-build/3.8.9
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.9" "https://www.python.org/ftp/python/3.8.9/Python-3.8.9.tar.xz#5e391f3ec45da2954419cab0beaefd8be38895ea5ce33577c3ec14940c4b9572" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.9" "https://www.python.org/ftp/python/3.8.9/Python-3.8.9.tar.xz#5e391f3ec45da2954419cab0beaefd8be38895ea5ce33577c3ec14940c4b9572" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.9" "https://www.python.org/ftp/python/3.8.9/Python-3.8.9.tgz#9779ec1df000bf86914cdd40860b88da56c1e61db59d37784beca14a259ac9e9" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.9" "https://www.python.org/ftp/python/3.8.9/Python-3.8.9.tgz#9779ec1df000bf86914cdd40860b88da56c1e61db59d37784beca14a259ac9e9" standard verify_py38 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.9.0
+++ b/plugins/python-build/share/python-build/3.9.0
@@ -4,8 +4,8 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.9.0" "https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz#9c73e63c99855709b9be0b3cc9e5b072cb60f37311e8c4e50f15576a0bf82854" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.0" "https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz#9c73e63c99855709b9be0b3cc9e5b072cb60f37311e8c4e50f15576a0bf82854" standard verify_py39 copy_python_gdb ensurepip
 else
-    install_package "Python-3.9.0" "https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tgz#df796b2dc8ef085edae2597a41c1c0a63625ebd92487adaef2fed22b567873e8" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.0" "https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tgz#df796b2dc8ef085edae2597a41c1c0a63625ebd92487adaef2fed22b567873e8" standard verify_py39 copy_python_gdb ensurepip
 fi
 

--- a/plugins/python-build/share/python-build/3.9.1
+++ b/plugins/python-build/share/python-build/3.9.1
@@ -4,8 +4,8 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.9.1" "https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tar.xz#991c3f8ac97992f3d308fefeb03a64db462574eadbff34ce8bc5bb583d9903ff" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.1" "https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tar.xz#991c3f8ac97992f3d308fefeb03a64db462574eadbff34ce8bc5bb583d9903ff" standard verify_py39 copy_python_gdb ensurepip
 else
-    install_package "Python-3.9.1" "https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tgz#29cb91ba038346da0bd9ab84a0a55a845d872c341a4da6879f462e94c741f117" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.1" "https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tgz#29cb91ba038346da0bd9ab84a0a55a845d872c341a4da6879f462e94c741f117" standard verify_py39 copy_python_gdb ensurepip
 fi
 

--- a/plugins/python-build/share/python-build/3.9.2
+++ b/plugins/python-build/share/python-build/3.9.2
@@ -4,8 +4,8 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1i" "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.9.2" "https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tar.xz#3c2034c54f811448f516668dce09d24008a0716c3a794dd8639b5388cbde247d" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.2" "https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tar.xz#3c2034c54f811448f516668dce09d24008a0716c3a794dd8639b5388cbde247d" standard verify_py39 copy_python_gdb ensurepip
 else
-    install_package "Python-3.9.2" "https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tgz#7899e8a6f7946748830d66739f2d8f2b30214dad956e56b9ba216b3de5581519" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.2" "https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tgz#7899e8a6f7946748830d66739f2d8f2b30214dad956e56b9ba216b3de5581519" standard verify_py39 copy_python_gdb ensurepip
 fi
 

--- a/plugins/python-build/share/python-build/3.9.3
+++ b/plugins/python-build/share/python-build/3.9.3
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.9.3" "https://www.python.org/ftp/python/3.9.3/Python-3.9.3.tar.xz#30811039c65e04c14fc698e423947e464f9316e69fb44610bd38446046bb82b5" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.3" "https://www.python.org/ftp/python/3.9.3/Python-3.9.3.tar.xz#30811039c65e04c14fc698e423947e464f9316e69fb44610bd38446046bb82b5" standard verify_py39 copy_python_gdb ensurepip
 else
-    install_package "Python-3.9.3" "https://www.python.org/ftp/python/3.9.3/Python-3.9.3.tgz#3afeb61a45b5a2e6f1c0f621bd8cf925a4ff406099fdb3d8c97b993a5f43d048" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.3" "https://www.python.org/ftp/python/3.9.3/Python-3.9.3.tgz#3afeb61a45b5a2e6f1c0f621bd8cf925a4ff406099fdb3d8c97b993a5f43d048" standard verify_py39 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.9.4
+++ b/plugins/python-build/share/python-build/3.9.4
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.9.4" "https://www.python.org/ftp/python/3.9.4/Python-3.9.4.tar.xz#4b0e6644a76f8df864ae24ac500a51bbf68bd098f6a173e27d3b61cdca9aa134" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.4" "https://www.python.org/ftp/python/3.9.4/Python-3.9.4.tar.xz#4b0e6644a76f8df864ae24ac500a51bbf68bd098f6a173e27d3b61cdca9aa134" standard verify_py39 copy_python_gdb ensurepip
 else
-    install_package "Python-3.9.4" "https://www.python.org/ftp/python/3.9.4/Python-3.9.4.tgz#66c4de16daa74a825cf9da9ddae1fe020b72c3854b73b1762011cc33f9e4592f" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.4" "https://www.python.org/ftp/python/3.9.4/Python-3.9.4.tgz#66c4de16daa74a825cf9da9ddae1fe020b72c3854b73b1762011cc33f9e4592f" standard verify_py39 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.9.5
+++ b/plugins/python-build/share/python-build/3.9.5
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.9.5" "https://www.python.org/ftp/python/3.9.5/Python-3.9.5.tar.xz#0c5a140665436ec3dbfbb79e2dfb6d192655f26ef4a29aeffcb6d1820d716d83" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.5" "https://www.python.org/ftp/python/3.9.5/Python-3.9.5.tar.xz#0c5a140665436ec3dbfbb79e2dfb6d192655f26ef4a29aeffcb6d1820d716d83" standard verify_py39 copy_python_gdb ensurepip
 else
-    install_package "Python-3.9.5" "https://www.python.org/ftp/python/3.9.5/Python-3.9.5.tgz#e0fbd5b6e1ee242524430dee3c91baf4cbbaba4a72dd1674b90fda87b713c7ab" ldflags_dirs standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.5" "https://www.python.org/ftp/python/3.9.5/Python-3.9.5.tgz#e0fbd5b6e1ee242524430dee3c91baf4cbbaba4a72dd1674b90fda87b713c7ab" standard verify_py39 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/stackless-2.7.10
+++ b/plugins/python-build/share/python-build/stackless-2.7.10
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-dev-stackless-b6b4c928e880" "http://www.stackless.com/binaries/stackless-2710-export.tar.xz#8af1318f95965138de51e290a509dc3d" ldflags_dirs standard verify_py27 ensurepip
+install_package "stackless-dev-stackless-b6b4c928e880" "http://www.stackless.com/binaries/stackless-2710-export.tar.xz#8af1318f95965138de51e290a509dc3d" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.11
+++ b/plugins/python-build/share/python-build/stackless-2.7.11
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-dev-stackless-456e93659e69" "http://www.stackless.com/binaries/stackless-2711-export.tar.xz#d5229693498a4ccc0b3245f7bf8e2b09" ldflags_dirs standard verify_py27 ensurepip
+install_package "stackless-dev-stackless-456e93659e69" "http://www.stackless.com/binaries/stackless-2711-export.tar.xz#d5229693498a4ccc0b3245f7bf8e2b09" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.12
+++ b/plugins/python-build/share/python-build/stackless-2.7.12
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-dev-stackless-82aaa252fbdc" "http://www.stackless.com/binaries/stackless-2712-export.tar.xz#c610611b39ee374ae36e891c5c739f39" ldflags_dirs standard verify_py27 ensurepip
+install_package "stackless-dev-stackless-82aaa252fbdc" "http://www.stackless.com/binaries/stackless-2712-export.tar.xz#c610611b39ee374ae36e891c5c739f39" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.14
+++ b/plugins/python-build/share/python-build/stackless-2.7.14
@@ -2,4 +2,4 @@
 prefer_openssl11
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-2.7.14-slp" "https://github.com/stackless-dev/stackless/archive/v2.7.14-slp.tar.gz#e67f60984d034bfd80fef58d26df9d5a1cdecb429c55ac7bc8d932cff6f88ab8" ldflags_dirs standard verify_py27 ensurepip
+install_package "stackless-2.7.14-slp" "https://github.com/stackless-dev/stackless/archive/v2.7.14-slp.tar.gz#e67f60984d034bfd80fef58d26df9d5a1cdecb429c55ac7bc8d932cff6f88ab8" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.2
+++ b/plugins/python-build/share/python-build/stackless-2.7.2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-272-export" "http://www.stackless.com/binaries/stackless-272-export.tar.bz2#e2e2706b22839e3e3f45085d0ec8030dd7374d8a65d3297981b7189a7c613197" ldflags_dirs standard verify_py27 ensurepip
+install_package "stackless-272-export" "http://www.stackless.com/binaries/stackless-272-export.tar.bz2#e2e2706b22839e3e3f45085d0ec8030dd7374d8a65d3297981b7189a7c613197" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.3
+++ b/plugins/python-build/share/python-build/stackless-2.7.3
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-273-export" "http://www.stackless.com/binaries/stackless-273-export.tar.bz2#77bee863bfd16dc4eca7fc078b12db608db7dd6e2481981bb68250118e001dfc" ldflags_dirs standard verify_py27 ensurepip
+install_package "stackless-273-export" "http://www.stackless.com/binaries/stackless-273-export.tar.bz2#77bee863bfd16dc4eca7fc078b12db608db7dd6e2481981bb68250118e001dfc" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.4
+++ b/plugins/python-build/share/python-build/stackless-2.7.4
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-274-export" "http://www.stackless.com/binaries/stackless-274-export.tar.bz2#ba566b18c66b095b65addbcfc4d814fc84f163c9fcffa1d0678755c581e64f45" ldflags_dirs standard verify_py27 ensurepip
+install_package "stackless-274-export" "http://www.stackless.com/binaries/stackless-274-export.tar.bz2#ba566b18c66b095b65addbcfc4d814fc84f163c9fcffa1d0678755c581e64f45" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.5
+++ b/plugins/python-build/share/python-build/stackless-2.7.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-275-export" "http://www.stackless.com/binaries/stackless-275-export.tar.bz2#5a389357762b32c590e1154a86b098cc379c71d10238b458a3e9b4fa4aac60d4" ldflags_dirs standard verify_py27 ensurepip
+install_package "stackless-275-export" "http://www.stackless.com/binaries/stackless-275-export.tar.bz2#5a389357762b32c590e1154a86b098cc379c71d10238b458a3e9b4fa4aac60d4" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.6
+++ b/plugins/python-build/share/python-build/stackless-2.7.6
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-276-export" "http://www.stackless.com/binaries/stackless-276-export.tar.bz2#1e905deaf74e8922f49b99139aa48e6670e9456c55fec8e60c47501f78c38ff5" ldflags_dirs standard verify_py27 ensurepip
+install_package "stackless-276-export" "http://www.stackless.com/binaries/stackless-276-export.tar.bz2#1e905deaf74e8922f49b99139aa48e6670e9456c55fec8e60c47501f78c38ff5" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.7
+++ b/plugins/python-build/share/python-build/stackless-2.7.7
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-dev-stackless-a182f63395c3" "http://www.stackless.com/binaries/stackless-277-export.tar.bz2#4ac0a1e95bc12d6733d9e7f3c221ec4a" ldflags_dirs standard verify_py27 ensurepip
+install_package "stackless-dev-stackless-a182f63395c3" "http://www.stackless.com/binaries/stackless-277-export.tar.bz2#4ac0a1e95bc12d6733d9e7f3c221ec4a" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.8
+++ b/plugins/python-build/share/python-build/stackless-2.7.8
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-dev-stackless-ff29dd4f67de" "http://www.stackless.com/binaries/stackless-278-export.tar.bz2#2880f05e599020eb8f2624ce3796592b" ldflags_dirs standard verify_py27 ensurepip
+install_package "stackless-dev-stackless-ff29dd4f67de" "http://www.stackless.com/binaries/stackless-278-export.tar.bz2#2880f05e599020eb8f2624ce3796592b" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.9
+++ b/plugins/python-build/share/python-build/stackless-2.7.9
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-dev-stackless-43302de87df4" "http://www.stackless.com/binaries/stackless-279-export.tar.xz#35307558796389aa51d96b0bc83f6f6f" ldflags_dirs standard verify_py27 ensurepip
+install_package "stackless-dev-stackless-43302de87df4" "http://www.stackless.com/binaries/stackless-279-export.tar.xz#35307558796389aa51d96b0bc83f6f6f" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.2.2
+++ b/plugins/python-build/share/python-build/stackless-3.2.2
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-322-export" "http://www.stackless.com/binaries/stackless-322-export.tar.bz2#779700f12b451a350fe7af4cd2849842adc7006dc83fe14712dd1a0999277b07" ldflags_dirs standard verify_py32
+install_package "stackless-322-export" "http://www.stackless.com/binaries/stackless-322-export.tar.bz2#779700f12b451a350fe7af4cd2849842adc7006dc83fe14712dd1a0999277b07" standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/stackless-3.2.5
+++ b/plugins/python-build/share/python-build/stackless-3.2.5
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-325-export" "http://www.stackless.com/binaries/stackless-325-export.tar.bz2#b021125e578ddd267d38feee9e1cbdb675f6aab247a2b88f4494abcf23babb05" ldflags_dirs standard verify_py32
+install_package "stackless-325-export" "http://www.stackless.com/binaries/stackless-325-export.tar.bz2#b021125e578ddd267d38feee9e1cbdb675f6aab247a2b88f4494abcf23babb05" standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/stackless-3.3.5
+++ b/plugins/python-build/share/python-build/stackless-3.3.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-dev-stackless-c856cc204b1c" "http://www.stackless.com/binaries/stackless-335-export.tar.xz#d839295b932eb10443f2ddfecf2c25e9" ldflags_dirs standard verify_py33 ensurepip
+install_package "stackless-dev-stackless-c856cc204b1c" "http://www.stackless.com/binaries/stackless-335-export.tar.xz#d839295b932eb10443f2ddfecf2c25e9" standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.3.7
+++ b/plugins/python-build/share/python-build/stackless-3.3.7
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-3.3.7-slp" "https://github.com/stackless-dev/stackless/archive/v3.3.7-slp.tar.gz#f05b8ff8a0e318aa5880dc995518ab4453894d068a26a171b89e21b98da5a5c1" ldflags_dirs standard verify_py33 ensurepip
+install_package "stackless-3.3.7-slp" "https://github.com/stackless-dev/stackless/archive/v3.3.7-slp.tar.gz#f05b8ff8a0e318aa5880dc995518ab4453894d068a26a171b89e21b98da5a5c1" standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.4.2
+++ b/plugins/python-build/share/python-build/stackless-3.4.2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-dev-stackless-587417070fe4" "http://www.stackless.com/binaries/stackless-342-export.tar.xz#dd6ae57cc8a162690a24f21ce1f0c4d96e096c24e17137783bacc9182b96b6dc" ldflags_dirs standard verify_py34 ensurepip
+install_package "stackless-dev-stackless-587417070fe4" "http://www.stackless.com/binaries/stackless-342-export.tar.xz#dd6ae57cc8a162690a24f21ce1f0c4d96e096c24e17137783bacc9182b96b6dc" standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.4.7
+++ b/plugins/python-build/share/python-build/stackless-3.4.7
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-3.4.7-slp" "https://github.com/stackless-dev/stackless/archive/v3.4.7-slp.tar.gz#e41959afcfc9381cbc9ac14c12110e3e748e65ceeec4fe61fb1c34cabcb9e6bf" ldflags_dirs standard verify_py34 ensurepip
+install_package "stackless-3.4.7-slp" "https://github.com/stackless-dev/stackless/archive/v3.4.7-slp.tar.gz#e41959afcfc9381cbc9ac14c12110e3e748e65ceeec4fe61fb1c34cabcb9e6bf" standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.5.4
+++ b/plugins/python-build/share/python-build/stackless-3.5.4
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-3.5.4-slp" "https://github.com/stackless-dev/stackless/archive/v3.5.4-slp.tar.gz#ddb65a8118c754f66875f65c4d5d2a4937d67858ec8c361a6c5b386f5e4d9fce" ldflags_dirs standard verify_py35 ensurepip
+install_package "stackless-3.5.4-slp" "https://github.com/stackless-dev/stackless/archive/v3.5.4-slp.tar.gz#ddb65a8118c754f66875f65c4d5d2a4937d67858ec8c361a6c5b386f5e4d9fce" standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.7.5
+++ b/plugins/python-build/share/python-build/stackless-3.7.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "stackless-3.7.5-slp" "https://github.com/stackless-dev/stackless/archive/v3.7.5-slp.tar.gz#e2562a8d235adc19be5451c170837f53ef916aec4cd5cd17d9e0ab1f1b875d3f" ldflags_dirs standard verify_py37 ensurepip
+install_package "stackless-3.7.5-slp" "https://github.com/stackless-dev/stackless/archive/v3.7.5-slp.tar.gz#e2562a8d235adc19be5451c170837f53ef916aec4cd5cd17d9e0ab1f1b875d3f" standard verify_py37 ensurepip

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -561,16 +561,3 @@ OUT
   run python-build "${TMP}/build-definition" "$INSTALL_ROOT"
   assert_failure "python-build: TMPDIR=$TMPDIR is set to a non-accessible location"
 }
-
-@test "initializes LDFLAGS directories" {
-  cached_tarball "Python-3.6.2"
-
-  export LDFLAGS="-L ${BATS_TEST_DIRNAME}/what/evs"
-  run_inline_definition <<DEF
-install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz" ldflags_dirs
-DEF
-  assert_success
-
-  assert [ -d "${INSTALL_ROOT}/lib" ]
-  assert [ -d "${BATS_TEST_DIRNAME}/what/evs" ]
-}


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.

Can preserve the fn (that will now be unused) if that makes a difference.

* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/732

### Description
- [x] Here are some details about my PR

Ensuring that all dirs in LDFLAGS exist is only needed for Ruby due to its `configure` requirements.
If some LDFLAGS entries point to a nonexisting path to which the user doesn't have permission. this causes a build failure.

### Tests
- [x] My PR adds the following unit tests (if any)

Tested a few versions in Bionic to check that the build still works.