### PR TITLE
Adding PyPy release 7.3.7 (Python 3.7 and 3.8).

### DIFF
--- a/plugins/python-build/share/python-build/pypy3.7-7.3.7
+++ b/plugins/python-build/share/python-build/pypy3.7-7.3.7
@@ -1,0 +1,43 @@
+VERSION='7.3.7'
+PYVER='3.7'
+# https://www.pypy.org/checksums.html
+
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux" )
+  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#0ab9e2e8ae1ac463bb811b9d3ba24d138f41f7378c17ca9e2d8dee51bf151d19" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux64" )
+  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#8332f923755441fedfe4767a84601c94f4d6f8475384406cb5f259ad8d0b2002" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux-aarch64" )
+  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#a1a84882525dd574c4b051b66e9b7ef0e132392acc2f729420d7825f96835216" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"osx64" )
+  if require_osx_version "10.13"; then
+    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#edc9df7d0f7c56f7ee05b24117bdb6c03aa65e768471e210c05ccdbbfd11a866" "pypy" "verify_py${PYVER//./}" ensurepip
+  else
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true), OS X < 10.13."
+      echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+      echo
+    } >&2
+    exit 1
+  fi
+  ;;
+"s390x" )
+  install_package "pypy${PYVER}-v${VERSION}-s390x" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-s390x.tar.bz2#7f91efc65a69e727519cc885ca6351f4bfdd6b90580dced2fdcc9ae1bf10013b" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"win64" )
+  install_zip "pypy${PYVER}-v${VERSION}-win64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-win64.zip#53505dc0b57590290efd7656117ee5384bcd036f7f7c4f0bc3f5cd10299037d1" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/pypy3.7-7.3.7-src
+++ b/plugins/python-build/share/python-build/pypy3.7-7.3.7-src
@@ -1,0 +1,7 @@
+VERSION='7.3.7'
+PYVER='3.7'
+
+#require_gcc
+prefer_openssl11
+install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
+install_package "pypy${PYVER}-v${VERSION}-src" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-src.tar.bz2#2ed02ac9e710859c41bc82deafb08619792bb9a27eeaa1676c741ededd214dd7" "pypy_builder" "verify_py${PYVER//./}" ensurepip

--- a/plugins/python-build/share/python-build/pypy3.8-7.3.7
+++ b/plugins/python-build/share/python-build/pypy3.8-7.3.7
@@ -1,0 +1,43 @@
+VERSION='7.3.7'
+PYVER='3.8'
+# https://www.pypy.org/checksums.html
+
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux" )
+  install_package "pypy${PYVER}-v${VERSION}-linux32" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux32.tar.bz2#dfb9d005f0fc917edc60fd618143e4934c412f9168b55166f5519ba0a3b1a835" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux64" )
+  install_package "pypy${PYVER}-v${VERSION}-linux64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#5dee37c7c3cb8b160028fbde3a5901c68043dfa545a16794502b897d4bc40d7e" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"linux-aarch64" )
+  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#cbd44e0a9146b3c03a9d14b265774a848f387ed846316c3e984847e278d0efd3" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"osx64" )
+  if require_osx_version "10.13"; then
+    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#1f044fe7bbdd443b7913ecf554683dab6dade5dcd7f47d4e6d01f4bb4cf84836" "pypy" "verify_py${PYVER//./}" ensurepip
+  else
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true), OS X < 10.13."
+      echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+      echo
+    } >&2
+    exit 1
+  fi
+  ;;
+"s390x" )
+  install_package "pypy${PYVER}-v${VERSION}-s390x" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-s390x.zip#ae7d6a76490b317a74b87788d596610c7ffd0ae2d3ffa2433d5bb5300f6b4b77" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+"win64" )
+  install_zip "pypy${PYVER}-v${VERSION}-win64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-win64.zip#8ceb03d2f7b73c6ce0758290bc42ba366a45c46e033eda36f1779d957a905735" "pypy" "verify_py${PYVER//./}" ensurepip
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of PyPy is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo "try 'pypy${PYVER}-${VERSION}-src' to build from source."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/pypy3.8-7.3.7-src
+++ b/plugins/python-build/share/python-build/pypy3.8-7.3.7-src
@@ -1,0 +1,8 @@
+VERSION='7.3.7'
+PYVER='3.8'
+# https://www.pypy.org/checksums.html
+
+#require_gcc
+prefer_openssl11
+install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
+install_package "pypy${PYVER}-v${VERSION}-src" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-src.tar.bz2#21ae339f4f5016d6ca7300305f3e3b554373835cb3c39a9041fe30e6811c80c6" "pypy_builder" "verify_py${PYVER//./}" ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)

### Description
- [x] Here are some details about my PR: This adds four new versions

### Tests
- [x] My PR adds the following unit tests (if any)
