### PR TITLE
Remove PATH warning

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -61,7 +61,6 @@ function main() {
     ;;
   "print")
     init_dirs
-    warn_path
     print_env
     print_completion
     print_shell_function
@@ -173,13 +172,6 @@ function print_path() {
       echo 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
       ;;
   esac
-}
-
-function warn_path() {
-  if ! [[ ":${PATH}:" == *":${PYENV_ROOT}/shims:"* ]] ; then
-    echo 'echo '\''WARNING: `pyenv init -` no longer sets PATH.'\'
-    echo 'echo '\''Run `pyenv init` to see the necessary changes to make to your configuration.'\'
-  fi
 }
 
 function print_env() {

--- a/test/init.bats
+++ b/test/init.bats
@@ -90,13 +90,6 @@ OUT
   assert_line 0 "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
 }
 
-@test "prints a warning if shims not in PATH" {
-  export PATH="$(perl -0x3A -ls -e 'while (<>) { chomp; ($_ ne $d) && print; }' -- -d="${PYENV_ROOT}/shims" <<<"$PATH")"
-  run pyenv-init -
-  assert_success
-  assert_line 0 'echo '\''WARNING: `pyenv init -` no longer sets PATH.'\'
-}
-
 @test "outputs sh-compatible syntax" {
   run pyenv-init - bash
   assert_success


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

* In some cases (Ubuntu), `pyenv init -` has to be run before `pyenv init --path` (https://github.com/pyenv/pyenv/discussions/1974).
* The warning has served its purpose by now.


### Tests
- [ ] My PR adds the following unit tests (if any)
