### PR TITLE
Support arm64 identifier from brew coreutils' uname for 2.7/3.7+.

### DIFF
--- a/plugins/python-build/share/python-build/patches/2.7.18/Python-2.7.18/0008-Support-arm64-identifier-from-brew-coreutils-uname-f.patch
+++ b/plugins/python-build/share/python-build/patches/2.7.18/Python-2.7.18/0008-Support-arm64-identifier-from-brew-coreutils-uname-f.patch
@@ -1,0 +1,38 @@
+From 88a8e34c7eb48dcb80d8c2717e6f3fa5ed049819 Mon Sep 17 00:00:00 2001
+From: Christian Hammond <christian@beanbaginc.com>
+Date: Fri, 12 Nov 2021 23:20:35 -0800
+Subject: [PATCH] Support "arm64" identifier from brew coreutils' uname for
+ Python 2.7.18.
+
+Python 2.7.18's `config.sub` attempts to determine whether the OS and
+machine identifier type returned by `uname` is a valid target for
+compilation. On M1 Macs, the system-default `uname` returns a value
+that's eventually parsed as "arm-apple-darwin21.0.1", which passes the
+pattern matching.
+
+However, if the coreutils Homebrew target is installed and its version
+of `uname` is in the path, the result is "arm64-apple-darwin21.0.1".
+This isn't handled by the existing patterns, and fails the build.
+
+This change adds `arm64-*` to the list of patterns, alongside `arm-*`,
+allowing compilation to proceed.
+---
+ config.sub | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config.sub b/config.sub
+index 40ea5dfe11..6fa6fe879a 100755
+--- a/config.sub
++++ b/config.sub
+@@ -376,7 +376,7 @@ case $basic_machine in
+ 	| alpha-* | alphaev[4-8]-* | alphaev56-* | alphaev6[78]-* \
+ 	| alpha64-* | alpha64ev[4-8]-* | alpha64ev56-* | alpha64ev6[78]-* \
+ 	| alphapca5[67]-* | alpha64pca5[67]-* | arc-* | arceb-* \
+-	| arm-*  | armbe-* | armle-* | armeb-* | armv*-* \
++	| arm-* | arm64-* | armbe-* | armle-* | armeb-* | armv*-* \
+ 	| avr-* | avr32-* \
+ 	| ba-* \
+ 	| be32-* | be64-* \
+-- 
+2.30.1 (Apple Git-130)
+

--- a/plugins/python-build/share/python-build/patches/3.10.0/Python-3.10.0/0002-Support-arm64-identifier-from-brew-coreutils-uname-f.patch
+++ b/plugins/python-build/share/python-build/patches/3.10.0/Python-3.10.0/0002-Support-arm64-identifier-from-brew-coreutils-uname-f.patch
@@ -1,0 +1,38 @@
+From 3af6d21e6e93984e9b139fcc57a2eef64ddcfe13 Mon Sep 17 00:00:00 2001
+From: Christian Hammond <christian@beanbaginc.com>
+Date: Fri, 12 Nov 2021 23:20:35 -0800
+Subject: [PATCH] Support "arm64" identifier from brew coreutils' uname for
+ Python 2.7.18.
+
+Python 2.7.18's `config.sub` attempts to determine whether the OS and
+machine identifier type returned by `uname` is a valid target for
+compilation. On M1 Macs, the system-default `uname` returns a value
+that's eventually parsed as "arm-apple-darwin21.0.1", which passes the
+pattern matching.
+
+However, if the coreutils Homebrew target is installed and its version
+of `uname` is in the path, the result is "arm64-apple-darwin21.0.1".
+This isn't handled by the existing patterns, and fails the build.
+
+This change adds `arm64-*` to the list of patterns, alongside `arm-*`,
+allowing compilation to proceed.
+---
+ config.sub | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config.sub b/config.sub
+index ba37cf99e2..fa72be4420 100755
+--- a/config.sub
++++ b/config.sub
+@@ -376,7 +376,7 @@ case $basic_machine in
+ 	| alpha-* | alphaev[4-8]-* | alphaev56-* | alphaev6[78]-* \
+ 	| alpha64-* | alpha64ev[4-8]-* | alpha64ev56-* | alpha64ev6[78]-* \
+ 	| alphapca5[67]-* | alpha64pca5[67]-* | arc-* | arceb-* \
+-	| arm-*  | armbe-* | armle-* | armeb-* | armv*-* \
++	| arm-* | arm64-* | armbe-* | armle-* | armeb-* | armv*-* \
+ 	| avr-* | avr32-* \
+ 	| ba-* \
+ 	| be32-* | be64-* \
+-- 
+2.30.1 (Apple Git-130)
+

--- a/plugins/python-build/share/python-build/patches/3.7.12/Python-3.7.12/0001-Support-arm64-identifier-from-brew-coreutils-uname-f.patch
+++ b/plugins/python-build/share/python-build/patches/3.7.12/Python-3.7.12/0001-Support-arm64-identifier-from-brew-coreutils-uname-f.patch
@@ -1,0 +1,38 @@
+From cb91ff180cd3ccf78546fd4997c564868283b9f9 Mon Sep 17 00:00:00 2001
+From: Christian Hammond <christian@beanbaginc.com>
+Date: Fri, 12 Nov 2021 23:20:35 -0800
+Subject: [PATCH] Support "arm64" identifier from brew coreutils' uname for
+ Python 2.7.18.
+
+Python 2.7.18's `config.sub` attempts to determine whether the OS and
+machine identifier type returned by `uname` is a valid target for
+compilation. On M1 Macs, the system-default `uname` returns a value
+that's eventually parsed as "arm-apple-darwin21.0.1", which passes the
+pattern matching.
+
+However, if the coreutils Homebrew target is installed and its version
+of `uname` is in the path, the result is "arm64-apple-darwin21.0.1".
+This isn't handled by the existing patterns, and fails the build.
+
+This change adds `arm64-*` to the list of patterns, alongside `arm-*`,
+allowing compilation to proceed.
+---
+ config.sub | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config.sub b/config.sub
+index ba37cf99e2..fa72be4420 100755
+--- a/config.sub
++++ b/config.sub
+@@ -376,7 +376,7 @@ case $basic_machine in
+ 	| alpha-* | alphaev[4-8]-* | alphaev56-* | alphaev6[78]-* \
+ 	| alpha64-* | alpha64ev[4-8]-* | alpha64ev56-* | alpha64ev6[78]-* \
+ 	| alphapca5[67]-* | alpha64pca5[67]-* | arc-* | arceb-* \
+-	| arm-*  | armbe-* | armle-* | armeb-* | armv*-* \
++	| arm-* | arm64-* | armbe-* | armle-* | armeb-* | armv*-* \
+ 	| avr-* | avr32-* \
+ 	| ba-* \
+ 	| be32-* | be64-* \
+-- 
+2.30.1 (Apple Git-130)
+

--- a/plugins/python-build/share/python-build/patches/3.8.12/Python-3.8.12/0001-Support-arm64-identifier-from-brew-coreutils-uname-f.patch
+++ b/plugins/python-build/share/python-build/patches/3.8.12/Python-3.8.12/0001-Support-arm64-identifier-from-brew-coreutils-uname-f.patch
@@ -1,0 +1,38 @@
+From 148bf6f8e0d886196d648c0ec753d6362b26c7b5 Mon Sep 17 00:00:00 2001
+From: Christian Hammond <christian@beanbaginc.com>
+Date: Fri, 12 Nov 2021 23:20:35 -0800
+Subject: [PATCH] Support "arm64" identifier from brew coreutils' uname for
+ Python 2.7.18.
+
+Python 2.7.18's `config.sub` attempts to determine whether the OS and
+machine identifier type returned by `uname` is a valid target for
+compilation. On M1 Macs, the system-default `uname` returns a value
+that's eventually parsed as "arm-apple-darwin21.0.1", which passes the
+pattern matching.
+
+However, if the coreutils Homebrew target is installed and its version
+of `uname` is in the path, the result is "arm64-apple-darwin21.0.1".
+This isn't handled by the existing patterns, and fails the build.
+
+This change adds `arm64-*` to the list of patterns, alongside `arm-*`,
+allowing compilation to proceed.
+---
+ config.sub | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config.sub b/config.sub
+index ba37cf99e2..fa72be4420 100755
+--- a/config.sub
++++ b/config.sub
+@@ -376,7 +376,7 @@ case $basic_machine in
+ 	| alpha-* | alphaev[4-8]-* | alphaev56-* | alphaev6[78]-* \
+ 	| alpha64-* | alpha64ev[4-8]-* | alpha64ev56-* | alpha64ev6[78]-* \
+ 	| alphapca5[67]-* | alpha64pca5[67]-* | arc-* | arceb-* \
+-	| arm-*  | armbe-* | armle-* | armeb-* | armv*-* \
++	| arm-* | arm64-* | armbe-* | armle-* | armeb-* | armv*-* \
+ 	| avr-* | avr32-* \
+ 	| ba-* \
+ 	| be32-* | be64-* \
+-- 
+2.30.1 (Apple Git-130)
+

--- a/plugins/python-build/share/python-build/patches/3.9.8/Python-3.9.8/0001-Support-arm64-identifier-from-brew-coreutils-uname-f.patch
+++ b/plugins/python-build/share/python-build/patches/3.9.8/Python-3.9.8/0001-Support-arm64-identifier-from-brew-coreutils-uname-f.patch
@@ -1,0 +1,38 @@
+From f5c71a81a2ece4f3c1abdc9a5b38583c4c902709 Mon Sep 17 00:00:00 2001
+From: Christian Hammond <christian@beanbaginc.com>
+Date: Fri, 12 Nov 2021 23:20:35 -0800
+Subject: [PATCH] Support "arm64" identifier from brew coreutils' uname for
+ Python 2.7.18.
+
+Python 2.7.18's `config.sub` attempts to determine whether the OS and
+machine identifier type returned by `uname` is a valid target for
+compilation. On M1 Macs, the system-default `uname` returns a value
+that's eventually parsed as "arm-apple-darwin21.0.1", which passes the
+pattern matching.
+
+However, if the coreutils Homebrew target is installed and its version
+of `uname` is in the path, the result is "arm64-apple-darwin21.0.1".
+This isn't handled by the existing patterns, and fails the build.
+
+This change adds `arm64-*` to the list of patterns, alongside `arm-*`,
+allowing compilation to proceed.
+---
+ config.sub | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config.sub b/config.sub
+index ba37cf99e2..fa72be4420 100755
+--- a/config.sub
++++ b/config.sub
+@@ -376,7 +376,7 @@ case $basic_machine in
+ 	| alpha-* | alphaev[4-8]-* | alphaev56-* | alphaev6[78]-* \
+ 	| alpha64-* | alpha64ev[4-8]-* | alpha64ev56-* | alpha64ev6[78]-* \
+ 	| alphapca5[67]-* | alpha64pca5[67]-* | arc-* | arceb-* \
+-	| arm-*  | armbe-* | armle-* | armeb-* | armv*-* \
++	| arm-* | arm64-* | armbe-* | armle-* | armeb-* | armv*-* \
+ 	| avr-* | avr32-* \
+ 	| ba-* \
+ 	| be32-* | be64-* \
+-- 
+2.30.1 (Apple Git-130)
+


### PR DESCRIPTION
### Description

During the initial phase of compilation, Python's `config.sub` attempts to determine whether the OS and machine identifier type returned by `uname` is a valid target. On M1 Macs, the system-default `uname` returns a value that's eventually parsed as `arm-apple-darwin21.0.1`, which passes the pattern matching.

However, if the coreutils Homebrew target is installed and its version of `uname` is in the path, the result is `arm64-apple-darwin21.0.1`. This isn't handled by the existing patterns, and fails the build.

This appears to be a problem on all shipping versions of Python, tested on Python 2.7.18, 3.6.15, 3.7.12, 3.8.12, 3.9.8, and 3.10.0 (the latest versions in each of their respective series).

This change patches `config.sub` to add `arm64-*` to the list of patterns, alongside `arm-*`, allowing compilation to proceed. Patches have been added for all the versions of Python mentioned above with the exception of 3.6.15, which will need additional work in order to compile.


### Tests

All existing unit tests pass.

Performed a clean build of each of the patched versions of Python on a 2021 M1 MacBook Pro and tested each.