### PR TITLE
Prevent addition of duplicate plugin dirs to PATH

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -77,9 +77,12 @@ export PYENV_DIR
 shopt -s nullglob
 
 bin_path="$(abs_dirname "$0")"
-for plugin_bin in "${bin_path%/*}"/plugins/*/bin; do
-  PATH="${plugin_bin}:${PATH}"
-done
+if [ "${bin_path%/*}" != "$PYENV_ROOT" ]; then
+  # Add the plugins paths for bin_path if it isn't in $PYENV_ROOT
+  for plugin_bin in "${bin_path%/*}"/plugins/*/bin; do
+    PATH="${plugin_bin}:${PATH}"
+  done
+fi
 for plugin_bin in "${PYENV_ROOT}"/plugins/*/bin; do
   PATH="${plugin_bin}:${PATH}"
 done

--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -77,15 +77,16 @@ export PYENV_DIR
 shopt -s nullglob
 
 bin_path="$(abs_dirname "$0")"
+for plugin_bin in "${bin_path%/*}"/plugins/*/bin; do
+  PATH="${plugin_bin}:${PATH}"
+done
+# PYENV_ROOT can be set to anything, so it may happen to be equal to the base path above,
+# resulting in duplicate PATH entries
 if [ "${bin_path%/*}" != "$PYENV_ROOT" ]; then
-  # Add the plugins paths for bin_path if it isn't in $PYENV_ROOT
-  for plugin_bin in "${bin_path%/*}"/plugins/*/bin; do
+  for plugin_bin in "${PYENV_ROOT}"/plugins/*/bin; do
     PATH="${plugin_bin}:${PATH}"
   done
 fi
-for plugin_bin in "${PYENV_ROOT}"/plugins/*/bin; do
-  PATH="${plugin_bin}:${PATH}"
-done
 export PATH="${bin_path}:${PATH}"
 
 PYENV_HOOK_PATH="${PYENV_HOOK_PATH}:${PYENV_ROOT}/pyenv.d"


### PR DESCRIPTION
### Description
- [x ] Here are some details about my PR

`libexec/pyenv` adds the `.../plugins/*/bin` directories to the PATH. This leads to duplicated PATH entries when `bin_path` is the same as `PYENV_ROOT`.

This PR simply checks if `bin_path` != `PYENV_ROOT` before adding the bin_path `plugins/*/bin` directories to PATH

### Tests
- [ ] My PR adds the following unit tests (if any)

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
  * _This is a trivial bug in libexe/pyenv and, therefore, not amenable to either a hook script or a plugin_
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
  *  _I checked rbenv and this code is specific to a difference between rbenv and pyenv, specifically: pyenv adds the bin_path plugins/*/bin directories, while rbenv does not_

* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX
  - _No existing pyenv issue_


