### PR TITLE
Append Homebrew custom prefix to search path

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -766,6 +766,7 @@ build_package_standard_build() {
   local PACKAGE_CFLAGS="${package_var_name}_CFLAGS"
 
   if [ "$package_var_name" = "PYTHON" ]; then
+      fallback_to_homebrew
       use_homebrew_readline || use_freebsd_pkg || true
     if is_mac -ge 1014; then
       use_xcode_sdk_zlib || use_homebrew_zlib || true
@@ -1308,6 +1309,17 @@ configured_with_package_dir() {
     fi
   done
   return 1
+}
+
+fallback_to_homebrew() {
+  if is_mac; then
+    local brew_prefix="$(brew --prefix 2>/dev/null || true)"
+    # /usr/local/lib:/usr/lib is the default library search path
+    if [[ -n $brew_prefix && brew_prefix != "/usr" && brew_prefix != "/usr/local" ]]; then
+      export CPPFLAGS="${CPPFLAGS} -I${brew_prefix}/include"
+      export LDFLAGS="${CPPFLAGS} -L${brew_prefix}/lib"
+    fi
+  fi
 }
 
 needs_yaml() {


### PR DESCRIPTION
Needed to find other Python deps (e.g. libintl) in Homebrew if it has
nonstandard prefix (e.g. Apple ARM64)

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/1877

### Description
- [x] Here are some details about my PR

Apple M1 install Homebrew into `/opt/homebrew`.
If x64 Homebrew is installed as well, ARM64 Python build looks there for libs fisrt and tries to link with those for the other architecture, resulting in error.
Append paths so as not to override any user-supplied paths.

### Tests
- [ ] My PR adds the following unit tests (if any)
