### PR TITLE
Use system Python3 for tests

### DIFF
--- a/test/exec.bats
+++ b/test/exec.bats
@@ -79,37 +79,37 @@ OUT
 }
 
 @test "sys.executable with system version (#98)" {
-  system_python=$(which python)
+  system_python=$(which python3)
 
   PYENV_VERSION="custom"
-  create_executable "python" ""
+  create_executable "python3" ""
   unset PYENV_VERSION
 
   pyenv-rehash
-  run pyenv-exec python -c 'import sys; print(sys.executable)'
+  run pyenv-exec python3 -c 'import sys; print(sys.executable)'
   assert_success "${system_python}"
 }
 
 @test 'PATH is not modified with system Python' {
   # Create a wrapper executable that verifies PATH.
   PYENV_VERSION="custom"
-  create_executable "python" '[[ "$PATH" == "${PYENV_TEST_DIR}/root/versions/custom/bin:"* ]] || { echo "unexpected:$PATH"; exit 2;}'
+  create_executable "python3" '[[ "$PATH" == "${PYENV_TEST_DIR}/root/versions/custom/bin:"* ]] || { echo "unexpected:$PATH"; exit 2;}'
   unset PYENV_VERSION
   pyenv-rehash
 
   # Path is not modified with system Python.
-  run pyenv-exec python -c 'import os; print(os.getenv("PATH"))'
+  run pyenv-exec python3 -c 'import os; print(os.getenv("PATH"))'
   assert_success "$PATH"
 
   # Path is modified with custom Python.
-  PYENV_VERSION=custom run pyenv-exec python
+  PYENV_VERSION=custom run pyenv-exec python3
   assert_success
 
   # Path is modified with custom:system Python.
-  PYENV_VERSION=custom:system run pyenv-exec python
+  PYENV_VERSION=custom:system run pyenv-exec python3
   assert_success
 
   # Path is not modified with system:custom Python.
-  PYENV_VERSION=system:custom run pyenv-exec python -c 'import os; print(os.getenv("PATH"))'
+  PYENV_VERSION=system:custom run pyenv-exec python3 -c 'import os; print(os.getenv("PATH"))'
   assert_success "$PATH"
 }


### PR DESCRIPTION
PEP 394 now doesn't require `python` presence or specify what it is.
Tests that invoke it use Py3-specific code.

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
