### PR TITLE
Default --with-universal-archs to universal2 on Apple Silicon

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2137,13 +2137,21 @@ if [[ "$CONFIGURE_OPTS $PYTHON_CONFIGURE_OPTS" == *"--enable-framework"* ]]; the
   package_option python configure --enable-framework="${PREFIX_PATH}/Library/Frameworks"
 fi
 
-# Build against universal SDK (#219, #220)
+# Build against universal SDK
 if [[ "$CONFIGURE_OPTS $PYTHON_CONFIGURE_OPTS" == *"--enable-universalsdk"* ]]; then
   if ! is_mac; then
     echo "python-build: universal installation is not supported." >&2
     exit 1
   fi
-  package_option python configure --enable-universalsdk=/ --with-universal-archs=intel
+  package_option python configure --enable-universalsdk=/
+  if [[ "$CONFIGURE_OPTS $PYTHON_CONFIGURE_OPTS" != *"--enable-universal-archs"* ]]; then
+    # in CPython's configure.ac, --with-universal-archs defaults to 'intel' which means i386 + x86_64
+    # since 2.7.5 and 3.3.0 -- i.e. in all non-EOL versions
+    # Apple Silicon cannot build these, in it, it rather makes sense to default to Universal2 binaries
+    if [[ $(arch) == "arm64" ]]; then
+      package_option python configure --with-universal-archs=universal2
+    fi
+  fi
 fi
 
 # Compile with `--enable-unicode=ucs4` by default (#257)

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -273,13 +273,41 @@ EOS
 @test "enable universalsdk" {
   
   for i in {1..3}; do stub uname '-s : echo Darwin'; done
+  stub arch "echo x86_64"
 
   PYTHON_CONFIGURE_OPTS="--enable-universalsdk" TMPDIR="$TMP" run_inline_definition <<OUT
 echo "PYTHON_CONFIGURE_OPTS_ARRAY=(\${PYTHON_CONFIGURE_OPTS_ARRAY[@]})"
 OUT
   assert_success
   assert_output <<EOS
-PYTHON_CONFIGURE_OPTS_ARRAY=(--libdir=${TMP}/install/lib --enable-universalsdk=/ --with-universal-archs=intel)
+PYTHON_CONFIGURE_OPTS_ARRAY=(--libdir=${TMP}/install/lib --enable-universalsdk=/)
+EOS
+}
+
+@test "enable universalsdk on Apple Silicon" {
+
+  for i in {1..3}; do stub uname '-s : echo Darwin'; done
+  stub arch "echo arm64"
+
+  PYTHON_CONFIGURE_OPTS="--enable-universalsdk" TMPDIR="$TMP" run_inline_definition <<OUT
+echo "PYTHON_CONFIGURE_OPTS_ARRAY=(\${PYTHON_CONFIGURE_OPTS_ARRAY[@]})"
+OUT
+  assert_success
+  assert_output <<EOS
+PYTHON_CONFIGURE_OPTS_ARRAY=(--libdir=${TMP}/install/lib --enable-universalsdk=/ --with-universal-archs=universal2)
+EOS
+}
+
+@test "enable universalsdk with explicit archs argument" {
+
+  for i in {1..3}; do stub uname '-s : echo Darwin'; done
+
+  PYTHON_CONFIGURE_OPTS="--enable-universalsdk --with-universal-archs=foo" TMPDIR="$TMP" run_inline_definition <<OUT
+echo "PYTHON_CONFIGURE_OPTS_ARRAY=(\${PYTHON_CONFIGURE_OPTS_ARRAY[@]})"
+OUT
+  assert_success
+  assert_output <<EOS
+PYTHON_CONFIGURE_OPTS_ARRAY=(--libdir=${TMP}/install/lib --enable-universalsdk=/)
 EOS
 }
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2121

### Description
- [x] Here are some details about my PR

https://github.com/pyenv/pyenv/issues/2121#issuecomment-950185279

### Tests
- [x] My PR adds the following unit tests (if any)

For added universalsdk handling logic