### PR TITLE
Fix installation instructions for Ubuntu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ easy to fork and contribute any changes back upstream.
          a \
          export PATH="$PYENV_ROOT/bin:$PATH"
          a \
-         ' -e ':a' -e '$!{n;ba};}' ~/.profile
+         ' -e ':a' -e '$!{n;ba};}' ~/.bashrc
          echo 'eval "$(pyenv init --path)"' >>~/.profile
 
          echo 'eval "$(pyenv init -)"' >> ~/.bashrc


### PR DESCRIPTION
### Description

Current instructions didn't work for me on Ubuntu installation.
Since `.bashrc` doesn't source `.profile` (it's the opposite), `$PATH` variables were not updated by the time `pyenv` is called. 

Proposing the fix that makes them work.

