### PR TITLE
Fixes README.md guide for fish shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ easy to fork and contribute any changes back upstream.
 
         And add this to `~/.config/fish/config.fish`:
         ~~~ fish
-        status is-login; and pyenv init --path | source
+        status is-login; and pyenv init --path fish | source
         ~~~
 
         If Fish is not your login shell, also follow the Bash/Zsh instructions to add to `~/.profile`.
@@ -309,7 +309,7 @@ easy to fork and contribute any changes back upstream.
       - For **Fish shell**:
         Add this to `~/.config/fish/config.fish`:
         ~~~ fish
-        pyenv init - | source
+        pyenv init - fish | source
         ~~~
 
       **General warning**: There are some systems where the `BASH_ENV` variable is configured


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
  **considered, but not applicable**
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project. (**not applicable**)
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - None - Thought it would be faster to just do the PR instead of mentioning the issue first

### Description
- [x] Here are some details about my PR

Tried to follow the setup instructions using fish, didn't work, so I went through the init script and noticed that with the parameter1 set to the shell in use, it used the fish commands instead of bash. That made it work. So I'm adjusting the README.md to make it easier for other fish users to get up and running with pyenv

### Tests
- [x] My PR adds the following unit tests (if any)
**none**