### PR TITLE
Allow system Python in sbin

### DIFF
--- a/libexec/pyenv-prefix
+++ b/libexec/pyenv-prefix
@@ -33,7 +33,9 @@ OLDIFS="$IFS"
       if PYTHON_PATH="$(PYENV_VERSION="${version}" pyenv-which python 2>/dev/null)" || \
           PYTHON_PATH="$(PYENV_VERSION="${version}" pyenv-which python3 2>/dev/null)" || \
           PYTHON_PATH="$(PYENV_VERSION="${version}" pyenv-which python2 2>/dev/null)"; then
-        PYENV_PREFIX_PATH="${PYTHON_PATH%/bin/*}"
+        shopt -s extglob
+        # In some distros (Arch), Python can be found in sbin as well as bin
+        PYENV_PREFIX_PATH="${PYTHON_PATH%/?(s)bin/*}"
         PYENV_PREFIX_PATH="${PYENV_PREFIX_PATH:-/}"
       else
         echo "pyenv: system version not found in PATH" >&2

--- a/test/prefix.bats
+++ b/test/prefix.bats
@@ -24,6 +24,15 @@ load test_helper
   assert_success "$PYENV_TEST_DIR"
 }
 
+#Arch has Python at sbin as well as bin
+@test "prefix for sbin system" {
+  mkdir -p "${PYENV_TEST_DIR}/sbin"
+  touch "${PYENV_TEST_DIR}/sbin/python"
+  chmod +x "${PYENV_TEST_DIR}/sbin/python"
+  PYENV_VERSION="system" run pyenv-prefix
+  assert_success "$PYENV_TEST_DIR"
+}
+
 @test "prefix for system in /" {
   mkdir -p "${BATS_TEST_DIRNAME}/libexec"
   cat >"${BATS_TEST_DIRNAME}/libexec/pyenv-which" <<OUT


### PR DESCRIPTION
Arch Linux has Python is sbin as well as bin

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/331

### Description
- [x] Here are some details about my PR

https://github.com/pyenv/pyenv/issues/331#issuecomment-920123439

### Tests
- [x] My PR adds the following unit tests (if any)

Allow system Python to be in sbin as well as bin