### PR TITLE
Fixes recognizing shell on windows10

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -39,7 +39,7 @@ done
 
 shell="$1"
 if [ -z "$shell" ]; then
-  shell="$(ps -p "$PPID" -o 'args=' 2>/dev/null || true)"
+  shell="$(ps -p $PPID 2>/dev/null | awk 'END {print $NF}' 2>/dev/null)"
   shell="${shell%% *}"
   shell="${shell##-}"
   shell="${shell:-$SHELL}"

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -39,7 +39,10 @@ done
 
 shell="$1"
 if [ -z "$shell" ]; then
-  shell="$(ps -p $PPID 2>/dev/null | awk 'END {print $NF}' 2>/dev/null)"
+  shell="$(ps -p "$PPID" -o 'args=' 2>/dev/null || true)"
+  if [ -z "$shell" ]; then
+    shell="$(ps -p $PPID 2>/dev/null | awk 'END {print $NF}' 2>/dev/null)"
+  fi
   shell="${shell%% *}"
   shell="${shell##-}"
   shell="${shell:-$SHELL}"


### PR DESCRIPTION
As discussed in [this pullrequest](https://github.com/pyenv/pyenv/pull/1960), pyenv can't correctly identify what shell it is running on windows 10, since the `ps -o` option is missing there.

This fix uses `awk` instead of the `-o` option. We could also check if the `-o` option worked (check if `$shell` is empty before using awk fallback), if you would want that instead of the current version, just tell me :)