### PR TITLE
Update to Pyston's v2 package of the 2.3.1 release

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -877,10 +877,8 @@ build_package_pyston2.2() {
 }
 
 build_package_pyston() {
-  # currently supported version 2.3.1 and higher
+  # currently supported version 2.3.1v2 and higher
   build_package_copy
-  mv "${PREFIX_PATH}/usr/bin" "${PREFIX_PATH}/bin"
-  mv "${PREFIX_PATH}/usr/lib" "${PREFIX_PATH}/lib"
 }
 
 build_package_ironpython() {

--- a/plugins/python-build/share/python-build/pyston-2.3.1
+++ b/plugins/python-build/share/python-build/pyston-2.3.1
@@ -6,7 +6,7 @@ echo
 
 case "$(pyston_architecture 2>/dev/null || true)" in
 "linux64" )
-  install_package "pyston_2.3.1" "https://github.com/pyston/pyston/releases/download/pyston_2.3.1/pyston_2.3.1_portable.tar.gz#04ba4cb0249973870b8f198f05d6d22c054cb5b059865cacf7e623b3624949e8" "pyston" verify_py38 get_pip
+  install_package "pyston_2.3.1" "https://github.com/pyston/pyston/releases/download/pyston_2.3.1/pyston_2.3.1_portable_v2.tar.gz#4e16df1eaf5f226c0629f2db1e63033454c94cb9e29f50154177819662df5b15" "pyston" verify_py38 get_pip
   ;;
 * )
   { echo


### PR DESCRIPTION
This package gets rid of the extra "usr" subdirectory that we had and now fits the format that pyenv expects

We got a bug report that compiling extension modules failed, because in my old patch the header files were still located at `usr/include` whereas the binary was at `bin` so it was only looking for `include`