### PR TITLE
Add missing Python 2.6.x definitions and patches

### DIFF
--- a/plugins/python-build/share/python-build/2.6.0
+++ b/plugins/python-build/share/python-build/2.6.0
@@ -1,0 +1,4 @@
+#require_gcc
+install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+install_package "Python-2.6" "https://www.python.org/ftp/python/2.6/Python-2.6.tgz#7c2f21a968a737a59ed0729f4b1dc154dc3aa183c20be96055186fe43c6742d0" standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.1
+++ b/plugins/python-build/share/python-build/2.6.1
@@ -1,0 +1,4 @@
+#require_gcc
+install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+install_package "Python-2.6.1" "https://www.python.org/ftp/python/2.6.1/Python-2.6.1.tgz#fb65e93678e1327e3e8559cc56e1e00ed8c07162b21287a3502677892c5c515c" standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.2
+++ b/plugins/python-build/share/python-build/2.6.2
@@ -1,0 +1,4 @@
+#require_gcc
+install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+install_package "Python-2.6.2" "https://www.python.org/ftp/python/2.6.2/Python-2.6.2.tgz#e37ecdf249f248f4fea227adbca09c778670b64fcb5e45947ec3e093cbc12c86" standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.3
+++ b/plugins/python-build/share/python-build/2.6.3
@@ -1,0 +1,4 @@
+#require_gcc
+install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+install_package "Python-2.6.3" "https://www.python.org/ftp/python/2.6.3/Python-2.6.3.tgz#a71b55540690425fd82ab00819aeb92c1b23cbb4730a0ccd2e25c833b22a812e" standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.4
+++ b/plugins/python-build/share/python-build/2.6.4
@@ -1,0 +1,4 @@
+#require_gcc
+install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+install_package "Python-2.6.4" "https://www.python.org/ftp/python/2.6.4/Python-2.6.4.tgz#1a25a47506e4165704cfe2b07c0a064b0b5762a2d18b8fbdad5af688aeacd252" standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.5
+++ b/plugins/python-build/share/python-build/2.6.5
@@ -1,0 +1,4 @@
+#require_gcc
+install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+install_package "Python-2.6.5" "https://www.python.org/ftp/python/2.6.5/Python-2.6.5.tgz#b331dafdce3361834fee783795d4f68ae7cf7d379e9137c2d8e8531cea615ede" standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/patches/2.6.0/Python-2.6/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/2.6.0/Python-2.6/000_patch-setup.py.diff
@@ -1,0 +1,71 @@
+
+# HG changeset patch
+# User Barry Warsaw <barry@python.org>
+# Date 1302190091 14400
+# Node ID bd0f73a9538e05f526feaf05821e68bdcff498fa
+# Parent  2e4cdaffe493e879fb5367a4aa454491de451137
+Backport for Python 2.7 of issue 11715 support for building Python on
+multiarch Debian/Ubuntu.
+
+diff -r -u setup.py setup.py
+--- setup.py.orig
++++ setup.py
+@@ -15,6 +15,7 @@
+ from distutils.command.build_ext import build_ext
+ from distutils.command.install import install
+ from distutils.command.install_lib import install_lib
++from distutils.spawn import find_executable
+ 
+ # This global variable is used to hold the list of modules to be disabled.
+ disabled_module_list = []
+@@ -308,10 +309,33 @@ class PyBuildExt(build_ext):
+                 return platform
+         return sys.platform
+ 
++    def add_multiarch_paths(self):
++        # Debian/Ubuntu multiarch support.
++        # https://wiki.ubuntu.com/MultiarchSpec
++        if not find_executable('dpkg-architecture'):
++            return
++        tmpfile = os.path.join(self.build_temp, 'multiarch')
++        if not os.path.exists(self.build_temp):
++            os.makedirs(self.build_temp)
++        ret = os.system(
++            'dpkg-architecture -qDEB_HOST_MULTIARCH > %s 2> /dev/null' %
++            tmpfile)
++        try:
++            if ret >> 8 == 0:
++                with open(tmpfile) as fp:
++                    multiarch_path_component = fp.readline().strip()
++                add_dir_to_list(self.compiler.library_dirs,
++                                '/usr/lib/' + multiarch_path_component)
++                add_dir_to_list(self.compiler.include_dirs,
++                                '/usr/include/' + multiarch_path_component)
++        finally:
++            os.unlink(tmpfile)
++
+     def detect_modules(self):
+         # Ensure that /usr/local is always used
+         add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+         add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
++        self.add_multiarch_paths()
+ 
+         # Add paths specified in the environment variables LDFLAGS and
+         # CPPFLAGS for header and library files.
+@@ -1308,14 +1332,13 @@
+ 
+ 
+         # Platform-specific libraries
+-        if platform == 'linux2':
++        if platform.startswith('linux'):
+             # Linux-specific modules
+             exts.append( Extension('linuxaudiodev', ['linuxaudiodev.c']) )
+         else:
+             missing.append('linuxaudiodev')
+ 
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')

--- a/plugins/python-build/share/python-build/patches/2.6.0/Python-2.6/002_readline63.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.0/Python-2.6/002_readline63.patch
@@ -1,0 +1,61 @@
+diff -r -u ../Python-2.6.orig/Modules/readline.c ./Modules/readline.c
+--- ../Python-2.6.orig/Modules/readline.c	2013-11-10 16:36:41.000000000 +0900
++++ ./Modules/readline.c	2014-03-29 16:17:48.643305752 +0900
+@@ -174,8 +174,7 @@
+ 	if (!PyArg_ParseTuple(args, buf, &function))
+ 		return NULL;
+ 	if (function == Py_None) {
+-		Py_XDECREF(*hook_var);
+-		*hook_var = NULL;
++		Py_CLEAR(*hook_var);
+ 	}
+ 	else if (PyCallable_Check(function)) {
+ 		PyObject *tmp = *hook_var;
+@@ -647,14 +646,22 @@
+ }
+ 
+ static int
++#if defined(_RL_FUNCTION_TYPEDEF)
+ on_startup_hook(void)
++#else
++on_startup_hook()
++#endif
+ {
+ 	return on_hook(startup_hook);
+ }
+ 
+ #ifdef HAVE_RL_PRE_INPUT_HOOK
+ static int
++#if defined(_RL_FUNCTION_TYPEDEF)
+ on_pre_input_hook(void)
++#else
++on_pre_input_hook()
++#endif
+ {
+ 	return on_hook(pre_input_hook);
+ }
+@@ -749,7 +756,7 @@
+  * before calling the normal completer */
+ 
+ static char **
+-flex_complete(char *text, int start, int end)
++flex_complete(const char *text, int start, int end)
+ {
+ 	Py_XDECREF(begidx);
+ 	Py_XDECREF(endidx);
+@@ -783,12 +790,12 @@
+ 	rl_bind_key_in_map ('\t', rl_complete, emacs_meta_keymap);
+ 	rl_bind_key_in_map ('\033', rl_complete, emacs_meta_keymap);
+ 	/* Set our hook functions */
+-	rl_startup_hook = (Function *)on_startup_hook;
++	rl_startup_hook = on_startup_hook;
+ #ifdef HAVE_RL_PRE_INPUT_HOOK
+-	rl_pre_input_hook = (Function *)on_pre_input_hook;
++	rl_pre_input_hook = on_pre_input_hook;
+ #endif
+ 	/* Set our completion function */
+-	rl_attempted_completion_function = (CPPFunction *)flex_complete;
++	rl_attempted_completion_function = flex_complete;
+ 	/* Set Python word break characters */
+ 	rl_completer_word_break_characters =
+ 		strdup(" \t\n`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?");

--- a/plugins/python-build/share/python-build/patches/2.6.0/Python-2.6/003_tk86.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.0/Python-2.6/003_tk86.patch
@@ -1,0 +1,12 @@
+diff -r -u ../Python-2.6.orig/setup.py ./setup.py
+--- ../Python-2.6.orig/setup.py	2013-10-30 00:04:39.000000000 +0900
++++ ./setup.py	2014-04-03 22:28:49.122061684 +0900
+@@ -1541,7 +1541,7 @@
+         # The versions with dots are used on Unix, and the versions without
+         # dots on Windows, for detection by cygwin.
+         tcllib = tklib = tcl_includes = tk_includes = None
+-        for version in ['8.5', '85', '8.4', '84', '8.3', '83', '8.2',
++        for version in ['8.6', '86', '8.5', '85', '8.4', '84', '8.3', '83',
+                         '82', '8.1', '81', '8.0', '80']:
+             tklib = self.compiler.find_library_file(lib_dirs, 'tk' + version)
+             tcllib = self.compiler.find_library_file(lib_dirs, 'tcl' + version)

--- a/plugins/python-build/share/python-build/patches/2.6.0/Python-2.6/010_ssl_no_ssl2_no_ssl3.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.0/Python-2.6/010_ssl_no_ssl2_no_ssl3.patch
@@ -1,0 +1,95 @@
+diff -r -u ../Python-2.6.4.orig/Lib/ssl.py ./Lib/ssl.py
+--- ../Python-2.6.4.orig/Lib/ssl.py	2012-04-10 15:32:06.000000000 +0000
++++ ./Lib/ssl.py	2015-12-18 14:46:36.487188331 +0000
+@@ -61,18 +61,24 @@
+ 
+ from _ssl import SSLError
+ from _ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
+-from _ssl import PROTOCOL_SSLv2, PROTOCOL_SSLv3, PROTOCOL_SSLv23, PROTOCOL_TLSv1
+-from _ssl import RAND_status, RAND_egd, RAND_add
+-from _ssl import \
+-     SSL_ERROR_ZERO_RETURN, \
+-     SSL_ERROR_WANT_READ, \
+-     SSL_ERROR_WANT_WRITE, \
+-     SSL_ERROR_WANT_X509_LOOKUP, \
+-     SSL_ERROR_SYSCALL, \
+-     SSL_ERROR_SSL, \
+-     SSL_ERROR_WANT_CONNECT, \
+-     SSL_ERROR_EOF, \
+-     SSL_ERROR_INVALID_ERROR_CODE
++from _ssl import RAND_status, RAND_add
++try:
++    from _ssl import RAND_egd
++except ImportError:
++    # LibreSSL does not provide RAND_egd
++    pass
++
++def _import_symbols(prefix):
++    for n in dir(_ssl):
++        if n.startswith(prefix):
++            globals()[n] = getattr(_ssl, n)
++
++_import_symbols('OP_')
++_import_symbols('ALERT_DESCRIPTION_')
++_import_symbols('SSL_ERROR_')
++_import_symbols('PROTOCOL_')
++
++_PROTOCOL_NAMES = dict([(value, name) for name, value in globals().items() if name.startswith('PROTOCOL_')])
+ 
+ from socket import socket, _fileobject
+ from socket import getnameinfo as _getnameinfo
+@@ -394,7 +400,7 @@
+     d = pem_cert_string.strip()[len(PEM_HEADER):-len(PEM_FOOTER)]
+     return base64.decodestring(d)
+ 
+-def get_server_certificate (addr, ssl_version=PROTOCOL_SSLv3, ca_certs=None):
++def get_server_certificate(addr, ssl_version=PROTOCOL_SSLv23, ca_certs=None):
+ 
+     """Retrieve the certificate from the server at the specified address,
+     and return it as a PEM-encoded string.
+diff -r -u ../Python-2.6.4.orig/Modules/_ssl.c ./Modules/_ssl.c
+--- ../Python-2.6.4.orig/Modules/_ssl.c	2012-04-10 15:32:09.000000000 +0000
++++ ./Modules/_ssl.c	2015-12-18 14:45:30.419597074 +0000
+@@ -61,8 +61,12 @@
+ };
+ 
+ enum py_ssl_version {
++#ifndef OPENSSL_NO_SSL2
+ 	PY_SSL_VERSION_SSL2,
++#endif
++#ifndef OPENSSL_NO_SSL3
+ 	PY_SSL_VERSION_SSL3,
++#endif
+ 	PY_SSL_VERSION_SSL23,
+ 	PY_SSL_VERSION_TLS1,
+ };
+@@ -298,10 +302,14 @@
+ 	PySSL_BEGIN_ALLOW_THREADS
+ 	if (proto_version == PY_SSL_VERSION_TLS1)
+ 		self->ctx = SSL_CTX_new(TLSv1_method()); /* Set up context */
++#ifndef OPENSSL_NO_SSL3
+ 	else if (proto_version == PY_SSL_VERSION_SSL3)
+ 		self->ctx = SSL_CTX_new(SSLv3_method()); /* Set up context */
++#endif
++#ifndef OPENSSL_NO_SSL2
+ 	else if (proto_version == PY_SSL_VERSION_SSL2)
+ 		self->ctx = SSL_CTX_new(SSLv2_method()); /* Set up context */
++#endif
+ 	else if (proto_version == PY_SSL_VERSION_SSL23)
+ 		self->ctx = SSL_CTX_new(SSLv23_method()); /* Set up context */
+ 	PySSL_END_ALLOW_THREADS
+@@ -1627,10 +1635,14 @@
+ 				PY_SSL_CERT_REQUIRED);
+ 
+ 	/* protocol versions */
++#ifndef OPENSSL_NO_SSL2
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv2",
+ 				PY_SSL_VERSION_SSL2);
++#endif
++#ifndef OPENSSL_NO_SSL3
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv3",
+ 				PY_SSL_VERSION_SSL3);
++#endif
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv23",
+ 				PY_SSL_VERSION_SSL23);
+ 	PyModule_AddIntConstant(m, "PROTOCOL_TLSv1",

--- a/plugins/python-build/share/python-build/patches/2.6.1/Python-2.6.1/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/2.6.1/Python-2.6.1/000_patch-setup.py.diff
@@ -1,0 +1,71 @@
+
+# HG changeset patch
+# User Barry Warsaw <barry@python.org>
+# Date 1302190091 14400
+# Node ID bd0f73a9538e05f526feaf05821e68bdcff498fa
+# Parent  2e4cdaffe493e879fb5367a4aa454491de451137
+Backport for Python 2.7 of issue 11715 support for building Python on
+multiarch Debian/Ubuntu.
+
+diff -r -u setup.py setup.py
+--- setup.py.orig
++++ setup.py
+@@ -15,6 +15,7 @@
+ from distutils.command.build_ext import build_ext
+ from distutils.command.install import install
+ from distutils.command.install_lib import install_lib
++from distutils.spawn import find_executable
+ 
+ # This global variable is used to hold the list of modules to be disabled.
+ disabled_module_list = []
+@@ -308,10 +309,33 @@ class PyBuildExt(build_ext):
+                 return platform
+         return sys.platform
+ 
++    def add_multiarch_paths(self):
++        # Debian/Ubuntu multiarch support.
++        # https://wiki.ubuntu.com/MultiarchSpec
++        if not find_executable('dpkg-architecture'):
++            return
++        tmpfile = os.path.join(self.build_temp, 'multiarch')
++        if not os.path.exists(self.build_temp):
++            os.makedirs(self.build_temp)
++        ret = os.system(
++            'dpkg-architecture -qDEB_HOST_MULTIARCH > %s 2> /dev/null' %
++            tmpfile)
++        try:
++            if ret >> 8 == 0:
++                with open(tmpfile) as fp:
++                    multiarch_path_component = fp.readline().strip()
++                add_dir_to_list(self.compiler.library_dirs,
++                                '/usr/lib/' + multiarch_path_component)
++                add_dir_to_list(self.compiler.include_dirs,
++                                '/usr/include/' + multiarch_path_component)
++        finally:
++            os.unlink(tmpfile)
++
+     def detect_modules(self):
+         # Ensure that /usr/local is always used
+         add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+         add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
++        self.add_multiarch_paths()
+ 
+         # Add paths specified in the environment variables LDFLAGS and
+         # CPPFLAGS for header and library files.
+@@ -1310,14 +1334,13 @@
+ 
+ 
+         # Platform-specific libraries
+-        if platform == 'linux2':
++        if platform.startswith('linux'):
+             # Linux-specific modules
+             exts.append( Extension('linuxaudiodev', ['linuxaudiodev.c']) )
+         else:
+             missing.append('linuxaudiodev')
+ 
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')

--- a/plugins/python-build/share/python-build/patches/2.6.1/Python-2.6.1/002_readline63.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.1/Python-2.6.1/002_readline63.patch
@@ -1,0 +1,61 @@
+diff -r -u ../Python-2.6.4.orig/Modules/readline.c ./Modules/readline.c
+--- ../Python-2.6.4.orig/Modules/readline.c	2013-11-10 16:36:41.000000000 +0900
++++ ./Modules/readline.c	2014-03-29 16:17:48.643305752 +0900
+@@ -178,8 +178,7 @@
+ 	if (!PyArg_ParseTuple(args, buf, &function))
+ 		return NULL;
+ 	if (function == Py_None) {
+-		Py_XDECREF(*hook_var);
+-		*hook_var = NULL;
++		Py_CLEAR(*hook_var);
+ 	}
+ 	else if (PyCallable_Check(function)) {
+ 		PyObject *tmp = *hook_var;
+@@ -655,14 +655,22 @@
+ }
+ 
+ static int
++#if defined(_RL_FUNCTION_TYPEDEF)
+ on_startup_hook(void)
++#else
++on_startup_hook()
++#endif
+ {
+ 	return on_hook(startup_hook);
+ }
+ 
+ #ifdef HAVE_RL_PRE_INPUT_HOOK
+ static int
++#if defined(_RL_FUNCTION_TYPEDEF)
+ on_pre_input_hook(void)
++#else
++on_pre_input_hook()
++#endif
+ {
+ 	return on_hook(pre_input_hook);
+ }
+@@ -757,7 +757,7 @@
+  * before calling the normal completer */
+ 
+ static char **
+-flex_complete(char *text, int start, int end)
++flex_complete(const char *text, int start, int end)
+ {
+ 	Py_XDECREF(begidx);
+ 	Py_XDECREF(endidx);
+@@ -791,12 +791,12 @@
+ 	rl_bind_key_in_map ('\t', rl_complete, emacs_meta_keymap);
+ 	rl_bind_key_in_map ('\033', rl_complete, emacs_meta_keymap);
+ 	/* Set our hook functions */
+-	rl_startup_hook = (Function *)on_startup_hook;
++	rl_startup_hook = on_startup_hook;
+ #ifdef HAVE_RL_PRE_INPUT_HOOK
+-	rl_pre_input_hook = (Function *)on_pre_input_hook;
++	rl_pre_input_hook = on_pre_input_hook;
+ #endif
+ 	/* Set our completion function */
+-	rl_attempted_completion_function = (CPPFunction *)flex_complete;
++	rl_attempted_completion_function = flex_complete;
+ 	/* Set Python word break characters */
+ 	rl_completer_word_break_characters =
+ 		strdup(" \t\n`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?");

--- a/plugins/python-build/share/python-build/patches/2.6.1/Python-2.6.1/003_tk86.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.1/Python-2.6.1/003_tk86.patch
@@ -1,0 +1,12 @@
+diff -r -u ../Python-2.6.1.orig/setup.py ./setup.py
+--- ../Python-2.6.1.orig/setup.py	2013-10-30 00:04:39.000000000 +0900
++++ ./setup.py	2014-04-03 22:28:49.122061684 +0900
+@@ -1543,7 +1543,7 @@
+         # The versions with dots are used on Unix, and the versions without
+         # dots on Windows, for detection by cygwin.
+         tcllib = tklib = tcl_includes = tk_includes = None
+-        for version in ['8.5', '85', '8.4', '84', '8.3', '83', '8.2',
++        for version in ['8.6', '86', '8.5', '85', '8.4', '84', '8.3', '83',
+                         '82', '8.1', '81', '8.0', '80']:
+             tklib = self.compiler.find_library_file(lib_dirs, 'tk' + version)
+             tcllib = self.compiler.find_library_file(lib_dirs, 'tcl' + version)

--- a/plugins/python-build/share/python-build/patches/2.6.1/Python-2.6.1/010_ssl_no_ssl2_no_ssl3.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.1/Python-2.6.1/010_ssl_no_ssl2_no_ssl3.patch
@@ -1,0 +1,95 @@
+diff -r -u ../Python-2.6.4.orig/Lib/ssl.py ./Lib/ssl.py
+--- ../Python-2.6.4.orig/Lib/ssl.py	2012-04-10 15:32:06.000000000 +0000
++++ ./Lib/ssl.py	2015-12-18 14:46:36.487188331 +0000
+@@ -61,18 +61,24 @@
+ 
+ from _ssl import SSLError
+ from _ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
+-from _ssl import PROTOCOL_SSLv2, PROTOCOL_SSLv3, PROTOCOL_SSLv23, PROTOCOL_TLSv1
+-from _ssl import RAND_status, RAND_egd, RAND_add
+-from _ssl import \
+-     SSL_ERROR_ZERO_RETURN, \
+-     SSL_ERROR_WANT_READ, \
+-     SSL_ERROR_WANT_WRITE, \
+-     SSL_ERROR_WANT_X509_LOOKUP, \
+-     SSL_ERROR_SYSCALL, \
+-     SSL_ERROR_SSL, \
+-     SSL_ERROR_WANT_CONNECT, \
+-     SSL_ERROR_EOF, \
+-     SSL_ERROR_INVALID_ERROR_CODE
++from _ssl import RAND_status, RAND_add
++try:
++    from _ssl import RAND_egd
++except ImportError:
++    # LibreSSL does not provide RAND_egd
++    pass
++
++def _import_symbols(prefix):
++    for n in dir(_ssl):
++        if n.startswith(prefix):
++            globals()[n] = getattr(_ssl, n)
++
++_import_symbols('OP_')
++_import_symbols('ALERT_DESCRIPTION_')
++_import_symbols('SSL_ERROR_')
++_import_symbols('PROTOCOL_')
++
++_PROTOCOL_NAMES = dict([(value, name) for name, value in globals().items() if name.startswith('PROTOCOL_')])
+ 
+ from socket import socket, _fileobject
+ from socket import getnameinfo as _getnameinfo
+@@ -394,7 +400,7 @@
+     d = pem_cert_string.strip()[len(PEM_HEADER):-len(PEM_FOOTER)]
+     return base64.decodestring(d)
+ 
+-def get_server_certificate (addr, ssl_version=PROTOCOL_SSLv3, ca_certs=None):
++def get_server_certificate(addr, ssl_version=PROTOCOL_SSLv23, ca_certs=None):
+ 
+     """Retrieve the certificate from the server at the specified address,
+     and return it as a PEM-encoded string.
+diff -r -u ../Python-2.6.4.orig/Modules/_ssl.c ./Modules/_ssl.c
+--- ../Python-2.6.4.orig/Modules/_ssl.c	2012-04-10 15:32:09.000000000 +0000
++++ ./Modules/_ssl.c	2015-12-18 14:45:30.419597074 +0000
+@@ -61,8 +61,12 @@
+ };
+ 
+ enum py_ssl_version {
++#ifndef OPENSSL_NO_SSL2
+ 	PY_SSL_VERSION_SSL2,
++#endif
++#ifndef OPENSSL_NO_SSL3
+ 	PY_SSL_VERSION_SSL3,
++#endif
+ 	PY_SSL_VERSION_SSL23,
+ 	PY_SSL_VERSION_TLS1,
+ };
+@@ -298,10 +302,14 @@
+ 	PySSL_BEGIN_ALLOW_THREADS
+ 	if (proto_version == PY_SSL_VERSION_TLS1)
+ 		self->ctx = SSL_CTX_new(TLSv1_method()); /* Set up context */
++#ifndef OPENSSL_NO_SSL3
+ 	else if (proto_version == PY_SSL_VERSION_SSL3)
+ 		self->ctx = SSL_CTX_new(SSLv3_method()); /* Set up context */
++#endif
++#ifndef OPENSSL_NO_SSL2
+ 	else if (proto_version == PY_SSL_VERSION_SSL2)
+ 		self->ctx = SSL_CTX_new(SSLv2_method()); /* Set up context */
++#endif
+ 	else if (proto_version == PY_SSL_VERSION_SSL23)
+ 		self->ctx = SSL_CTX_new(SSLv23_method()); /* Set up context */
+ 	PySSL_END_ALLOW_THREADS
+@@ -1627,10 +1635,14 @@
+ 				PY_SSL_CERT_REQUIRED);
+ 
+ 	/* protocol versions */
++#ifndef OPENSSL_NO_SSL2
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv2",
+ 				PY_SSL_VERSION_SSL2);
++#endif
++#ifndef OPENSSL_NO_SSL3
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv3",
+ 				PY_SSL_VERSION_SSL3);
++#endif
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv23",
+ 				PY_SSL_VERSION_SSL23);
+ 	PyModule_AddIntConstant(m, "PROTOCOL_TLSv1",

--- a/plugins/python-build/share/python-build/patches/2.6.2/Python-2.6.2/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/2.6.2/Python-2.6.2/000_patch-setup.py.diff
@@ -1,0 +1,71 @@
+
+# HG changeset patch
+# User Barry Warsaw <barry@python.org>
+# Date 1302190091 14400
+# Node ID bd0f73a9538e05f526feaf05821e68bdcff498fa
+# Parent  2e4cdaffe493e879fb5367a4aa454491de451137
+Backport for Python 2.7 of issue 11715 support for building Python on
+multiarch Debian/Ubuntu.
+
+diff -r -u setup.py setup.py
+--- setup.py.orig
++++ setup.py
+@@ -15,6 +15,7 @@
+ from distutils.command.build_ext import build_ext
+ from distutils.command.install import install
+ from distutils.command.install_lib import install_lib
++from distutils.spawn import find_executable
+ 
+ # This global variable is used to hold the list of modules to be disabled.
+ disabled_module_list = []
+@@ -308,10 +309,33 @@ class PyBuildExt(build_ext):
+                 return platform
+         return sys.platform
+ 
++    def add_multiarch_paths(self):
++        # Debian/Ubuntu multiarch support.
++        # https://wiki.ubuntu.com/MultiarchSpec
++        if not find_executable('dpkg-architecture'):
++            return
++        tmpfile = os.path.join(self.build_temp, 'multiarch')
++        if not os.path.exists(self.build_temp):
++            os.makedirs(self.build_temp)
++        ret = os.system(
++            'dpkg-architecture -qDEB_HOST_MULTIARCH > %s 2> /dev/null' %
++            tmpfile)
++        try:
++            if ret >> 8 == 0:
++                with open(tmpfile) as fp:
++                    multiarch_path_component = fp.readline().strip()
++                add_dir_to_list(self.compiler.library_dirs,
++                                '/usr/lib/' + multiarch_path_component)
++                add_dir_to_list(self.compiler.include_dirs,
++                                '/usr/include/' + multiarch_path_component)
++        finally:
++            os.unlink(tmpfile)
++
+     def detect_modules(self):
+         # Ensure that /usr/local is always used
+         add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+         add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
++        self.add_multiarch_paths()
+ 
+         # Add paths specified in the environment variables LDFLAGS and
+         # CPPFLAGS for header and library files.
+@@ -1331,14 +1355,13 @@
+ 
+ 
+         # Platform-specific libraries
+-        if platform == 'linux2':
++        if platform.startswith('linux'):
+             # Linux-specific modules
+             exts.append( Extension('linuxaudiodev', ['linuxaudiodev.c']) )
+         else:
+             missing.append('linuxaudiodev')
+ 
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')

--- a/plugins/python-build/share/python-build/patches/2.6.2/Python-2.6.2/002_readline63.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.2/Python-2.6.2/002_readline63.patch
@@ -1,0 +1,61 @@
+diff -r -u ../Python-2.6.4.orig/Modules/readline.c ./Modules/readline.c
+--- ../Python-2.6.4.orig/Modules/readline.c	2013-11-10 16:36:41.000000000 +0900
++++ ./Modules/readline.c	2014-03-29 16:17:48.643305752 +0900
+@@ -178,8 +178,7 @@
+ 	if (!PyArg_ParseTuple(args, buf, &function))
+ 		return NULL;
+ 	if (function == Py_None) {
+-		Py_XDECREF(*hook_var);
+-		*hook_var = NULL;
++		Py_CLEAR(*hook_var);
+ 	}
+ 	else if (PyCallable_Check(function)) {
+ 		PyObject *tmp = *hook_var;
+@@ -655,14 +654,22 @@
+ }
+ 
+ static int
++#if defined(_RL_FUNCTION_TYPEDEF)
+ on_startup_hook(void)
++#else
++on_startup_hook()
++#endif
+ {
+ 	return on_hook(startup_hook);
+ }
+ 
+ #ifdef HAVE_RL_PRE_INPUT_HOOK
+ static int
++#if defined(_RL_FUNCTION_TYPEDEF)
+ on_pre_input_hook(void)
++#else
++on_pre_input_hook()
++#endif
+ {
+ 	return on_hook(pre_input_hook);
+ }
+@@ -757,7 +764,7 @@
+  * before calling the normal completer */
+ 
+ static char **
+-flex_complete(char *text, int start, int end)
++flex_complete(const char *text, int start, int end)
+ {
+ 	Py_XDECREF(begidx);
+ 	Py_XDECREF(endidx);
+@@ -791,12 +798,12 @@
+ 	rl_bind_key_in_map ('\t', rl_complete, emacs_meta_keymap);
+ 	rl_bind_key_in_map ('\033', rl_complete, emacs_meta_keymap);
+ 	/* Set our hook functions */
+-	rl_startup_hook = (Function *)on_startup_hook;
++	rl_startup_hook = on_startup_hook;
+ #ifdef HAVE_RL_PRE_INPUT_HOOK
+-	rl_pre_input_hook = (Function *)on_pre_input_hook;
++	rl_pre_input_hook = on_pre_input_hook;
+ #endif
+ 	/* Set our completion function */
+-	rl_attempted_completion_function = (CPPFunction *)flex_complete;
++	rl_attempted_completion_function = flex_complete;
+ 	/* Set Python word break characters */
+ 	rl_completer_word_break_characters =
+ 		strdup(" \t\n`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?");

--- a/plugins/python-build/share/python-build/patches/2.6.2/Python-2.6.2/003_tk86.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.2/Python-2.6.2/003_tk86.patch
@@ -1,0 +1,12 @@
+diff -r -u ../Python-2.6.2.orig/setup.py ./setup.py
+--- ../Python-2.6.2.orig/setup.py	2013-10-30 00:04:39.000000000 +0900
++++ ./setup.py	2014-04-03 22:28:49.122061684 +0900
+@@ -1564,7 +1564,7 @@
+         # The versions with dots are used on Unix, and the versions without
+         # dots on Windows, for detection by cygwin.
+         tcllib = tklib = tcl_includes = tk_includes = None
+-        for version in ['8.5', '85', '8.4', '84', '8.3', '83', '8.2',
++        for version in ['8.6', '86', '8.5', '85', '8.4', '84', '8.3', '83',
+                         '82', '8.1', '81', '8.0', '80']:
+             tklib = self.compiler.find_library_file(lib_dirs, 'tk' + version)
+             tcllib = self.compiler.find_library_file(lib_dirs, 'tcl' + version)

--- a/plugins/python-build/share/python-build/patches/2.6.2/Python-2.6.2/010_ssl_no_ssl2_no_ssl3.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.2/Python-2.6.2/010_ssl_no_ssl2_no_ssl3.patch
@@ -1,0 +1,95 @@
+diff -r -u ../Python-2.6.4.orig/Lib/ssl.py ./Lib/ssl.py
+--- ../Python-2.6.4.orig/Lib/ssl.py	2012-04-10 15:32:06.000000000 +0000
++++ ./Lib/ssl.py	2015-12-18 14:46:36.487188331 +0000
+@@ -61,18 +61,24 @@
+ 
+ from _ssl import SSLError
+ from _ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
+-from _ssl import PROTOCOL_SSLv2, PROTOCOL_SSLv3, PROTOCOL_SSLv23, PROTOCOL_TLSv1
+-from _ssl import RAND_status, RAND_egd, RAND_add
+-from _ssl import \
+-     SSL_ERROR_ZERO_RETURN, \
+-     SSL_ERROR_WANT_READ, \
+-     SSL_ERROR_WANT_WRITE, \
+-     SSL_ERROR_WANT_X509_LOOKUP, \
+-     SSL_ERROR_SYSCALL, \
+-     SSL_ERROR_SSL, \
+-     SSL_ERROR_WANT_CONNECT, \
+-     SSL_ERROR_EOF, \
+-     SSL_ERROR_INVALID_ERROR_CODE
++from _ssl import RAND_status, RAND_add
++try:
++    from _ssl import RAND_egd
++except ImportError:
++    # LibreSSL does not provide RAND_egd
++    pass
++
++def _import_symbols(prefix):
++    for n in dir(_ssl):
++        if n.startswith(prefix):
++            globals()[n] = getattr(_ssl, n)
++
++_import_symbols('OP_')
++_import_symbols('ALERT_DESCRIPTION_')
++_import_symbols('SSL_ERROR_')
++_import_symbols('PROTOCOL_')
++
++_PROTOCOL_NAMES = dict([(value, name) for name, value in globals().items() if name.startswith('PROTOCOL_')])
+ 
+ from socket import socket, _fileobject
+ from socket import getnameinfo as _getnameinfo
+@@ -394,7 +400,7 @@
+     d = pem_cert_string.strip()[len(PEM_HEADER):-len(PEM_FOOTER)]
+     return base64.decodestring(d)
+ 
+-def get_server_certificate (addr, ssl_version=PROTOCOL_SSLv3, ca_certs=None):
++def get_server_certificate(addr, ssl_version=PROTOCOL_SSLv23, ca_certs=None):
+ 
+     """Retrieve the certificate from the server at the specified address,
+     and return it as a PEM-encoded string.
+diff -r -u ../Python-2.6.4.orig/Modules/_ssl.c ./Modules/_ssl.c
+--- ../Python-2.6.4.orig/Modules/_ssl.c	2012-04-10 15:32:09.000000000 +0000
++++ ./Modules/_ssl.c	2015-12-18 14:45:30.419597074 +0000
+@@ -61,8 +61,12 @@
+ };
+ 
+ enum py_ssl_version {
++#ifndef OPENSSL_NO_SSL2
+ 	PY_SSL_VERSION_SSL2,
++#endif
++#ifndef OPENSSL_NO_SSL3
+ 	PY_SSL_VERSION_SSL3,
++#endif
+ 	PY_SSL_VERSION_SSL23,
+ 	PY_SSL_VERSION_TLS1,
+ };
+@@ -298,10 +302,14 @@
+ 	PySSL_BEGIN_ALLOW_THREADS
+ 	if (proto_version == PY_SSL_VERSION_TLS1)
+ 		self->ctx = SSL_CTX_new(TLSv1_method()); /* Set up context */
++#ifndef OPENSSL_NO_SSL3
+ 	else if (proto_version == PY_SSL_VERSION_SSL3)
+ 		self->ctx = SSL_CTX_new(SSLv3_method()); /* Set up context */
++#endif
++#ifndef OPENSSL_NO_SSL2
+ 	else if (proto_version == PY_SSL_VERSION_SSL2)
+ 		self->ctx = SSL_CTX_new(SSLv2_method()); /* Set up context */
++#endif
+ 	else if (proto_version == PY_SSL_VERSION_SSL23)
+ 		self->ctx = SSL_CTX_new(SSLv23_method()); /* Set up context */
+ 	PySSL_END_ALLOW_THREADS
+@@ -1627,10 +1635,14 @@
+ 				PY_SSL_CERT_REQUIRED);
+ 
+ 	/* protocol versions */
++#ifndef OPENSSL_NO_SSL2
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv2",
+ 				PY_SSL_VERSION_SSL2);
++#endif
++#ifndef OPENSSL_NO_SSL3
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv3",
+ 				PY_SSL_VERSION_SSL3);
++#endif
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv23",
+ 				PY_SSL_VERSION_SSL23);
+ 	PyModule_AddIntConstant(m, "PROTOCOL_TLSv1",

--- a/plugins/python-build/share/python-build/patches/2.6.3/Python-2.6.3/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/2.6.3/Python-2.6.3/000_patch-setup.py.diff
@@ -1,0 +1,71 @@
+
+# HG changeset patch
+# User Barry Warsaw <barry@python.org>
+# Date 1302190091 14400
+# Node ID bd0f73a9538e05f526feaf05821e68bdcff498fa
+# Parent  2e4cdaffe493e879fb5367a4aa454491de451137
+Backport for Python 2.7 of issue 11715 support for building Python on
+multiarch Debian/Ubuntu.
+
+diff -r -u setup.py setup.py
+--- setup.py.orig
++++ setup.py
+@@ -15,6 +15,7 @@
+ from distutils.command.build_ext import build_ext
+ from distutils.command.install import install
+ from distutils.command.install_lib import install_lib
++from distutils.spawn import find_executable
+ 
+ # This global variable is used to hold the list of modules to be disabled.
+ disabled_module_list = []
+@@ -308,10 +309,33 @@ class PyBuildExt(build_ext):
+                 return platform
+         return sys.platform
+ 
++    def add_multiarch_paths(self):
++        # Debian/Ubuntu multiarch support.
++        # https://wiki.ubuntu.com/MultiarchSpec
++        if not find_executable('dpkg-architecture'):
++            return
++        tmpfile = os.path.join(self.build_temp, 'multiarch')
++        if not os.path.exists(self.build_temp):
++            os.makedirs(self.build_temp)
++        ret = os.system(
++            'dpkg-architecture -qDEB_HOST_MULTIARCH > %s 2> /dev/null' %
++            tmpfile)
++        try:
++            if ret >> 8 == 0:
++                with open(tmpfile) as fp:
++                    multiarch_path_component = fp.readline().strip()
++                add_dir_to_list(self.compiler.library_dirs,
++                                '/usr/lib/' + multiarch_path_component)
++                add_dir_to_list(self.compiler.include_dirs,
++                                '/usr/include/' + multiarch_path_component)
++        finally:
++            os.unlink(tmpfile)
++
+     def detect_modules(self):
+         # Ensure that /usr/local is always used
+         add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+         add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
++        self.add_multiarch_paths()
+ 
+         # Add paths specified in the environment variables LDFLAGS and
+         # CPPFLAGS for header and library files.
+@@ -1331,14 +1355,13 @@
+ 
+ 
+         # Platform-specific libraries
+-        if platform == 'linux2':
++        if platform.startswith('linux'):
+             # Linux-specific modules
+             exts.append( Extension('linuxaudiodev', ['linuxaudiodev.c']) )
+         else:
+             missing.append('linuxaudiodev')
+ 
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')

--- a/plugins/python-build/share/python-build/patches/2.6.3/Python-2.6.3/002_readline63.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.3/Python-2.6.3/002_readline63.patch
@@ -1,0 +1,61 @@
+diff -r -u ../Python-2.6.4.orig/Modules/readline.c ./Modules/readline.c
+--- ../Python-2.6.4.orig/Modules/readline.c	2013-11-10 16:36:41.000000000 +0900
++++ ./Modules/readline.c	2014-03-29 16:17:48.643305752 +0900
+@@ -178,8 +178,7 @@
+ 	if (!PyArg_ParseTuple(args, buf, &function))
+ 		return NULL;
+ 	if (function == Py_None) {
+-		Py_XDECREF(*hook_var);
+-		*hook_var = NULL;
++		Py_CLEAR(*hook_var);
+ 	}
+ 	else if (PyCallable_Check(function)) {
+ 		PyObject *tmp = *hook_var;
+@@ -655,14 +654,22 @@
+ }
+ 
+ static int
++#if defined(_RL_FUNCTION_TYPEDEF)
+ on_startup_hook(void)
++#else
++on_startup_hook()
++#endif
+ {
+ 	return on_hook(startup_hook);
+ }
+ 
+ #ifdef HAVE_RL_PRE_INPUT_HOOK
+ static int
++#if defined(_RL_FUNCTION_TYPEDEF)
+ on_pre_input_hook(void)
++#else
++on_pre_input_hook()
++#endif
+ {
+ 	return on_hook(pre_input_hook);
+ }
+@@ -757,7 +764,7 @@
+  * before calling the normal completer */
+ 
+ static char **
+-flex_complete(char *text, int start, int end)
++flex_complete(const char *text, int start, int end)
+ {
+ 	Py_XDECREF(begidx);
+ 	Py_XDECREF(endidx);
+@@ -791,12 +798,12 @@
+ 	rl_bind_key_in_map ('\t', rl_complete, emacs_meta_keymap);
+ 	rl_bind_key_in_map ('\033', rl_complete, emacs_meta_keymap);
+ 	/* Set our hook functions */
+-	rl_startup_hook = (Function *)on_startup_hook;
++	rl_startup_hook = on_startup_hook;
+ #ifdef HAVE_RL_PRE_INPUT_HOOK
+-	rl_pre_input_hook = (Function *)on_pre_input_hook;
++	rl_pre_input_hook = on_pre_input_hook;
+ #endif
+ 	/* Set our completion function */
+-	rl_attempted_completion_function = (CPPFunction *)flex_complete;
++	rl_attempted_completion_function = flex_complete;
+ 	/* Set Python word break characters */
+ 	rl_completer_word_break_characters =
+ 		strdup(" \t\n`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?");

--- a/plugins/python-build/share/python-build/patches/2.6.3/Python-2.6.3/003_tk86.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.3/Python-2.6.3/003_tk86.patch
@@ -1,0 +1,12 @@
+diff -r -u ../Python-2.6.4.orig/setup.py ./setup.py
+--- ../Python-2.6.4.orig/setup.py	2013-10-30 00:04:39.000000000 +0900
++++ ./setup.py	2014-04-03 22:28:49.122061684 +0900
+@@ -1573,7 +1573,7 @@
+         # The versions with dots are used on Unix, and the versions without
+         # dots on Windows, for detection by cygwin.
+         tcllib = tklib = tcl_includes = tk_includes = None
+-        for version in ['8.5', '85', '8.4', '84', '8.3', '83', '8.2',
++        for version in ['8.6', '86', '8.5', '85', '8.4', '84', '8.3', '83',
+                         '82', '8.1', '81', '8.0', '80']:
+             tklib = self.compiler.find_library_file(lib_dirs, 'tk' + version)
+             tcllib = self.compiler.find_library_file(lib_dirs, 'tcl' + version)

--- a/plugins/python-build/share/python-build/patches/2.6.3/Python-2.6.3/010_ssl_no_ssl2_no_ssl3.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.3/Python-2.6.3/010_ssl_no_ssl2_no_ssl3.patch
@@ -1,0 +1,95 @@
+diff -r -u ../Python-2.6.4.orig/Lib/ssl.py ./Lib/ssl.py
+--- ../Python-2.6.4.orig/Lib/ssl.py	2012-04-10 15:32:06.000000000 +0000
++++ ./Lib/ssl.py	2015-12-18 14:46:36.487188331 +0000
+@@ -61,18 +61,24 @@
+ 
+ from _ssl import SSLError
+ from _ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
+-from _ssl import PROTOCOL_SSLv2, PROTOCOL_SSLv3, PROTOCOL_SSLv23, PROTOCOL_TLSv1
+-from _ssl import RAND_status, RAND_egd, RAND_add
+-from _ssl import \
+-     SSL_ERROR_ZERO_RETURN, \
+-     SSL_ERROR_WANT_READ, \
+-     SSL_ERROR_WANT_WRITE, \
+-     SSL_ERROR_WANT_X509_LOOKUP, \
+-     SSL_ERROR_SYSCALL, \
+-     SSL_ERROR_SSL, \
+-     SSL_ERROR_WANT_CONNECT, \
+-     SSL_ERROR_EOF, \
+-     SSL_ERROR_INVALID_ERROR_CODE
++from _ssl import RAND_status, RAND_add
++try:
++    from _ssl import RAND_egd
++except ImportError:
++    # LibreSSL does not provide RAND_egd
++    pass
++
++def _import_symbols(prefix):
++    for n in dir(_ssl):
++        if n.startswith(prefix):
++            globals()[n] = getattr(_ssl, n)
++
++_import_symbols('OP_')
++_import_symbols('ALERT_DESCRIPTION_')
++_import_symbols('SSL_ERROR_')
++_import_symbols('PROTOCOL_')
++
++_PROTOCOL_NAMES = dict([(value, name) for name, value in globals().items() if name.startswith('PROTOCOL_')])
+ 
+ from socket import socket, _fileobject
+ from socket import getnameinfo as _getnameinfo
+@@ -394,7 +400,7 @@
+     d = pem_cert_string.strip()[len(PEM_HEADER):-len(PEM_FOOTER)]
+     return base64.decodestring(d)
+ 
+-def get_server_certificate (addr, ssl_version=PROTOCOL_SSLv3, ca_certs=None):
++def get_server_certificate(addr, ssl_version=PROTOCOL_SSLv23, ca_certs=None):
+ 
+     """Retrieve the certificate from the server at the specified address,
+     and return it as a PEM-encoded string.
+diff -r -u ../Python-2.6.4.orig/Modules/_ssl.c ./Modules/_ssl.c
+--- ../Python-2.6.4.orig/Modules/_ssl.c	2012-04-10 15:32:09.000000000 +0000
++++ ./Modules/_ssl.c	2015-12-18 14:45:30.419597074 +0000
+@@ -61,8 +61,12 @@
+ };
+ 
+ enum py_ssl_version {
++#ifndef OPENSSL_NO_SSL2
+ 	PY_SSL_VERSION_SSL2,
++#endif
++#ifndef OPENSSL_NO_SSL3
+ 	PY_SSL_VERSION_SSL3,
++#endif
+ 	PY_SSL_VERSION_SSL23,
+ 	PY_SSL_VERSION_TLS1,
+ };
+@@ -298,10 +302,14 @@
+ 	PySSL_BEGIN_ALLOW_THREADS
+ 	if (proto_version == PY_SSL_VERSION_TLS1)
+ 		self->ctx = SSL_CTX_new(TLSv1_method()); /* Set up context */
++#ifndef OPENSSL_NO_SSL3
+ 	else if (proto_version == PY_SSL_VERSION_SSL3)
+ 		self->ctx = SSL_CTX_new(SSLv3_method()); /* Set up context */
++#endif
++#ifndef OPENSSL_NO_SSL2
+ 	else if (proto_version == PY_SSL_VERSION_SSL2)
+ 		self->ctx = SSL_CTX_new(SSLv2_method()); /* Set up context */
++#endif
+ 	else if (proto_version == PY_SSL_VERSION_SSL23)
+ 		self->ctx = SSL_CTX_new(SSLv23_method()); /* Set up context */
+ 	PySSL_END_ALLOW_THREADS
+@@ -1627,10 +1635,14 @@
+ 				PY_SSL_CERT_REQUIRED);
+ 
+ 	/* protocol versions */
++#ifndef OPENSSL_NO_SSL2
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv2",
+ 				PY_SSL_VERSION_SSL2);
++#endif
++#ifndef OPENSSL_NO_SSL3
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv3",
+ 				PY_SSL_VERSION_SSL3);
++#endif
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv23",
+ 				PY_SSL_VERSION_SSL23);
+ 	PyModule_AddIntConstant(m, "PROTOCOL_TLSv1",

--- a/plugins/python-build/share/python-build/patches/2.6.4/Python-2.6.4/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/2.6.4/Python-2.6.4/000_patch-setup.py.diff
@@ -1,0 +1,71 @@
+
+# HG changeset patch
+# User Barry Warsaw <barry@python.org>
+# Date 1302190091 14400
+# Node ID bd0f73a9538e05f526feaf05821e68bdcff498fa
+# Parent  2e4cdaffe493e879fb5367a4aa454491de451137
+Backport for Python 2.7 of issue 11715 support for building Python on
+multiarch Debian/Ubuntu.
+
+diff -r -u setup.py setup.py
+--- setup.py.orig
++++ setup.py
+@@ -15,6 +15,7 @@
+ from distutils.command.build_ext import build_ext
+ from distutils.command.install import install
+ from distutils.command.install_lib import install_lib
++from distutils.spawn import find_executable
+ 
+ # This global variable is used to hold the list of modules to be disabled.
+ disabled_module_list = []
+@@ -308,10 +309,33 @@ class PyBuildExt(build_ext):
+                 return platform
+         return sys.platform
+ 
++    def add_multiarch_paths(self):
++        # Debian/Ubuntu multiarch support.
++        # https://wiki.ubuntu.com/MultiarchSpec
++        if not find_executable('dpkg-architecture'):
++            return
++        tmpfile = os.path.join(self.build_temp, 'multiarch')
++        if not os.path.exists(self.build_temp):
++            os.makedirs(self.build_temp)
++        ret = os.system(
++            'dpkg-architecture -qDEB_HOST_MULTIARCH > %s 2> /dev/null' %
++            tmpfile)
++        try:
++            if ret >> 8 == 0:
++                with open(tmpfile) as fp:
++                    multiarch_path_component = fp.readline().strip()
++                add_dir_to_list(self.compiler.library_dirs,
++                                '/usr/lib/' + multiarch_path_component)
++                add_dir_to_list(self.compiler.include_dirs,
++                                '/usr/include/' + multiarch_path_component)
++        finally:
++            os.unlink(tmpfile)
++
+     def detect_modules(self):
+         # Ensure that /usr/local is always used
+         add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+         add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
++        self.add_multiarch_paths()
+ 
+         # Add paths specified in the environment variables LDFLAGS and
+         # CPPFLAGS for header and library files.
+@@ -1331,14 +1355,13 @@
+ 
+ 
+         # Platform-specific libraries
+-        if platform == 'linux2':
++        if platform.startswith('linux'):
+             # Linux-specific modules
+             exts.append( Extension('linuxaudiodev', ['linuxaudiodev.c']) )
+         else:
+             missing.append('linuxaudiodev')
+ 
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')

--- a/plugins/python-build/share/python-build/patches/2.6.4/Python-2.6.4/002_readline63.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.4/Python-2.6.4/002_readline63.patch
@@ -1,0 +1,61 @@
+diff -r -u ../Python-2.6.4.orig/Modules/readline.c ./Modules/readline.c
+--- ../Python-2.6.4.orig/Modules/readline.c	2013-11-10 16:36:41.000000000 +0900
++++ ./Modules/readline.c	2014-03-29 16:17:48.643305752 +0900
+@@ -178,8 +178,7 @@
+ 	if (!PyArg_ParseTuple(args, buf, &function))
+ 		return NULL;
+ 	if (function == Py_None) {
+-		Py_XDECREF(*hook_var);
+-		*hook_var = NULL;
++		Py_CLEAR(*hook_var);
+ 	}
+ 	else if (PyCallable_Check(function)) {
+ 		PyObject *tmp = *hook_var;
+@@ -655,14 +654,22 @@
+ }
+ 
+ static int
++#if defined(_RL_FUNCTION_TYPEDEF)
+ on_startup_hook(void)
++#else
++on_startup_hook()
++#endif
+ {
+ 	return on_hook(startup_hook);
+ }
+ 
+ #ifdef HAVE_RL_PRE_INPUT_HOOK
+ static int
++#if defined(_RL_FUNCTION_TYPEDEF)
+ on_pre_input_hook(void)
++#else
++on_pre_input_hook()
++#endif
+ {
+ 	return on_hook(pre_input_hook);
+ }
+@@ -757,7 +764,7 @@
+  * before calling the normal completer */
+ 
+ static char **
+-flex_complete(char *text, int start, int end)
++flex_complete(const char *text, int start, int end)
+ {
+ 	Py_XDECREF(begidx);
+ 	Py_XDECREF(endidx);
+@@ -791,12 +798,12 @@
+ 	rl_bind_key_in_map ('\t', rl_complete, emacs_meta_keymap);
+ 	rl_bind_key_in_map ('\033', rl_complete, emacs_meta_keymap);
+ 	/* Set our hook functions */
+-	rl_startup_hook = (Function *)on_startup_hook;
++	rl_startup_hook = on_startup_hook;
+ #ifdef HAVE_RL_PRE_INPUT_HOOK
+-	rl_pre_input_hook = (Function *)on_pre_input_hook;
++	rl_pre_input_hook = on_pre_input_hook;
+ #endif
+ 	/* Set our completion function */
+-	rl_attempted_completion_function = (CPPFunction *)flex_complete;
++	rl_attempted_completion_function = flex_complete;
+ 	/* Set Python word break characters */
+ 	rl_completer_word_break_characters =
+ 		strdup(" \t\n`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?");

--- a/plugins/python-build/share/python-build/patches/2.6.4/Python-2.6.4/003_tk86.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.4/Python-2.6.4/003_tk86.patch
@@ -1,0 +1,12 @@
+diff -r -u ../Python-2.6.4.orig/setup.py ./setup.py
+--- ../Python-2.6.4.orig/setup.py	2013-10-30 00:04:39.000000000 +0900
++++ ./setup.py	2014-04-03 22:28:49.122061684 +0900
+@@ -1573,7 +1573,7 @@
+         # The versions with dots are used on Unix, and the versions without
+         # dots on Windows, for detection by cygwin.
+         tcllib = tklib = tcl_includes = tk_includes = None
+-        for version in ['8.5', '85', '8.4', '84', '8.3', '83', '8.2',
++        for version in ['8.6', '86', '8.5', '85', '8.4', '84', '8.3', '83',
+                         '82', '8.1', '81', '8.0', '80']:
+             tklib = self.compiler.find_library_file(lib_dirs, 'tk' + version)
+             tcllib = self.compiler.find_library_file(lib_dirs, 'tcl' + version)

--- a/plugins/python-build/share/python-build/patches/2.6.4/Python-2.6.4/010_ssl_no_ssl2_no_ssl3.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.4/Python-2.6.4/010_ssl_no_ssl2_no_ssl3.patch
@@ -1,0 +1,95 @@
+diff -r -u ../Python-2.6.4.orig/Lib/ssl.py ./Lib/ssl.py
+--- ../Python-2.6.4.orig/Lib/ssl.py	2012-04-10 15:32:06.000000000 +0000
++++ ./Lib/ssl.py	2015-12-18 14:46:36.487188331 +0000
+@@ -61,18 +61,24 @@
+ 
+ from _ssl import SSLError
+ from _ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
+-from _ssl import PROTOCOL_SSLv2, PROTOCOL_SSLv3, PROTOCOL_SSLv23, PROTOCOL_TLSv1
+-from _ssl import RAND_status, RAND_egd, RAND_add
+-from _ssl import \
+-     SSL_ERROR_ZERO_RETURN, \
+-     SSL_ERROR_WANT_READ, \
+-     SSL_ERROR_WANT_WRITE, \
+-     SSL_ERROR_WANT_X509_LOOKUP, \
+-     SSL_ERROR_SYSCALL, \
+-     SSL_ERROR_SSL, \
+-     SSL_ERROR_WANT_CONNECT, \
+-     SSL_ERROR_EOF, \
+-     SSL_ERROR_INVALID_ERROR_CODE
++from _ssl import RAND_status, RAND_add
++try:
++    from _ssl import RAND_egd
++except ImportError:
++    # LibreSSL does not provide RAND_egd
++    pass
++
++def _import_symbols(prefix):
++    for n in dir(_ssl):
++        if n.startswith(prefix):
++            globals()[n] = getattr(_ssl, n)
++
++_import_symbols('OP_')
++_import_symbols('ALERT_DESCRIPTION_')
++_import_symbols('SSL_ERROR_')
++_import_symbols('PROTOCOL_')
++
++_PROTOCOL_NAMES = dict([(value, name) for name, value in globals().items() if name.startswith('PROTOCOL_')])
+ 
+ from socket import socket, _fileobject
+ from socket import getnameinfo as _getnameinfo
+@@ -394,7 +400,7 @@
+     d = pem_cert_string.strip()[len(PEM_HEADER):-len(PEM_FOOTER)]
+     return base64.decodestring(d)
+ 
+-def get_server_certificate (addr, ssl_version=PROTOCOL_SSLv3, ca_certs=None):
++def get_server_certificate(addr, ssl_version=PROTOCOL_SSLv23, ca_certs=None):
+ 
+     """Retrieve the certificate from the server at the specified address,
+     and return it as a PEM-encoded string.
+diff -r -u ../Python-2.6.4.orig/Modules/_ssl.c ./Modules/_ssl.c
+--- ../Python-2.6.4.orig/Modules/_ssl.c	2012-04-10 15:32:09.000000000 +0000
++++ ./Modules/_ssl.c	2015-12-18 14:45:30.419597074 +0000
+@@ -61,8 +61,12 @@
+ };
+ 
+ enum py_ssl_version {
++#ifndef OPENSSL_NO_SSL2
+ 	PY_SSL_VERSION_SSL2,
++#endif
++#ifndef OPENSSL_NO_SSL3
+ 	PY_SSL_VERSION_SSL3,
++#endif
+ 	PY_SSL_VERSION_SSL23,
+ 	PY_SSL_VERSION_TLS1,
+ };
+@@ -298,10 +302,14 @@
+ 	PySSL_BEGIN_ALLOW_THREADS
+ 	if (proto_version == PY_SSL_VERSION_TLS1)
+ 		self->ctx = SSL_CTX_new(TLSv1_method()); /* Set up context */
++#ifndef OPENSSL_NO_SSL3
+ 	else if (proto_version == PY_SSL_VERSION_SSL3)
+ 		self->ctx = SSL_CTX_new(SSLv3_method()); /* Set up context */
++#endif
++#ifndef OPENSSL_NO_SSL2
+ 	else if (proto_version == PY_SSL_VERSION_SSL2)
+ 		self->ctx = SSL_CTX_new(SSLv2_method()); /* Set up context */
++#endif
+ 	else if (proto_version == PY_SSL_VERSION_SSL23)
+ 		self->ctx = SSL_CTX_new(SSLv23_method()); /* Set up context */
+ 	PySSL_END_ALLOW_THREADS
+@@ -1627,10 +1635,14 @@
+ 				PY_SSL_CERT_REQUIRED);
+ 
+ 	/* protocol versions */
++#ifndef OPENSSL_NO_SSL2
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv2",
+ 				PY_SSL_VERSION_SSL2);
++#endif
++#ifndef OPENSSL_NO_SSL3
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv3",
+ 				PY_SSL_VERSION_SSL3);
++#endif
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv23",
+ 				PY_SSL_VERSION_SSL23);
+ 	PyModule_AddIntConstant(m, "PROTOCOL_TLSv1",

--- a/plugins/python-build/share/python-build/patches/2.6.5/Python-2.6.5/000_patch-setup.py.diff
+++ b/plugins/python-build/share/python-build/patches/2.6.5/Python-2.6.5/000_patch-setup.py.diff
@@ -1,0 +1,71 @@
+
+# HG changeset patch
+# User Barry Warsaw <barry@python.org>
+# Date 1302190091 14400
+# Node ID bd0f73a9538e05f526feaf05821e68bdcff498fa
+# Parent  2e4cdaffe493e879fb5367a4aa454491de451137
+Backport for Python 2.7 of issue 11715 support for building Python on
+multiarch Debian/Ubuntu.
+
+diff -r -u setup.py setup.py
+--- setup.py.orig
++++ setup.py
+@@ -15,6 +15,7 @@
+ from distutils.command.build_ext import build_ext
+ from distutils.command.install import install
+ from distutils.command.install_lib import install_lib
++from distutils.spawn import find_executable
+ 
+ # This global variable is used to hold the list of modules to be disabled.
+ disabled_module_list = []
+@@ -308,10 +309,33 @@ class PyBuildExt(build_ext):
+                 return platform
+         return sys.platform
+ 
++    def add_multiarch_paths(self):
++        # Debian/Ubuntu multiarch support.
++        # https://wiki.ubuntu.com/MultiarchSpec
++        if not find_executable('dpkg-architecture'):
++            return
++        tmpfile = os.path.join(self.build_temp, 'multiarch')
++        if not os.path.exists(self.build_temp):
++            os.makedirs(self.build_temp)
++        ret = os.system(
++            'dpkg-architecture -qDEB_HOST_MULTIARCH > %s 2> /dev/null' %
++            tmpfile)
++        try:
++            if ret >> 8 == 0:
++                with open(tmpfile) as fp:
++                    multiarch_path_component = fp.readline().strip()
++                add_dir_to_list(self.compiler.library_dirs,
++                                '/usr/lib/' + multiarch_path_component)
++                add_dir_to_list(self.compiler.include_dirs,
++                                '/usr/include/' + multiarch_path_component)
++        finally:
++            os.unlink(tmpfile)
++
+     def detect_modules(self):
+         # Ensure that /usr/local is always used
+         add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+         add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
++        self.add_multiarch_paths()
+ 
+         # Add paths specified in the environment variables LDFLAGS and
+         # CPPFLAGS for header and library files.
+@@ -1339,14 +1363,13 @@
+ 
+ 
+         # Platform-specific libraries
+-        if platform == 'linux2':
++        if platform.startswith('linux'):
+             # Linux-specific modules
+             exts.append( Extension('linuxaudiodev', ['linuxaudiodev.c']) )
+         else:
+             missing.append('linuxaudiodev')
+ 
+-        if platform in ('linux2', 'freebsd4', 'freebsd5', 'freebsd6',
+-                        'freebsd7', 'freebsd8'):
++        if platform.startswith('linux') or platform.startswith('freebsd'):
+             exts.append( Extension('ossaudiodev', ['ossaudiodev.c']) )
+         else:
+             missing.append('ossaudiodev')

--- a/plugins/python-build/share/python-build/patches/2.6.5/Python-2.6.5/002_readline63.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.5/Python-2.6.5/002_readline63.patch
@@ -1,0 +1,61 @@
+diff -r -u ../Python-2.6.5.orig/Modules/readline.c ./Modules/readline.c
+--- ../Python-2.6.5.orig/Modules/readline.c	2013-11-10 16:36:41.000000000 +0900
++++ ./Modules/readline.c	2014-03-29 16:17:48.643305752 +0900
+@@ -199,8 +199,7 @@
+ 	if (!PyArg_ParseTuple(args, buf, &function))
+ 		return NULL;
+ 	if (function == Py_None) {
+-		Py_XDECREF(*hook_var);
+-		*hook_var = NULL;
++		Py_CLEAR(*hook_var);
+ 	}
+ 	else if (PyCallable_Check(function)) {
+ 		PyObject *tmp = *hook_var;
+@@ -699,14 +698,22 @@
+ }
+ 
+ static int
++#if defined(_RL_FUNCTION_TYPEDEF)
+ on_startup_hook(void)
++#else
++on_startup_hook()
++#endif
+ {
+ 	return on_hook(startup_hook);
+ }
+ 
+ #ifdef HAVE_RL_PRE_INPUT_HOOK
+ static int
++#if defined(_RL_FUNCTION_TYPEDEF)
+ on_pre_input_hook(void)
++#else
++on_pre_input_hook()
++#endif
+ {
+ 	return on_hook(pre_input_hook);
+ }
+@@ -801,7 +808,7 @@
+  * before calling the normal completer */
+ 
+ static char **
+-flex_complete(char *text, int start, int end)
++flex_complete(const char *text, int start, int end)
+ {
+ #ifdef HAVE_RL_COMPLETION_APPEND_CHARACTER
+ 	rl_completion_append_character ='\0';
+@@ -841,12 +848,12 @@
+ 	rl_bind_key_in_map ('\t', rl_complete, emacs_meta_keymap);
+ 	rl_bind_key_in_map ('\033', rl_complete, emacs_meta_keymap);
+ 	/* Set our hook functions */
+-	rl_startup_hook = (Function *)on_startup_hook;
++	rl_startup_hook = on_startup_hook;
+ #ifdef HAVE_RL_PRE_INPUT_HOOK
+-	rl_pre_input_hook = (Function *)on_pre_input_hook;
++	rl_pre_input_hook = on_pre_input_hook;
+ #endif
+ 	/* Set our completion function */
+-	rl_attempted_completion_function = (CPPFunction *)flex_complete;
++	rl_attempted_completion_function = flex_complete;
+ 	/* Set Python word break characters */
+ 	rl_completer_word_break_characters =
+ 		strdup(" \t\n`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?");

--- a/plugins/python-build/share/python-build/patches/2.6.5/Python-2.6.5/003_tk86.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.5/Python-2.6.5/003_tk86.patch
@@ -1,0 +1,12 @@
+diff -r -u ../Python-2.6.5.orig/setup.py ./setup.py
+--- ../Python-2.6.5.orig/setup.py	2013-10-30 00:04:39.000000000 +0900
++++ ./setup.py	2014-04-03 22:28:49.122061684 +0900
+@@ -1581,7 +1581,7 @@
+         # The versions with dots are used on Unix, and the versions without
+         # dots on Windows, for detection by cygwin.
+         tcllib = tklib = tcl_includes = tk_includes = None
+-        for version in ['8.5', '85', '8.4', '84', '8.3', '83', '8.2',
++        for version in ['8.6', '86', '8.5', '85', '8.4', '84', '8.3', '83',
+                         '82', '8.1', '81', '8.0', '80']:
+             tklib = self.compiler.find_library_file(lib_dirs, 'tk' + version)
+             tcllib = self.compiler.find_library_file(lib_dirs, 'tcl' + version)

--- a/plugins/python-build/share/python-build/patches/2.6.5/Python-2.6.5/010_ssl_no_ssl2_no_ssl3.patch
+++ b/plugins/python-build/share/python-build/patches/2.6.5/Python-2.6.5/010_ssl_no_ssl2_no_ssl3.patch
@@ -1,0 +1,95 @@
+diff -r -u ../Python-2.6.5.orig/Lib/ssl.py ./Lib/ssl.py
+--- ../Python-2.6.5.orig/Lib/ssl.py	2012-04-10 15:32:06.000000000 +0000
++++ ./Lib/ssl.py	2015-12-18 14:46:36.487188331 +0000
+@@ -61,18 +61,24 @@
+ 
+ from _ssl import SSLError
+ from _ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
+-from _ssl import PROTOCOL_SSLv2, PROTOCOL_SSLv3, PROTOCOL_SSLv23, PROTOCOL_TLSv1
+-from _ssl import RAND_status, RAND_egd, RAND_add
+-from _ssl import \
+-     SSL_ERROR_ZERO_RETURN, \
+-     SSL_ERROR_WANT_READ, \
+-     SSL_ERROR_WANT_WRITE, \
+-     SSL_ERROR_WANT_X509_LOOKUP, \
+-     SSL_ERROR_SYSCALL, \
+-     SSL_ERROR_SSL, \
+-     SSL_ERROR_WANT_CONNECT, \
+-     SSL_ERROR_EOF, \
+-     SSL_ERROR_INVALID_ERROR_CODE
++from _ssl import RAND_status, RAND_add
++try:
++    from _ssl import RAND_egd
++except ImportError:
++    # LibreSSL does not provide RAND_egd
++    pass
++
++def _import_symbols(prefix):
++    for n in dir(_ssl):
++        if n.startswith(prefix):
++            globals()[n] = getattr(_ssl, n)
++
++_import_symbols('OP_')
++_import_symbols('ALERT_DESCRIPTION_')
++_import_symbols('SSL_ERROR_')
++_import_symbols('PROTOCOL_')
++
++_PROTOCOL_NAMES = dict([(value, name) for name, value in globals().items() if name.startswith('PROTOCOL_')])
+ 
+ from socket import socket, _fileobject
+ from socket import getnameinfo as _getnameinfo
+@@ -394,7 +400,7 @@
+     d = pem_cert_string.strip()[len(PEM_HEADER):-len(PEM_FOOTER)]
+     return base64.decodestring(d)
+ 
+-def get_server_certificate(addr, ssl_version=PROTOCOL_SSLv3, ca_certs=None):
++def get_server_certificate(addr, ssl_version=PROTOCOL_SSLv23, ca_certs=None):
+ 
+     """Retrieve the certificate from the server at the specified address,
+     and return it as a PEM-encoded string.
+diff -r -u ../Python-2.6.5.orig/Modules/_ssl.c ./Modules/_ssl.c
+--- ../Python-2.6.5.orig/Modules/_ssl.c	2012-04-10 15:32:09.000000000 +0000
++++ ./Modules/_ssl.c	2015-12-18 14:45:30.419597074 +0000
+@@ -61,8 +61,12 @@
+ };
+ 
+ enum py_ssl_version {
++#ifndef OPENSSL_NO_SSL2
+ 	PY_SSL_VERSION_SSL2,
++#endif
++#ifndef OPENSSL_NO_SSL3
+ 	PY_SSL_VERSION_SSL3,
++#endif
+ 	PY_SSL_VERSION_SSL23,
+ 	PY_SSL_VERSION_TLS1,
+ };
+@@ -298,10 +302,14 @@
+ 	PySSL_BEGIN_ALLOW_THREADS
+ 	if (proto_version == PY_SSL_VERSION_TLS1)
+ 		self->ctx = SSL_CTX_new(TLSv1_method()); /* Set up context */
++#ifndef OPENSSL_NO_SSL3
+ 	else if (proto_version == PY_SSL_VERSION_SSL3)
+ 		self->ctx = SSL_CTX_new(SSLv3_method()); /* Set up context */
++#endif
++#ifndef OPENSSL_NO_SSL2
+ 	else if (proto_version == PY_SSL_VERSION_SSL2)
+ 		self->ctx = SSL_CTX_new(SSLv2_method()); /* Set up context */
++#endif
+ 	else if (proto_version == PY_SSL_VERSION_SSL23)
+ 		self->ctx = SSL_CTX_new(SSLv23_method()); /* Set up context */
+ 	PySSL_END_ALLOW_THREADS
+@@ -1627,10 +1635,14 @@
+ 				PY_SSL_CERT_REQUIRED);
+ 
+ 	/* protocol versions */
++#ifndef OPENSSL_NO_SSL2
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv2",
+ 				PY_SSL_VERSION_SSL2);
++#endif
++#ifndef OPENSSL_NO_SSL3
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv3",
+ 				PY_SSL_VERSION_SSL3);
++#endif
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv23",
+ 				PY_SSL_VERSION_SSL23);
+ 	PyModule_AddIntConstant(m, "PROTOCOL_TLSv1",


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [X] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [X] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [X] Here are some details about my PR

This pull requests adds the missing definition files for the Python 2.6.x series (from 2.6.0 to 2.6.5), as well as their corresponding patches. The definition files are created from the one in Python 2.6.6 but updating the Python versions as well as the digests with:
```
shasum -a 256 -b Python-2.6.tgz
shasum -a 256 -b Python-2.6.1.tgz
shasum -a 256 -b Python-2.6.2.tgz
shasum -a 256 -b Python-2.6.3.tgz
shasum -a 256 -b Python-2.6.4.tgz
shasum -a 256 -b Python-2.6.5.tgz
```

These are the logs when building in an ancient Docker image (Debian 4.0 under Ubuntu 20.04):
* [python_build_2.6.0.log](https://github.com/pyenv/pyenv/files/7117614/python_build_2.6.0.log)
* [python_build_2.6.1.log](https://github.com/pyenv/pyenv/files/7117615/python_build_2.6.1.log)
* [python_build_2.6.2.log](https://github.com/pyenv/pyenv/files/7117616/python_build_2.6.2.log)
* [python_build_2.6.3.log](https://github.com/pyenv/pyenv/files/7117618/python_build_2.6.3.log)
* [python_build_2.6.4.log](https://github.com/pyenv/pyenv/files/7117619/python_build_2.6.4.log)
* [python_build_2.6.5.log](https://github.com/pyenv/pyenv/files/7117620/python_build_2.6.5.log)

I took the patch files from Python 2.6.6 and performed minor modifications to make them compliant with the former Python versions, which are mainly (but not only):
- The line numbers for the patch hunks.
- The indentation in the C files was done with tabs instead of spaces before Python 2.6.6.
- The missing `from distutils.spawn import find_executable` import in `setup.py`.

Relevant is the following part:
```
INFO: Can't locate Tcl/Tk libs and/or headers

Failed to find the necessary bits to build these modules:
_tkinter           bsddb185           dl              
imageop            sunaudiodev                        
To find the necessary bits, look in setup.py in detect_modules() for the module's name.
```
which is the same result as when installing Python 2.6.6-2.6.9 in pull request #2049 (i.e. `linuxaudiodev` and `ossaudiodev` are built correctly).

### Tests
- [ ] My PR adds the following unit tests (if any)
