### PR TITLE
Fix build of ossaudiodev in Linux/FreeBSD for Python 3.1

### DIFF
--- a/plugins/python-build/share/python-build/patches/3.1.0/Python-3.1/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/3.1.0/Python-3.1/000_patch-setup.py.diff
@@ -43,3 +43,13 @@ diff -r -u ../Python-3.1/setup.py ./setup.py
  
          # Add paths specified in the environment variables LDFLAGS and
          # CPPFLAGS for header and library files.
+@@ -1203,8 +1203,7 @@
+         # End multiprocessing
+ 
+         # Platform-specific libraries
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')

--- a/plugins/python-build/share/python-build/patches/3.1.1/Python-3.1.1/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/3.1.1/Python-3.1.1/000_patch-setup.py.diff
@@ -43,3 +43,13 @@ diff -r -u ../Python-3.1/setup.py ./setup.py
  
          # Add paths specified in the environment variables LDFLAGS and
          # CPPFLAGS for header and library files.
+@@ -1203,8 +1203,7 @@
+         # End multiprocessing
+ 
+         # Platform-specific libraries
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')

--- a/plugins/python-build/share/python-build/patches/3.1.2/Python-3.1.2/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/3.1.2/Python-3.1.2/000_patch-setup.py.diff
@@ -43,3 +43,13 @@ diff -r -u ../Python-3.1/setup.py ./setup.py
  
          # Add paths specified in the environment variables LDFLAGS and
          # CPPFLAGS for header and library files.
+@@ -1207,8 +1207,7 @@
+         # End multiprocessing
+ 
+         # Platform-specific libraries
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')

--- a/plugins/python-build/share/python-build/patches/3.1.3/Python-3.1.3/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/3.1.3/Python-3.1.3/000_patch-setup.py.diff
@@ -44,4 +44,13 @@ diff -r -u setup.py setup.py
  
          # Add paths specified in the environment variables LDFLAGS and
          # CPPFLAGS for header and library files.
-
+@@ -1321,8 +1321,7 @@
+         # End multiprocessing
+ 
+         # Platform-specific libraries
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')

--- a/plugins/python-build/share/python-build/patches/3.1.4/Python-3.1.4/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/3.1.4/Python-3.1.4/000_patch-setup.py.diff
@@ -1,0 +1,12 @@
+--- setup.py.orig	2012-04-10 01:25:37.000000000 +0200
++++ setup.py	2021-09-03 10:16:58.575042300 +0200
+@@ -1344,8 +1344,7 @@
+         # End multiprocessing
+ 
+         # Platform-specific libraries
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')

--- a/plugins/python-build/share/python-build/patches/3.1.5/Python-3.1.5/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/3.1.5/Python-3.1.5/000_patch-setup.py.diff
@@ -1,0 +1,12 @@
+--- setup.py.orig	2012-04-10 01:25:37.000000000 +0200
++++ setup.py	2021-09-03 10:16:58.575042300 +0200
+@@ -1344,8 +1344,7 @@
+         # End multiprocessing
+ 
+         # Platform-specific libraries
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [X] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [X] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [X] Here are some details about my PR

This pull request updates the patches for the Python 3.1.x series to fix the build of `ossaudiodev` under recent GNU/Linux distributions.

With the normal `setup.py`, the installation of the `ossaudiodev` module is skipped under GNU/Linux with newer kernel versions because Python 3.1 appends the major kernel version to the result of `build_ext.get_platform` and later `ossaudiodev` is skipped if the major kernel version is not 2. A similar problem might occur if installing in FreeBSD but because `build_ext.get_platform` appends the FreeBSD major release version number.

This problem may even occur if installing Python 3.1.x in a Docker image of an old distribution (e.g. prehistoric Debian or CentOS), because the major kernel version is still the one of the host system.

The solution is to use `str.startswith` and only check that the platform starts with 'linux' or 'freebsd'.

----

I attach one example of `python-build` log before and after the proposed changes when installing Python 3.1.5 using an ancient Debian GNU/Linux Docker image with recent Ubuntu as host (Linux kernel major version 5):
[pybuild_3.1.5_without_patch.log](https://github.com/pyenv/pyenv/files/7105078/pybuild_3.1.5_without_patch.log)
[pybuild_3.1.5_with_patch.log](https://github.com/pyenv/pyenv/files/7105073/pybuild_3.1.5_with_patch.log)

So before the proposed changes:
```
building dbm using gdbm

Python build finished, but the necessary bits to build these modules were not found:
_tkinter           ossaudiodev                        
To find the necessary bits, look in setup.py in detect_modules() for the module's name.
```

After the proposed changes:
```
building dbm using gdbm

Python build finished, but the necessary bits to build these modules were not found:
_tkinter                                              
To find the necessary bits, look in setup.py in detect_modules() for the module's name.
```

The missing `_tkinter` from the logs is an expected result because my test was performed without adding the `tk-dev` headers, it plays no role in this pull request.

I made equivalent tests with the other versions from the Python 3.1.x series and the behaviour is identical.

### Tests
- [ ] My PR adds the following unit tests (if any)
