### PR TITLE
Update mtime of shims with their targets

### DIFF
--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -110,6 +110,20 @@ make_shims() {
   done
 }
 
+copy_mtime_for_shims() {
+  local version file shim
+  pyenv-versions --bare --skip-aliases | \
+  while read -r version; do
+    for file in "${PYENV_ROOT}/versions/${version}/bin/"*; do
+      shim="${PYENV_ROOT}/shims/${file##*/}"
+      if [ "$file" -nt "$shim" ]; then
+        # Copy the newer timestamp; `touch -r` is defined by POSIX.
+        touch -r "$file" "$shim"
+      fi
+    done
+  done
+}
+
 if ((${BASH_VERSINFO[0]} > 3)); then
 
   declare -A registered_shims
@@ -188,3 +202,5 @@ done
 
 install_registered_shims
 remove_stale_shims
+
+copy_mtime_for_shims

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -63,6 +63,17 @@ python
 OUT
 }
 
+@test "updates mtime" {
+  create_executable "3.4" "a"
+  create_executable "3.4" "b"
+  pyenv-rehash
+
+  create_executable "3.4" "b"
+  pyenv-rehash
+  run test "${PYENV_ROOT}/shims/b" -nt "${PYENV_ROOT}/shims/a"
+  assert_success
+}
+
 @test "removes stale shims" {
   mkdir -p "${PYENV_ROOT}/shims"
   touch "${PYENV_ROOT}/shims/oldshim1"


### PR DESCRIPTION
### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/1980

### Description
- [x] Here are some details about my PR

This PR adds a step at the end of pyenv-rehash to update mtimes of shims, where appropriate:

1. List the full paths of all executables under `$PYENV_ROOT/versions/*/bin`.
2. For each of these executables:
3. Determine the full path of the corresponding shim (`$PYENV_ROOT/shims/$basename`)
4. If the executable is newer than the shim, copy its timestamp to the shim.

Step 4 uses bash's builtin `test -nt` to compare mtimes, and `touch -r` to copy the mtime. Note that `touch -r` is specified by POSIX. I have explicitly checked support for `touch -r` on Linux (GNU coreutils), FreeBSD, and MacOS.

### Tests
- [x] My PR adds the following unit tests (if any)
  - Add test that rehash updates mtime
