### PR TITLE
Add pyston-2.3.1 support

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -881,18 +881,6 @@ build_package_pyston() {
   build_package_copy
   mv "${PREFIX_PATH}/usr/bin" "${PREFIX_PATH}/bin"
   mv "${PREFIX_PATH}/usr/lib" "${PREFIX_PATH}/lib"
-  local bin
-  shopt -s nullglob
-  for bin in "usr/bin/"*; do
-    if [ -f "${bin}" ] && [ -x "${bin}" ] && [ ! -L "${bin}" ]; then
-      case "${bin##*/}" in
-      "python"* )
-        ( cd "${PREFIX_PATH}/bin" && ln -fs ../usr/bin/"${bin##*/}" "python" )
-        ;;
-      esac
-    fi
-  done
-  shopt -u nullglob
 }
 
 build_package_ironpython() {

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -858,8 +858,8 @@ build_package_jython_builder() {
   ( cd "dist" && build_package_jython )
 }
 
-build_package_pyston() {
-  # currently supported version 2.2 and upper
+build_package_pyston2.2() {
+  # currently supported version 2.2 and 2.3
   build_package_copy
   mkdir -p "${PREFIX_PATH}/bin" "${PREFIX_PATH}/lib"
   local bin
@@ -869,6 +869,25 @@ build_package_pyston() {
       case "${bin##*/}" in
       "pyston"* )
         ( cd "${PREFIX_PATH}/bin" && ln -fs "${bin##*/}" "python" )
+        ;;
+      esac
+    fi
+  done
+  shopt -u nullglob
+}
+
+build_package_pyston() {
+  # currently supported version 2.3.1 and higher
+  build_package_copy
+  mv "${PREFIX_PATH}/usr/bin" "${PREFIX_PATH}/bin"
+  mv "${PREFIX_PATH}/usr/lib" "${PREFIX_PATH}/lib"
+  local bin
+  shopt -s nullglob
+  for bin in "usr/bin/"*; do
+    if [ -f "${bin}" ] && [ -x "${bin}" ] && [ ! -L "${bin}" ]; then
+      case "${bin##*/}" in
+      "python"* )
+        ( cd "${PREFIX_PATH}/bin" && ln -fs ../usr/bin/"${bin##*/}" "python" )
         ;;
       esac
     fi

--- a/plugins/python-build/share/python-build/pyston-2.2
+++ b/plugins/python-build/share/python-build/pyston-2.2
@@ -6,7 +6,7 @@ echo
 
 case "$(pyston_architecture 2>/dev/null || true)" in
 "linux64" )
-  install_package "pyston_2.2" "https://github.com/pyston/pyston/releases/download/pyston_2.2/pyston_2.2_portable.tar.gz#d113cc4d1f6821c0f117f7a84978823d8ac751d7970fa7841eb994663ec5a59f" "pyston" verify_py38 get_pip
+  install_package "pyston_2.2" "https://github.com/pyston/pyston/releases/download/pyston_2.2/pyston_2.2_portable.tar.gz#d113cc4d1f6821c0f117f7a84978823d8ac751d7970fa7841eb994663ec5a59f" "pyston2.2" verify_py38 get_pip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pyston-2.3
+++ b/plugins/python-build/share/python-build/pyston-2.3
@@ -6,7 +6,7 @@ echo
 
 case "$(pyston_architecture 2>/dev/null || true)" in
 "linux64" )
-  install_package "pyston_2.3" "https://github.com/pyston/pyston/releases/download/v2.3/pyston_2.3_portable-v2.tar.gz#90185e29e4a1a19562c095f2bb4e81a5d0715150fa10eca363ec1188b5ba7ee7" "pyston" verify_py38 get_pip
+  install_package "pyston_2.3" "https://github.com/pyston/pyston/releases/download/v2.3/pyston_2.3_portable-v2.tar.gz#90185e29e4a1a19562c095f2bb4e81a5d0715150fa10eca363ec1188b5ba7ee7" "pyston2.2" verify_py38 get_pip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pyston-2.3.1
+++ b/plugins/python-build/share/python-build/pyston-2.3.1
@@ -1,0 +1,19 @@
+echo
+colorize 1 "WARNING"
+echo ": Pyston only runs on x86_64 platforms, and only has been tested on Ubuntu"
+echo "so, your mileage may vary with other Linux distributions."
+echo
+
+case "$(pyston_architecture 2>/dev/null || true)" in
+"linux64" )
+  install_package "pyston_2.3.1" "https://github.com/pyston/pyston/releases/download/pyston_2.3.1/pyston_2.3.1_portable.tar.gz#04ba4cb0249973870b8f198f05d6d22c054cb5b059865cacf7e623b3624949e8" "pyston" verify_py38 get_pip
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": A Pyston 2.3.1 binary is not available for $(pyston_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
We changed the directory structure for pyston 2.3.1 slightly, where we now
include a top-level "pyston-2.3.1" directory when you unpack the tarball.

My first time looking at pyenv so I'm not super confident in how I've laid things out.