### PR TITLE
Add explicit Zsh instructions for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ easy to fork and contribute any changes back upstream.
       to add the `PYENV_ROOT=` and `PATH=` lines.
       You also don't need to add commands into `~/.profile` if your shell doesn't use it.
    
-      - For **bash**:
+      - For **Bash**:
 
          ~~~ bash
          echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.profile

--- a/README.md
+++ b/README.md
@@ -263,8 +263,24 @@ easy to fork and contribute any changes back upstream.
 
       - For **Zsh**:
 
-        Same as for Bash above, but add the commands into both `~/.profile`
-        and `~/.zprofile`.
+         - **MacOS, if Pyenv is installed with Homebrew:**
+
+            ~~~ zsh
+            echo 'eval "$(pyenv init --path)"' >> ~/.zprofile
+            ~~~
+         
+         - **MacOS, if Pyenv is installed with a Git checkout:**
+         
+            ~~~ zsh
+            echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zprofile
+            echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zprofile
+            echo 'eval "$(pyenv init --path)"' >> ~/.zprofile
+            ~~~
+
+         - **Other OSes:**
+         
+           Same as for Bash above, but add the commands into both `~/.profile`
+           and `~/.zprofile`.
         
       - For **Fish shell**:
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes #1947
  - Closes #1948

### Description
- [x] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)
