### PR TITLE
Add instructions to check if login shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ easy to fork and contribute any changes back upstream.
    (especially if you're using an alternative terminal app and/or shell).
    The configuration samples for MacOS are written under this assumption and won't work otherwise.
    
+   In zsh, this can be checked using this line of code:
+   ~~~ zsh
+         if [[ -o login ]]; then echo "login shell"; else echo "not login shell"; fi
+   ~~~
+
+   
    - For **Bash**:
 
       - **If your `~/.profile` sources `~/.bashrc` (Debian, Ubuntu, Mint):**


### PR DESCRIPTION
Line 251> "Make sure that your terminal app is configured to run the shell as a login shell"
Finding the instructions to check for this in zsh, the default shell for MacOS as of Big Sur, took me some time

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)
