### PR TITLE
Adapt conda.bash for bash associative array

### DIFF
--- a/pyenv.d/rehash/conda.bash
+++ b/pyenv.d/rehash/conda.bash
@@ -34,14 +34,22 @@ make_shims() {
 }
 
 deregister_conda_shims() {
-  local shim
-  local shims=()
-  for shim in ${registered_shims}; do
-    if ! conda_shim "${shim}" 1>&2; then
-      shims[${#shims[*]}]="${shim}"
-    fi
-  done
-  registered_shims=" ${shims[@]} "
+  if [[ -v registered_shims[@] ]]; then # adapted for Bash 4.x's associative array (#1749)
+    for shim in ${!registered_shims[*]}; do
+      if conda_shim "${shim}" 1>&2; then
+        unset registered_shims[${shim}]
+      fi
+    done
+  else
+    local shim
+    local shims=()
+    for shim in ${registered_shims}; do
+      if ! conda_shim "${shim}" 1>&2; then
+        shims[${#shims[*]}]="${shim}"
+      fi
+    done
+    registered_shims=" ${shims[@]} "
+  fi
 }
 
 if conda_exists; then


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.

### Description
- [x] Here are some details about my PR
In #1749 , we move to use associative array on bash >= 4. However, rehash's hook conda.bash are not adapted, thus rendering pyenv's shim rehash filtering for conda useless.

### Tests
- [x] My PR adds the following unit tests (if any)
