### PR TITLE
Set command name when PYENV_COMMAND_PATH is empty

### DIFF
--- a/libexec/pyenv-which
+++ b/libexec/pyenv-which
@@ -6,7 +6,7 @@
 #
 # Displays the full path to the executable that pyenv will invoke when
 # you run the given command.
-# Use --nosystem argument in case when you don't need to search command in the 
+# Use --nosystem argument in case when you don't need to search command in the
 # system environment.
 #
 
@@ -58,6 +58,10 @@ for version in "${versions[@]}" "$system"; do
     break
   fi
 done
+
+if [ -z "$PYENV_COMMAND_PATH" ] && [ ! -x "$PYENV_COMMAND" ]; then
+  PYENV_COMMAND_PATH="$PYENV_COMMAND"
+fi
 
 OLDIFS="$IFS"
 IFS=$'\n' scripts=(`pyenv-hooks which`)


### PR DESCRIPTION
### Description

When called, some hooks (e.g., pyenv-virtualenv) assume that `PYENV_COMMAND_PATH` contains a path ending with a command name (`PYENV_COMMAND`) and uses it to construct a command path to test for existence and executable bit. In cases where the assumption is broken, such a hook may set a directory to `PYENV_COMMAND_PATH`. Since the executable state of path in `PYENV_COMMAND_PATH` is done via `-x` (and not `-f` additionally), `pyenv-which` sometimes returns a path to directory and not to a command. 

The proposed patch avoid this issue by setting `PYENV_COMMAND_PATH` to `PYENV_COMMAND` when it is empty. However, this cannot be set as default since we want to avoid `PYENV_COMMAND_PATH` to point to a command in the current working directory.

### Tests

All existing tests pass.
