### PR TITLE
Fix sed commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ easy to fork and contribute any changes back upstream.
          ~~~bash
          # the sed invocation inserts the lines at the start of the file
          # after any initial comment lines
-         sed -iEe '/^([^#]|$)/ {a \
+         sed -Ei -e '/^([^#]|$)/ {a \
          export PYENV_ROOT="$HOME/.pyenv"
          a \
          export PATH="$PYENV_ROOT/bin:$PATH"
@@ -253,7 +253,7 @@ easy to fork and contribute any changes back upstream.
       - **If your `~/.bash_profile` sources `~/.bashrc` (Red Hat, Fedora, CentOS):**
 
          ~~~ bash
-         sed -iEe '/^([^#]|$)/ {a \
+         sed -Ei -e '/^([^#]|$)/ {a \
          export PYENV_ROOT="$HOME/.pyenv"
          a \
          export PATH="$PYENV_ROOT/bin:$PATH"


### PR DESCRIPTION
In GNU `sed`, the `-iEe` argument is equivalent to `--in-place=Ee`, which would create `~/.profileEe` as backup of `~/.profile` if the command executed successfully. However, because the `e` is no longer being processed as an expression argument, `sed` does not correctly join the expressions and exits with `sed: -e expression #2, char 10: unexpected }`.

The proposed change fixes the immediate error, though perhaps it actually makes sense to create a backup for the user (with `-Ei"_backup" -e` or something).

In a larger sense, it's probably a bad idea to use a multi-line, complicated `sed` command (with hold and pattern space actions, no less!) here. It is overly complex, unmaintainable, and happens in a place that's outside of test coverage (as we just saw). An error could also break a user's system. 

It would be safer to provide the user with the lines they need to insert into their config, the state of which `pyenv` knows nothing. And if the desire is to automate this process, then the process should be automated with readable, maintainable, and testable code. (Doesn't `pyenv-installer` already do this?)
