### PR TITLE
Windows 10 recognize shell

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -39,7 +39,7 @@ done
 
 shell="$1"
 if [ -z "$shell" ]; then
-  shell="$(ps -p "$PPID" -o 'args=' 2>/dev/null || true)"
+  shell="$(ps -p $PPID 2>/dev/null | awk 'END {print $NF}' 2>/dev/null)"
   shell="${shell%% *}"
   shell="${shell##-}"
   shell="${shell:-$SHELL}"

--- a/plugins/python-build/share/python-build/pyston-2.2
+++ b/plugins/python-build/share/python-build/pyston-2.2
@@ -6,7 +6,7 @@ echo
 
 case "$(pyston_architecture 2>/dev/null || true)" in
 "linux64" )
-  install_package "pyston_2.2" "https://github.com/pyston/pyston/releases/download/pyston_2.2/pyston_2.2_portable.tar.gz#d113cc4d1f6821c0f117f7a84978823d8ac751d7970fa7841eb994663ec5a59f" "pyston" verify_py38
+  install_package "pyston_2.2" "https://github.com/pyston/pyston/releases/download/pyston_2.2/pyston_2.2_portable.tar.gz#d113cc4d1f6821c0f117f7a84978823d8ac751d7970fa7841eb994663ec5a59f" "pyston" verify_py38 get_pip
   ;;
 * )
   { echo


### PR DESCRIPTION
As discussed in [this pullrequest](https://github.com/pyenv/pyenv/pull/1960), pyenv can't correctly identify what shell it is running on windows 10, since the `ps -o` option is missing there.

This fix uses `awk` instead of the `-o` option. We could also check if the `-o` option worked (check if `$shell` is empty before using awk fallback), if you would want that instead of the current version, just tell me :)