### PR TITLE
add support for macOS Apple M1

### DIFF
--- a/plugins/python-build/share/python-build/miniconda3-latest
+++ b/plugins/python-build/share/python-build/miniconda3-latest
@@ -8,6 +8,9 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
 "MacOSX-x86_64" )
   install_script "Miniconda3-latest-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" "miniconda" verify_py3_latest
   ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-latest-MacOSX-arm64" "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-arm64.sh" "miniconda" verify_py3_latest
+  ;;
 * )
   { echo
     colorize 1 "ERROR"


### PR DESCRIPTION
[source](https://www.anaconda.com/blog/anaconda-individual-edition-2021-11#:~:text=Update%20on%20macOS%20Apple%20M1%20Support)

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
