### PR TITLE
Add definition of pyenv help in COMMANDS.md

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -27,48 +27,8 @@ The most common subcommands are:
 
 ## `pyenv help`
 
-List all available pyenv commands along with a brief description of what they do. Run `pyenv help <command>` for information on a specific command.
+List all available pyenv commands along with a brief description of what they do. Run `pyenv help <command>` for information on a specific command. For full documentation, see: https://github.com/pyenv/pyenv#readme
 
-```
-$ pyenv help
-Usage: pyenv <command> [<args>]
-
-Some useful pyenv commands are:
-   activate    Activate virtual environment
-   commands    List all available pyenv commands
-   deactivate   Deactivate virtual environment
-   doctor      Verify pyenv installation and development tools to build pythons.
-   exec        Run an executable with the selected Python version
-   global      Set or show the global Python version(s)
-   help        Display help for a command
-   hooks       List hook scripts for a given pyenv command
-   init        Configure the shell environment for pyenv
-   install     Install a Python version using python-build
-   local       Set or show the local application-specific Python version(s)
-   prefix      Display prefix for a Python version
-   rehash      Rehash pyenv shims (run this after installing executables)
-   root        Display the root directory where versions and shims are kept
-   shell       Set or show the shell-specific Python version
-   shims       List existing pyenv shims
-   uninstall   Uninstall a specific Python version
-   --version   Display the version of pyenv
-   version     Show the current Python version(s) and its origin
-   version-file   Detect the file that sets the current pyenv version
-   version-name   Show the current Python version
-   version-origin   Explain how the current Python version is set
-   versions    List all Python versions available to pyenv
-   virtualenv   Create a Python virtualenv using the pyenv-virtualenv plugin
-   virtualenv-delete   Uninstall a specific Python virtualenv
-   virtualenv-init   Configure the shell environment for pyenv-virtualenv
-   virtualenv-prefix   Display real_prefix for a Python virtualenv version
-   virtualenvs   List all Python virtualenvs found in `$PYENV_ROOT/versions/*'.
-   whence      List all Python versions that contain the given executable
-   which       Display the full path to an executable
-
-See `pyenv help <command>' for information on a specific command.
-For full documentation, see: https://github.com/pyenv/pyenv#readme
-
-```
 
 ## `pyenv commands`
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -5,6 +5,7 @@ first argument.
 
 The most common subcommands are:
 
+* [`pyenv help`](#pyenv-help)
 * [`pyenv commands`](#pyenv-commands)
 * [`pyenv local`](#pyenv-local)
 * [`pyenv global`](#pyenv-global)
@@ -23,6 +24,51 @@ The most common subcommands are:
 * [`pyenv shims`](#pyenv-shims)
 * [`pyenv init`](#pyenv-init)
 * [`pyenv completions`](#pyenv-completions)
+
+## `pyenv help`
+
+List all available pyenv commands along with a brief description of what they do. Run `pyenv help <command>` for information on a specific command.
+
+```
+$ pyenv help
+Usage: pyenv <command> [<args>]
+
+Some useful pyenv commands are:
+   activate    Activate virtual environment
+   commands    List all available pyenv commands
+   deactivate   Deactivate virtual environment
+   doctor      Verify pyenv installation and development tools to build pythons.
+   exec        Run an executable with the selected Python version
+   global      Set or show the global Python version(s)
+   help        Display help for a command
+   hooks       List hook scripts for a given pyenv command
+   init        Configure the shell environment for pyenv
+   install     Install a Python version using python-build
+   local       Set or show the local application-specific Python version(s)
+   prefix      Display prefix for a Python version
+   rehash      Rehash pyenv shims (run this after installing executables)
+   root        Display the root directory where versions and shims are kept
+   shell       Set or show the shell-specific Python version
+   shims       List existing pyenv shims
+   uninstall   Uninstall a specific Python version
+   --version   Display the version of pyenv
+   version     Show the current Python version(s) and its origin
+   version-file   Detect the file that sets the current pyenv version
+   version-name   Show the current Python version
+   version-origin   Explain how the current Python version is set
+   versions    List all Python versions available to pyenv
+   virtualenv   Create a Python virtualenv using the pyenv-virtualenv plugin
+   virtualenv-delete   Uninstall a specific Python virtualenv
+   virtualenv-init   Configure the shell environment for pyenv-virtualenv
+   virtualenv-prefix   Display real_prefix for a Python virtualenv version
+   virtualenvs   List all Python virtualenvs found in `$PYENV_ROOT/versions/*'.
+   whence      List all Python versions that contain the given executable
+   which       Display the full path to an executable
+
+See `pyenv help <command>' for information on a specific command.
+For full documentation, see: https://github.com/pyenv/pyenv#readme
+
+```
 
 ## `pyenv commands`
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -333,18 +333,18 @@ Lists all Python versions with the given command installed.
 
 ## `pyenv exec`
 
-    `Usage: pyenv exec <command> [arg1 arg2...]`
+    Usage: pyenv exec <command> [arg1 arg2...]
 
 Runs an executable by first preparing PATH so that the selected Python
 version's `bin` directory is at the front.
 
 For example, if the currently selected Python version is 3.9.7:
 
-    `pyenv exec pip install -r requirements.txt`
+    pyenv exec pip install -r requirements.txt
     
 is equivalent to:
 
-    `PATH="$PYENV_ROOT/versions/3.9.7/bin:$PATH" pip install -r requirements.txt`
+    PATH="$PYENV_ROOT/versions/3.9.7/bin:$PATH" pip install -r requirements.txt
 
 ## `pyenv root`
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Add missing definition of `pyenv help` in COMMANDS.md

### Tests
- [ ] My PR adds the following unit tests (if any)
