### PR TITLE
Suggest that fish users init in interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ easy to fork and contribute any changes back upstream.
 
         And add this to `~/.config/fish/config.fish`:
         ~~~ fish
-        status is-login; and pyenv init --path | source
+        status is-interactive; and pyenv init --path | source
         ~~~
 
         If Fish is not your login shell, also follow the Bash/Zsh instructions to add to `~/.profile`.

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -109,7 +109,7 @@ function help_() {
       echo "# Load pyenv automatically by appending"
       echo "# the following to ~/.config/fish/config.fish:"
       echo
-      echo 'status is-login; and pyenv init --path | source'
+      echo 'status is-interactive; and pyenv init --path | source'
       echo 'pyenv init - | source'
       echo
       echo "# If fish is not your login shell,"


### PR DESCRIPTION
...rather than login mode.

I couldn't get rid of the warning that `pyenv init -` no longer sets path until I did this. It looks like setting only on the login shell wasn't enough to hide the warning in other shells I opened. This fits with [how rbenv does the same thing](https://github.com/rbenv/rbenv/blob/master/libexec/rbenv-init#L74).

I'm way out of my depth here, so someone who knows about shell types should definitely review this.