### PR TITLE
Don't update conda when installing pip

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1042,7 +1042,9 @@ build_package_anaconda() {
 
 build_package_miniconda() {
   build_package_anaconda "$@"
-  "${PREFIX_PATH}/bin/conda" install --yes "pip"
+  # Workaround to not upgrade conda when installing pip
+  # see https://github.com/pyenv/pyenv/issues/2070
+  "${PREFIX_PATH}/bin/conda" install --yes "pip" "conda=$(${PREFIX_PATH}/bin/conda --version | cut -d ' ' -f 2)
 }
 
 build_package_copy() {

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1044,7 +1044,7 @@ build_package_miniconda() {
   build_package_anaconda "$@"
   # Workaround to not upgrade conda when installing pip
   # see https://github.com/pyenv/pyenv/issues/2070
-  "${PREFIX_PATH}/bin/conda" install --yes "pip" "conda=$(${PREFIX_PATH}/bin/conda --version | cut -d ' ' -f 2)
+  "${PREFIX_PATH}/bin/conda" install --yes "pip" "conda=$(${PREFIX_PATH}/bin/conda --version | cut -d ' ' -f 2)"
 }
 
 build_package_copy() {


### PR DESCRIPTION
### Solution to tell conda to not update other dependencies when installing pip.
The main idea is to specify the existing version of the conda when installing the pip package.  Conda is the main tool for installing packages in miniconda & miniforge. So, some users does not always need the latest version of conda, for example. After installation of miniconda or miniforge, user can update all packages  manually or use such a setting as  `conda config --set auto_update_conda False`.
Thanks to @native-api, @humitos for the suggested solutions.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2070

### Description
- [x ] Here are some details about my PR
- https://github.com/pyenv/pyenv/issues/2070#issue-1000827548

### Tests
- [ ] My PR adds the following unit tests (if any)
