### PR TITLE
Revert "Drop inferring version to install from `pyenv local`"

### DIFF
--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -115,7 +115,12 @@ done
 
 unset VERSION_NAME
 
+# The first argument contains the definition to install. If the
+# argument is missing, try to install whatever local app-specific
+# version is specified by pyenv. Show usage instructions if a local
+# version is not specified.
 DEFINITION="${ARGUMENTS[0]}"
+[ -n "$DEFINITION" ] || DEFINITION="$(pyenv-local 2>/dev/null || true)"
 [ -n "$DEFINITION" ] || usage 1 >&2
 
 # Define `before_install` and `after_install` functions that allow

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -23,6 +23,17 @@ stub_python_build() {
   unstub pyenv-rehash
 }
 
+@test "install pyenv local version by default" {
+  stub_python_build 'echo python-build "$1"'
+  stub pyenv-local 'echo 3.4.2'
+
+  run pyenv-install
+  assert_success "python-build 3.4.2"
+
+  unstub python-build
+  unstub pyenv-local
+}
+
 @test "list available versions" {
   stub_python_build \
     "--definitions : echo 2.6.9 2.7.9-rc1 2.7.9-rc2 3.4.2 | tr ' ' $'\\n'"


### PR DESCRIPTION
Reverts pyenv/pyenv#1907

Reopens https://github.com/pyenv/pyenv/issues/919

Closes https://github.com/pyenv/pyenv/issues/1975

---

I misread https://github.com/pyenv/pyenv/blob/1706436faeaf1aa439cf4ef5852707c8388f5155/plugins/python-build/bin/pyenv-install#L114, I thought it falls back to help when no arguments are given. It does not. So `pyenv install` does still trigger the inferring logic when no arguments are given (and @anton-petrov who merged #1907 was none the wiser, too :frowning_face: ).