### PR TITLE
Add Miniforge and Mambaforge 4.10.3-10

### DIFF
--- a/plugins/python-build/share/python-build/mambaforge-4.10.3-10
+++ b/plugins/python-build/share/python-build/mambaforge-4.10.3-10
@@ -1,0 +1,22 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86_64" )
+  install_script "Mambaforge-4.10.3-10-Linux-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-10/Mambaforge-4.10.3-10-Linux-x86_64.sh#8b789c619d03760e606a9c9b3d098414653f6037b80f16174ad94f0ee0c679d8" "miniconda" verify_py38
+  ;;
+"Linux-aarch64" )
+  install_script "Mambaforge-4.10.3-10-Linux-aarch64" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-10/Mambaforge-4.10.3-10-Linux-aarch64.sh#60a1d50c92fe1d48e2744effca9e7b51bfd5cc4e863dbcdb762ed48020703e3a" "miniconda" verify_py38
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.10.3-10-MacOSX-arm64" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-10/Mambaforge-4.10.3-10-MacOSX-arm64.sh#72bc86612ab9435915b616c2edb076737cbabe2c33fd684d58c2f9ae72e1957c" "miniconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.10.3-10-MacOSX-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-10/Mambaforge-4.10.3-10-MacOSX-x86_64.sh#7c44259a0982cd3ef212649678af5f0dd4e0bb7306e8fffc93601dd1d739ec0b" "miniconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.10.3-10
+++ b/plugins/python-build/share/python-build/miniforge3-4.10.3-10
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.10.3-10-Linux-ppc64le" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-10/Miniforge3-4.10.3-10-Linux-ppc64le.sh#8df85d4af3d2d24f86bb6784d4c196b770b7b9c0be8917d79aec9e08f517d0e9" "miniconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.10.3-10-Linux-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-10/Miniforge3-4.10.3-10-Linux-x86_64.sh#8ed8cd582d16cd58e0ccd87e692fbe71de6365a51678b579b2f40d8d6f6e5771" "miniconda" verify_py38
+  ;;
+"Linux-aarch64" )
+  install_script "Miniforge3-4.10.3-10-Linux-aarch64" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-10/Miniforge3-4.10.3-10-Linux-aarch64.sh#b2d510c6cd0aac3964a7a7838a7f7376b804fbdd0ba04909ece53f883f624233" "miniconda" verify_py38
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.10.3-10-MacOSX-arm64" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-10/Miniforge3-4.10.3-10-MacOSX-arm64.sh#bd4d59ead779a6e2d9af69fd8cdcaac8e1446191c59ab446ae8547a1aecd75b7" "miniconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.10.3-10-MacOSX-x86_64" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-10/Miniforge3-4.10.3-10-MacOSX-x86_64.sh#7d325a5370664ec2fe1c09c3066c22fd905431f338c7eed31ad7e14c7ce4bd83" "miniconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- Add latest releases of Miniforge and Mambaforge, which fix https://github.com/conda/conda/issues/10614

### Tests
- [ ] My PR adds the following unit tests (if any)
