### PR TITLE
Fix .bashrc `echo` install syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ easy to fork and contribute any changes back upstream.
         - **If your `/etc/profile` sources `~/.bashrc` (SUSE):**
         
           ~~~bash
-          echo 'if command -v pyenv >/dev/null; then eval "$(pyenv init -)"; done' >> ~/.bashrc 
+          echo 'if command -v pyenv >/dev/null; then eval "$(pyenv init -)"; fi' >> ~/.bashrc 
           ~~~
 
       - For **Zsh**:


### PR DESCRIPTION
Change `done` to `fi` since otherwise Bash emits an unexpected token error:

```
bash: /home/foo/.bashrc: line 120: syntax error near unexpected token `done'
bash: /home/foo/.bashrc: line 120: `if command -v pyenv >/dev/null; then eval "$(pyenv init -)"; done'
```
