### PR TITLE
Update anaconda3-2021.05 - fixed checksum for macOS package

### DIFF
--- a/plugins/python-build/share/python-build/anaconda3-2021.05
+++ b/plugins/python-build/share/python-build/anaconda3-2021.05
@@ -6,7 +6,7 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
   install_script "Anaconda3-2021.05-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2021.05-Linux-x86_64.sh#2751ab3d678ff0277ae80f9e8a74f218cfc70fe9a9cdc7bb1c137d7e47e33d53" "anaconda" verify_py38
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda3-2021.05-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2021.05-MacOSX-x86_64.sh#ec11e325c792a6f49dbdbe5e641991d0a29788689176d7e54da97def9532c762" "anaconda" verify_py38
+  install_script "Anaconda3-2021.05-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2021.05-MacOSX-x86_64.sh#0407bee87eeecad521f1e38eb607b0a85babef4c1b47516dc5c090e152eba5d5" "anaconda" verify_py38
   ;;
 * )
   { echo


### PR DESCRIPTION
Fixed checksum for macos package

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Fixed checksum for macOS package

### Tests
- [ ] My PR adds the following unit tests (if any)
