### PR TITLE
Improve `add_miniconda.py`

### DIFF
--- a/plugins/python-build/scripts/add_miniconda.py
+++ b/plugins/python-build/scripts/add_miniconda.py
@@ -44,7 +44,7 @@ esac
 
 install_line_fmt = """
 "{os}-{arch}" )
-  install_script "Miniconda{suffix}-{version_str}-{os}-{arch}" "{repo}/Miniconda{suffix}-{version_str}-{os}-{arch}.sh#{md5}" "miniconda" verify_{py_version}
+  install_script "Miniconda{suffix}-{version_py_version}{version_str}-{os}-{arch}" "{repo}/Miniconda{suffix}-{version_py_version}{version_str}-{os}-{arch}.sh#{md5}" "miniconda" verify_{py_version}
   ;;
 """.strip()
 
@@ -126,17 +126,29 @@ class VersionStr(str):
 class MinicondaVersion(NamedTuple):
     suffix: Suffix
     version_str: VersionStr
+    py_version: Optional[PyVersion]
 
     @classmethod
     def from_str(cls, s):
-        miniconda_n, ver = s.split("-")
-        return MinicondaVersion(Suffix(miniconda_n[-1]), VersionStr(ver))
+        components = s.split("-")
+        if len(components) == 3:
+            miniconda_n, py_ver, ver = components
+            py_ver = PyVersion(f"py{py_ver.replace('.', '')}")
+        else:
+            miniconda_n, ver = components
+            py_ver = None
+        return MinicondaVersion(Suffix(miniconda_n[-1]), VersionStr(ver), py_ver)
 
     def to_filename(self):
-        return f"miniconda{self.suffix}-{self.version_str}"
+        if self.py_version:
+            return f"miniconda{self.suffix}-{self.py_version.version()}-{self.version_str}"
+        else:
+            return f"miniconda{self.suffix}-{self.version_str}"
 
     def default_py_version(self):
-        if self.suffix == Suffix.TWO:
+        if self.py_version:
+            return self.py_version
+        elif self.suffix == Suffix.TWO:
             return PyVersion.PY27
         elif self.version_str.info() < (4, 7):
             # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-python.html
@@ -146,7 +158,7 @@ class MinicondaVersion(NamedTuple):
 
     def with_version_triple(self):
         return MinicondaVersion(
-            self.suffix, VersionStr.from_info(self.version_str.info()[:3])
+            self.suffix, VersionStr.from_info(self.version_str.info()[:3]), self.py_version
         )
 
 
@@ -160,8 +172,13 @@ class MinicondaSpec(NamedTuple):
     @classmethod
     def from_filestem(cls, stem, md5, py_version=None):
         miniconda_n, ver, os, arch = stem.split("-")
+        if ver.startswith("py"):
+            py_ver, ver = ver.split("_", maxsplit=1)
+            py_ver = PyVersion(py_ver)
+        else:
+            py_ver = None
         spec = MinicondaSpec(
-            MinicondaVersion(Suffix(miniconda_n[-1]), VersionStr(ver)),
+            MinicondaVersion(Suffix(miniconda_n[-1]), VersionStr(ver), py_ver),
             SupportedOS(os),
             SupportedArch(arch),
             md5,
@@ -175,6 +192,7 @@ class MinicondaSpec(NamedTuple):
             repo=MINICONDA_REPO,
             suffix=self.version.suffix,
             version_str=self.version.version_str,
+            version_py_version=f"{self.version.py_version}_" if self.version.py_version else "",
             os=self.os,
             arch=self.arch,
             md5=self.md5,

--- a/plugins/python-build/scripts/add_miniconda.py
+++ b/plugins/python-build/scripts/add_miniconda.py
@@ -250,7 +250,7 @@ if __name__ == "__main__":
         help="Do not write scripts, just report them to stdout",
     )
     parser.add_argument(
-        "-v", "--verbose", action="count",
+        "-v", "--verbose", action="count", default=0,
         help="Increase verbosity of logging",
     )
     parsed = parser.parse_args()

--- a/plugins/python-build/share/python-build/miniconda2-2.7-4.8.3
+++ b/plugins/python-build/share/python-build/miniconda2-2.7-4.8.3
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda2-py27_4.8.3-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda2-py27_4.8.3-Linux-ppc64le.sh#120b300120b1362831f2075cc0bd452f" "miniconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda2-py27_4.8.3-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-py27_4.8.3-Linux-x86_64.sh#19ce7d0039ab349914d928e7f32b1c1b" "miniconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda2-py27_4.8.3-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda2-py27_4.8.3-MacOSX-x86_64.sh#14e2d294decc5a48a449b588f5819c10" "miniconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.7-4.10.3
+++ b/plugins/python-build/share/python-build/miniconda3-3.7-4.10.3
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda3-py37_4.10.3-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Linux-ppc64le.sh#a926bbaf28d59ac1264799e3ca770a44" "miniconda" verify_py37
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py37_4.10.3-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh#9f186c1d86c266acc47dbc1603f0e2ed" "miniconda" verify_py37
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py37_4.10.3-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-MacOSX-x86_64.sh#b88a2eb66917c55a6bd1973fabaf05b3" "miniconda" verify_py37
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.8-4.10.3
+++ b/plugins/python-build/share/python-build/miniconda3-3.8-4.10.3
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda3-py38_4.10.3-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-ppc64le.sh#12ddb1b94f30f8fc633c3223b0398d2f" "miniconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py38_4.10.3-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh#14da4a9a44b337f7ccb8363537f65b9c" "miniconda" verify_py38
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py38_4.10.3-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-MacOSX-x86_64.sh#cb609591c280423e999fc421cdb779d3" "miniconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.9-4.10.3
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-4.10.3
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniconda3-py39_4.10.3-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Linux-ppc64le.sh#07ea41c691bdcc7d9c71cae1a1a88151" "miniconda" verify_py39
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py39_4.10.3-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Linux-x86_64.sh#8c69f65a4ae27fb41df0fe552b4a8a3b" "miniconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py39_4.10.3-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-MacOSX-x86_64.sh#09bb30a9204ced74ce3c06762cb442fc" "miniconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - None

### Description
- [x] Here are some details about my PR

I wanted to add the newer versions of miniconda, and I came across this script that works automatically. However, it was unable to handle the newer versions, which is likely why it hasn't been used recently. I made some inelegant fixes to make `add_miniconda.py` work with newer versions of miniconda and creating files from it accordingly.

It would probably look better after a refactor, but that seemed like a lot of work and out-of-scope for this PR.

### Tests
- [x] My PR adds the following unit tests (if any)