### PR TITLE
Add micropython 1.16 and 1.17

### DIFF
--- a/plugins/python-build/share/python-build/micropython-1.16
+++ b/plugins/python-build/share/python-build/micropython-1.16
@@ -1,0 +1,4 @@
+has_tar_xz_support \
+  && { install=install_package; src="https://micropython.org/resources/source/micropython-1.16.tar.xz#48271fb5da97efc22325c3fc1d87ba45b32bab25673206d8d8136c25e4ff29a9"; } \
+  || { install=install_zip; src="https://micropython.org/resources/source/micropython-1.16.zip#427adc00d2a99d102e4ce46d9eb4933d168e863f859bb3ce5b84735f0899c1ed"; }
+$install micropython-1.16 "$src" micropython

--- a/plugins/python-build/share/python-build/micropython-1.17
+++ b/plugins/python-build/share/python-build/micropython-1.17
@@ -1,0 +1,4 @@
+has_tar_xz_support \
+  && { install=install_package; src="https://micropython.org/resources/source/micropython-1.17.tar.xz#e322f915cee784de0f8614779cdb88fce175956975b3864e2d1898a53638a2f7"; } \
+  || { install=install_zip; src="https://micropython.org/resources/source/micropython-1.17.zip#4dfc60e2ba67e89c0b794c0533bb4e43a10d4e38095d0640b64b4faa9160f244"; }
+$install micropython-1.17 "$src" micropython


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
