### PR TITLE
Prevent duplicated shims in PATH variable

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -84,13 +84,16 @@ fi
 
 mkdir -p "${PYENV_ROOT}/"{shims,versions}
 
+no_path=1
+[[ ":${PATH}:" != *":${PYENV_ROOT}/shims:"* ]] && no_path=""
+
 case "$shell" in
 fish )
-  echo "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
+  [[ -z "$no_path" ]] && echo "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
   echo "set -gx PYENV_SHELL $shell"
 ;;
 * )
-  echo 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
+  [[ -z "$no_path" ]] && echo 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
   echo "export PYENV_SHELL=$shell"
 ;;
 esac

--- a/test/init.bats
+++ b/test/init.bats
@@ -76,18 +76,18 @@ OUT
   assert_line 0 "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
 }
 
-@test "can add shims to PATH more than once" {
+@test "does not add shims to PATH more than once" {
   export PATH="${PYENV_ROOT}/shims:$PATH"
   run pyenv-init - bash
   assert_success
-  assert_line 0 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
+  refute_line 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
 }
 
-@test "can add shims to PATH more than once (fish)" {
+@test "does not add shims to PATH more than once (fish)" {
   export PATH="${PYENV_ROOT}/shims:$PATH"
   run pyenv-init - fish
   assert_success
-  assert_line 0 "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
+  refute_line "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
 }
 
 @test "outputs sh-compatible syntax" {


### PR DESCRIPTION
This happens when someone adds the shims folder to the PATH variable manually.

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
