### PR TITLE
Use command -v instead of which in python-build test

### DIFF
--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -183,7 +183,7 @@ OUT
 }
 
 @test "pyenv-install has usage help preface" {
-  run head "$(which pyenv-install)"
+  run head "$(command -v pyenv-install)"
   assert_output_contains 'Usage: pyenv install'
 }
 
@@ -212,6 +212,6 @@ OUT
 }
 
 @test "pyenv-uninstall has usage help preface" {
-  run head "$(which pyenv-uninstall)"
+  run head "$(command -v pyenv-uninstall)"
   assert_output_contains 'Usage: pyenv uninstall'
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -110,28 +110,13 @@ assert() {
   fi
 }
 
-which_a() {
-    if command -v which; then
-        # which -a is portable
-        which -a "$@"
-    elif command -v whereis; then
-        local where
-        # -b to whereis is not portable, not available e.g. in macOS 11
-        where=$(whereis -b "$@") || return $?
-        [ -z "$where" ] && return 1
-    else
-        echo "which -a or whereis -b required" >&2
-        return 127
-    fi
-}
-
 # Output a modified PATH that ensures that the given executable is not present,
 # but in which system utils necessary for pyenv operation are still available.
 path_without() {
   local path=":${PATH}:"
   for exe; do 
     local found alt util
-    for found in $(PATH="$path" which_a "$exe"); do
+    for found in $(PATH="$path" type -aP "$exe"); do
       found="${found%/*}"
       if [ "$found" != "${PYENV_ROOT}/shims" ]; then
         alt="${PYENV_TEST_DIR}/$(echo "${found#/}" | tr '/' '-')"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -110,13 +110,28 @@ assert() {
   fi
 }
 
+which_a() {
+    if command -v which; then
+        # which -a is portable
+        which -a "$@"
+    elif command -v whereis; then
+        local where
+        # -b to whereis is not portable, not available e.g. in macOS 11
+        where=$(whereis -b "$@") || return $?
+        [ -z "$where" ] && return 1
+    else
+        echo "which -a or whereis -b required" >&2
+        return 127
+    fi
+}
+
 # Output a modified PATH that ensures that the given executable is not present,
 # but in which system utils necessary for pyenv operation are still available.
 path_without() {
   local path=":${PATH}:"
   for exe; do 
     local found alt util
-    for found in $(PATH="$path" whereis -b "$exe" | sed -e "s/.*://"); do
+    for found in $(PATH="$path" which_a "$exe"); do
       found="${found%/*}"
       if [ "$found" != "${PYENV_ROOT}/shims" ]; then
         alt="${PYENV_TEST_DIR}/$(echo "${found#/}" | tr '/' '-')"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -116,7 +116,7 @@ path_without() {
   local path=":${PATH}:"
   for exe; do 
     local found alt util
-    for found in $(PATH="$path" which -a "$exe"); do
+    for found in $(PATH="$path" whereis -b "$exe" | sed -e "s/.*://"); do
       found="${found%/*}"
       if [ "$found" != "${PYENV_ROOT}/shims" ]; then
         alt="${PYENV_TEST_DIR}/$(echo "${found#/}" | tr '/' '-')"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -121,7 +121,7 @@ path_without() {
       if [ "$found" != "${PYENV_ROOT}/shims" ]; then
         alt="${PYENV_TEST_DIR}/$(echo "${found#/}" | tr '/' '-')"
         mkdir -p "$alt"
-        for util in bash head cut readlink greadlink which; do
+        for util in bash head cut readlink greadlink; do
           if [ -x "${found}/$util" ]; then
             ln -s "${found}/$util" "${alt}/$util"
           fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
  * https://github.com/rbenv/rbenv/pull/1359
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

`which` has been deprecated in Debian's debianutils 5.0+ (currently only
Debian unstable), use `command -v` instead like is already done
elsewhere.

### Tests
- [ ] My PR adds the following unit tests (if any)
