### PR TITLE
#1813 fix broken feature.

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -62,6 +62,24 @@ else
 fi
 export PYENV_ROOT
 
+# Transfer PYENV_FILE_ARG (from shims) into PYENV_DIR.
+if [ -z "${PYENV_DIR}" ]; then
+  if [ -n "${PYENV_FILE_ARG}" ]; then
+    if [ -L "${PYENV_FILE_ARG}" ]; then
+      PYENV_DIR="$(abs_dirname "${PYENV_FILE_ARG}")"
+    else
+      PYENV_DIR="${PYENV_FILE_ARG%/*}"
+    fi
+    export PYENV_DIR
+    unset PYENV_FILE_ARG
+  fi
+else
+  [[ $PYENV_DIR == /* ]] || PYENV_DIR="$PWD/$PYENV_DIR"
+  cd "$PYENV_DIR" 2>/dev/null || abort "cannot change working directory to \`$PYENV_DIR'"
+  PYENV_DIR="$PWD"
+  cd "$OLDPWD"
+fi
+
 if [ -z "${PYENV_DIR}" ]; then
   PYENV_DIR="$PWD"
 fi

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -68,6 +68,19 @@ set -e
 [ -n "\$PYENV_DEBUG" ] && set -x
 
 program="\${0##*/}"
+if [[ "\$program" = "python"* ]]; then
+  for arg; do
+    case "\$arg" in
+    -c* | -- ) break ;;
+    */* )
+      if [ -f "\$arg" ]; then
+        export PYENV_FILE_ARG="\$arg"
+        break
+      fi
+      ;;
+    esac
+  done
+fi
 
 export PYENV_ROOT="$PYENV_ROOT"
 exec "$(command -v pyenv)" exec "\$program" "\$@"


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/1813

### Description
- [x] Here are some details about my PR
I found the last working version is v1.2.22. 
here is compare: https://github.com/pyenv/pyenv/compare/v1.2.22..v2.0.1
Please note the differences in these files:
- [libexec/pyenv](https://github.com/pyenv/pyenv/compare/v1.2.22..v2.0.1#diff-6e0affde5e4632aed5256a2023513fafbd3ea40461aa43b5c25e9b5fbd162fd9L64-L81)
- [libexec/pyenv-rehash](https://github.com/pyenv/pyenv/compare/v1.2.22..v2.0.1#diff-d3c2d85854e3a3d7b26f048786b17e8a94e775cf7b58f3a11caab9817fedaa29L70-L82)

### Tests

test-pyenv.py
```python
#!/usr/bin/env python

import sys

print("script:", __file__)

print("Python version")
print (sys.version)

print("Version info.")
print (sys.version_info)
```

test script (fish)
```fish
for ver in system 3.6.13 3.7.10 3.8.10 3.9.5
  echo "##### $ver #####"
  mkdir -p $ver
  cp test-pyenv.py $ver
  pushd $ver
  pyenv local $ver
  popd
  # run script out of directory
  $ver/test-pyenv.py
end
```

Result:
```
##### system #####
('script:', 'system/test-pyenv.py')
Python version
2.7.16 (default, May  8 2021, 11:48:02)
[GCC Apple LLVM 12.0.5 (clang-1205.0.19.59.6) [+internal-os, ptrauth-isa=deploy
Version info.
sys.version_info(major=2, minor=7, micro=16, releaselevel='final', serial=0)
##### 3.6.13 #####
script: 3.6.13/test-pyenv.py
Python version
3.6.13 (default, Jun 18 2021, 12:05:19)
[GCC Apple LLVM 12.0.5 (clang-1205.0.22.9)]
Version info.
sys.version_info(major=3, minor=6, micro=13, releaselevel='final', serial=0)
##### 3.7.10 #####
script: 3.7.10/test-pyenv.py
Python version
3.7.10 (default, Jun 18 2021, 17:34:04)
[Clang 12.0.5 (clang-1205.0.22.9)]
Version info.
sys.version_info(major=3, minor=7, micro=10, releaselevel='final', serial=0)
##### 3.8.10 #####
script: 3.8.10/test-pyenv.py
Python version
3.8.10 (default, Jun 18 2021, 17:28:52)
[Clang 12.0.5 (clang-1205.0.22.9)]
Version info.
sys.version_info(major=3, minor=8, micro=10, releaselevel='final', serial=0)
##### 3.9.5 #####
script: /Users/kzhang/Documents/workspaces/MyWorkspace/pyenv-tests/3.9.5/test-pyenv.py
Python version
3.9.5 (default, Jun 18 2021, 11:18:55)
[Clang 12.0.5 (clang-1205.0.22.9)]
Version info.
sys.version_info(major=3, minor=9, micro=5, releaselevel='final', serial=0)
```