### PR TITLE
Add space after `yes/no` prompt

### DIFF
--- a/plugins/python-build/bin/pyenv-uninstall
+++ b/plugins/python-build/bin/pyenv-uninstall
@@ -69,7 +69,7 @@ if [ -z "$FORCE" ]; then
     exit 1
   fi
 
-  read -p "pyenv: remove $PREFIX? [y|N]"
+  read -p "pyenv: remove $PREFIX? [y|N] "
   case "$REPLY" in
   y | Y | yes | YES ) ;;
   * ) exit 1 ;;


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

![image](https://user-images.githubusercontent.com/11611397/130412367-2c4ee775-f298-4950-9b1d-476e51001a5e.png)

There is no space between [y|N] and user input when using `pyenv-uninstall` which looks somewhat weird, whereas `pyenv-install` has space.

https://github.com/pyenv/pyenv/blob/8b60418361e29d30fbe7ee3133e57f4d351464da/plugins/python-build/bin/pyenv-install#L160

Also the style is slightly different (`pyenv-install (y/N), pyenv-uninstall [y|N]`) but um I think it's not a big deal. Well, this PR is not a big deal actually.


### Tests
- [ ] My PR adds the following unit tests (if any)
