### PR TITLE
update readme after pyenv changed bashrc script

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ easy to fork and contribute any changes back upstream.
          ' -e ':a' -e '$!{n;ba};}' ~/.profile
          echo 'eval "$(pyenv init --path)"' >>~/.profile
 
-         echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+         echo 'eval "$(pyenv init --path)"' >> ~/.bashrc
          ~~~
 
       - **If your `~/.bash_profile` sources `~/.bashrc` (Red Hat, Fedora, CentOS):**


### PR DESCRIPTION
Fix readme reference when configuring a shell's environment for pyenv, as discussed in [issue 112](https://github.com/pyenv/pyenv-installer/issues/112) of pyenv-installer.