### PR TITLE
[Minor][Docs] Fix errant "echo" in README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ easy to fork and contribute any changes back upstream.
          to be a shell function (e.g. `shell` and Pyenv-Virtualenv's `activate`).
 
          ~~~bash
-         echo 'eval "$(pyenv init -)"'
+         eval "$(pyenv init -)"
          ~~~
          
          If you are installing Pyenv yourself as part of the batch job,


### PR DESCRIPTION
### Prerequisite
* [x] (not applicable to implement as a plugin ; this error is in the README file)
* [x] (not applicable to fix in rbenv ; READMEs diverge)
* [x] (does not address any issues filed in GitHub)

### Description
There is a really minor error in the readme. Instead of providing a useful command for setting up pyenv in a build script, it is just an "echo" statement that echos a string. There is no real file we want to pipe this command to, we just want to tell the user to add this command to their build script, so to resolve I have removed the "echo".

### Tests
- [x] (My PR does not add any automated tests, it is not a code change, just documentation change.)
