### PR TITLE
Fix install path issue for shims in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ easy to fork and contribute any changes back upstream.
          
             ~~~ zsh
             echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zprofile
-            echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zprofile
+            echo 'export PATH="$PYENV_ROOT/shims:$PATH"' >> ~/.zprofile
             echo 'eval "$(pyenv init --path)"' >> ~/.zprofile
             ~~~
 


### PR DESCRIPTION
### This is not necessarily a typo in the docs, it needs reviewing by a maintainer to ensure my problem is not specific to my installation

I think there is a mistake in the doc. Not sure why but the install path wasn't correct in my machine (macOS, installed with home-brew). This line is repeated for every possible install platform and it might be needed to update them as well. 

```bash
before:
            echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zprofile
after:
            echo 'export PATH="$PYENV_ROOT/shims:$PATH"' >> ~/.zprofile
```