### PR TITLE
Fix build of ossaudiodev in Linux/FreeBSD for Python 2.6

### DIFF
--- a/plugins/python-build/share/python-build/patches/2.6.6/Python-2.6.6/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/2.6.6/Python-2.6.6/000_patch-setup.py.diff
@@ -44,4 +44,20 @@ diff -r -u setup.py setup.py
  
          # Add paths specified in the environment variables LDFLAGS and
          # CPPFLAGS for header and library files.
-
+@@ -1443,14 +1443,13 @@
+ 
+ 
+         # Platform-specific libraries
+-        if platform == 'linux2':
++        if platform.startswith('linux'):
+             # Linux-specific modules
+             exts.append( Extension('linuxaudiodev', ['linuxaudiodev.c']) )
+         else:
+             missing.append('linuxaudiodev')
+ 
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')

--- a/plugins/python-build/share/python-build/patches/2.6.7/Python-2.6.7/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/2.6.7/Python-2.6.7/000_patch-setup.py.diff
@@ -44,4 +44,20 @@ diff -r -u setup.py setup.py
  
          # Add paths specified in the environment variables LDFLAGS and
          # CPPFLAGS for header and library files.
-
+@@ -1443,14 +1443,13 @@
+ 
+ 
+         # Platform-specific libraries
+-        if platform == 'linux2':
++        if platform.startswith('linux'):
+             # Linux-specific modules
+             exts.append( Extension('linuxaudiodev', ['linuxaudiodev.c']) )
+         else:
+             missing.append('linuxaudiodev')
+ 
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')

--- a/plugins/python-build/share/python-build/patches/2.6.8/Python-2.6.8/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/2.6.8/Python-2.6.8/000_patch-setup.py.diff
@@ -44,4 +44,20 @@ diff -r -u setup.py setup.py
  
          # Add paths specified in the environment variables LDFLAGS and
          # CPPFLAGS for header and library files.
-
+@@ -1443,14 +1443,13 @@
+ 
+ 
+         # Platform-specific libraries
+-        if platform == 'linux2':
++        if platform.startswith('linux'):
+             # Linux-specific modules
+             exts.append( Extension('linuxaudiodev', ['linuxaudiodev.c']) )
+         else:
+             missing.append('linuxaudiodev')
+ 
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')

--- a/plugins/python-build/share/python-build/patches/2.6.9/Python-2.6.9/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/2.6.9/Python-2.6.9/000_patch-setup.py.diff
@@ -44,4 +44,20 @@ diff -r -u setup.py setup.py
  
          # Add paths specified in the environment variables LDFLAGS and
          # CPPFLAGS for header and library files.
-
+@@ -1443,14 +1443,13 @@
+ 
+ 
+         # Platform-specific libraries
+-        if platform == 'linux2':
++        if platform.startswith('linux'):
+             # Linux-specific modules
+             exts.append( Extension('linuxaudiodev', ['linuxaudiodev.c']) )
+         else:
+             missing.append('linuxaudiodev')
+ 
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [X] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [X] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [X] Here are some details about my PR

This is essentially the same fix as in pull request #2047, but now:
- It is applied from Python 2.6.6 to 2.6.9, and
- It is applied to `ossaudiodev` as well as the (deprecated) `linuxaudiodev` module.

Below you may find sample logs when building with an ancient Debian Docker image (Debian 4.0 hosted by Ubuntu 20.04) before and after applying the patch (the architecture is x86_64):

* [python-build_2.6.6_without_patch.log](https://github.com/pyenv/pyenv/files/7110484/python-build_2.6.6_without_patch.log)
* [python-build_2.6.6_with_patch.log](https://github.com/pyenv/pyenv/files/7110485/python-build_2.6.6_with_patch.log)
* [python-build_2.6.7_without_patch.log](https://github.com/pyenv/pyenv/files/7110486/python-build_2.6.7_without_patch.log)
* [python-build_2.6.7_with_patch.log](https://github.com/pyenv/pyenv/files/7110487/python-build_2.6.7_with_patch.log)
* [python-build_2.6.8_without_patch.log](https://github.com/pyenv/pyenv/files/7110488/python-build_2.6.8_without_patch.log)
* [python-build_2.6.8_with_patch.log](https://github.com/pyenv/pyenv/files/7110489/python-build_2.6.8_with_patch.log)
* [python-build_2.6.9_without_patch.log](https://github.com/pyenv/pyenv/files/7110490/python-build_2.6.9_without_patch.log)
* [python-build_2.6.9_with_patch.log](https://github.com/pyenv/pyenv/files/7110491/python-build_2.6.9_with_patch.log)

Basically before:
```
INFO: Can't locate Tcl/Tk libs and/or headers

Failed to find the necessary bits to build these modules:
_tkinter           bsddb185           dl              
imageop            linuxaudiodev      ossaudiodev     
sunaudiodev                                           
To find the necessary bits, look in setup.py in detect_modules() for the module's name.
```
and after:
```
INFO: Can't locate Tcl/Tk libs and/or headers

Failed to find the necessary bits to build these modules:
_tkinter           bsddb185           dl              
imageop            sunaudiodev                        
To find the necessary bits, look in setup.py in detect_modules() for the module's name.
```
where `_tkinter` is not built because I intentionally omitted the `tk-dev` package, `bsddb185` is not compatible with modern versions of `libdb-dev`,  `dl` and `imageop` are only built for 32-bit systems, and `sunaudiodev` is only built for SunOS.

### Tests
- [ ] My PR adds the following unit tests (if any)
