### PR TITLE
Discover Tcl/Tk reliably and use active version

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1533,12 +1533,13 @@ use_xcode_sdk_zlib() {
 
 use_homebrew_tcltk() {
   # get the version from the folder that homebrew versions
-  local tcltk_version_long="$(ls "$(brew --cellar tcl-tk)")"
-  local tcltk_version="${tcltk_version_long%.*}"
-  local tcltk_flags="--with-tcltk-includes=-I$tcltk_libdir/include --with-tcltk-libs=-L$tcltk_libdir/lib -ltcl$tcltk_version -ltk$tcltk_version"
-  echo "python-build: use tcl-tk from homebrew"
-  package_option python configure --with-tcltk-libs="-L$tcltk_libdir/lib -ltcl$tcltk_version -ltk$tcltk_version"
-  package_option python configure --with-tcltk-includes="-I$tcltk_libdir/include"
+  local tcltk_libdir="$(brew --prefix tcl-tk 2>/dev/null || true)"
+  if [ -d "$tcltk_libdir" ]; then
+    echo "python-build: use tcl-tk from homebrew"
+    local tcltk_version="$(sh -c '. '"$tcltk_libdir"'/lib/tclConfig.sh; echo $TCL_VERSION')"
+    package_option python configure --with-tcltk-libs="-L$tcltk_libdir/lib -ltcl$tcltk_version -ltk$tcltk_version"
+    package_option python configure --with-tcltk-includes="-I$tcltk_libdir/include"
+  fi
 }
 
 # FIXME: this function is a workaround for #1125

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -242,18 +242,15 @@ OUT
 
 @test "tcl-tk is linked from Homebrew" {
   cached_tarball "Python-3.6.2"
-
-  # python build
+  tcl_tk_version=8.6
   tcl_tk_libdir="$TMP/homebrew-tcl-tk"
-  tcl_tk_version_long="8.6.10"
-  tcl_tk_version="${tcl_tk_version_long%.*}"
-  mkdir -p "$tcl_tk_libdir"
-  mkdir -p "$tcl_tk_libdir/$tcl_tk_version_long"
+  mkdir -p "$tcl_tk_libdir/lib"
+  echo "TCL_VERSION='$tcl_tk_version'" >>"$tcl_tk_libdir/lib/tclConfig.sh"
 
-  # pyenv/pyenv#1026
-  stub uname false false
+  stub uname false
 
-  stub brew "--prefix tcl-tk : echo '$tcl_tk_libdir'" "--cellar tcl-tk : echo '$TMP/homebrew-tcl-tk'" false
+  for i in {1..2}; do stub brew "--prefix tcl-tk : echo '$tcl_tk_libdir'"; done
+  stub brew false
   stub_make_install
 
   run_inline_definition <<DEF


### PR DESCRIPTION
Link to the active version like other Homebrew deps --
this won't break when another binary-compatible version is installed.
Use a discovery method that doesn't break when other versions are present alongside.

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2102

### Description
- [x] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)
