### PR TITLE
Add documentation for init command

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -22,6 +22,7 @@ The most common subcommands are:
 * [`pyenv hooks`](#pyenv-hooks)
 * [`pyenv shims`](#pyenv-shims)
 * [`pyenv init`](#pyenv-init)
+* [`pyenv completions`](#pyenv-completions)
 
 ## `pyenv commands`
 
@@ -357,3 +358,9 @@ Configure the shell environment for pyenv
                            and shell function
       --path               Print shims path
       --no-rehash          Add no rehash command to output     
+
+## `pyenv completions`
+
+Lists available completions for a given pyenv command.
+
+    Usage: pyenv completions <command> [arg1 arg2...]

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ easy to fork and contribute any changes back upstream.
 
          In MacOS, make sure that your terminal app runs the shell as a login shell.
 
-      - **Temporary environments (CI, batch jobs):**
+      - **Temporary environments (CI, Docker, batch jobs):**
 
          In CI/build environments, paths and the environment are usually already set up for you
          in one of the above ways.
@@ -322,6 +322,18 @@ easy to fork and contribute any changes back upstream.
          ~~~bash
          echo 'eval "$(pyenv init -)"'
          ~~~
+         
+         If you are installing Pyenv yourself as part of the batch job,
+         after installing the files, run the following in the job's shell
+         to be able to use it.
+         
+         ~~~bash
+         export PYENV_ROOT="$HOME/.pyenv"
+         export PATH="$PYENV_ROOT/bin:$PATH"    # if `pyenv` is not already on PATH
+         eval "$(pyenv init --path)"
+         eval "$(pyenv init -)"
+         ~~~
+
          
       **General Bash warning**: There are some systems where the `BASH_ENV` variable is configured
       to point to `.bashrc`. On such systems, you should almost certainly put the


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/1527

### Description
- [x ] Added documentation for `init` command in [COMMANDS.md](https://github.com/pyenv/pyenv/blob/master/COMMANDS.md)

### Tests
- [ ] My PR adds the following unit tests (if any)
