### PR TITLE
Disable conda package self-update

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1059,9 +1059,7 @@ build_package_miniconda_autoupdate() {
 
 build_package_miniconda() {
   build_package_anaconda "$@"
-  # Workaround to not upgrade conda when installing pip
-  # see https://github.com/pyenv/pyenv/issues/2070
-  "${PREFIX_PATH}/bin/conda" install --yes "pip" "conda=$(${PREFIX_PATH}/bin/conda --version | cut -d ' ' -f 2)"
+  "${PREFIX_PATH}/bin/conda" install --yes "pip"
 }
 
 build_package_copy() {

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1041,10 +1041,20 @@ anaconda_architecture() {
   esac
 }
 
-build_package_anaconda() {
+build_package_anaconda_autoupdate() {
   local package_name="$1"
-  { bash "${package_name}.sh" -f -b -p "${PREFIX_PATH}"
+  { bash "${package_name}.sh" -x -f -b -p "${PREFIX_PATH}"
   } >&4 2>&1
+}
+
+build_package_anaconda() {
+  build_package_anaconda_autoupdate "$@"
+  "${PREFIX_PATH}/bin/conda" config --set auto_update_conda False
+}
+
+build_package_miniconda_autoupdate() {
+  build_package_anaconda_autoupdate "$@"
+  "${PREFIX_PATH}/bin/conda" install --yes "pip"
 }
 
 build_package_miniconda() {

--- a/plugins/python-build/share/python-build/miniconda2-latest
+++ b/plugins/python-build/share/python-build/miniconda2-latest
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda2-latest-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86.sh" "miniconda" verify_py27
+  install_script "Miniconda2-latest-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86.sh" "miniconda_autoupdate" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda2-latest-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh" "miniconda" verify_py27
+  install_script "Miniconda2-latest-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh" "miniconda_autoupdate" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda2-latest-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh" "miniconda" verify_py27
+  install_script "Miniconda2-latest-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh" "miniconda_autoupdate" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-latest
+++ b/plugins/python-build/share/python-build/miniconda3-latest
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda3-latest-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86.sh" "miniconda" verify_py3_latest
+  install_script "Miniconda3-latest-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86.sh" "miniconda_autoupdate" verify_py3_latest
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-latest-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" "miniconda" verify_py3_latest
+  install_script "Miniconda3-latest-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" "miniconda_autoupdate" verify_py3_latest
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-latest-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" "miniconda" verify_py3_latest
+  install_script "Miniconda3-latest-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" "miniconda_autoupdate" verify_py3_latest
   ;;
 * )
   { echo


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2070

### Description
https://conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#update-conda-automatically-auto-update-conda is the option intended to prevent implicit `conda` package updates.

CAUTION: it seems to [still not protect from `conda update --all`](https://github.com/conda/conda/issues/5294)!! Pinning protects from it, but it's local to an environment. Since we shim `conda`, we can propagate the pin to other environments as they are created, but that'd be another feature.

### Tests
- [x] My PR adds the following unit tests (if any)
Test the feature + helper fns for Anaconda