### PR TITLE
Fix incorrect pypy 2.7-7.3.6 sha256 hashes

### DIFF
--- a/plugins/python-build/share/python-build/pypy2.7-7.3.6
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.6
@@ -9,11 +9,11 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   install_package "pypy${PYVER}-v${VERSION}-linux64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-linux64.tar.bz2#82127f43fae6ce75d47d6c4539f8c1ea372e9c2dbfa40fae8b58351d522793a4" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 "linux-aarch64" )
-  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#9a97de82037d4be1949ec0c35a4d638ba635e8b34948549ae2fa08abd2cbaa8c" "pypy" "verify_py${PYVER//./}" ensurepip
+  install_package "pypy${PYVER}-v${VERSION}-aarch64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-aarch64.tar.bz2#90e9aafb310314938f54678d4d6d7db1163b57c9343e640b447112f74d7f9151" "pypy" "verify_py${PYVER//./}" ensurepip
   ;;
 "osx64" )
   if require_osx_version "10.13"; then
-    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#8b10442ef31c3b28048816f858adde6d6858a190d9367001a49648e669cbebb6" "pypy" "verify_py${PYVER//./}" ensurepip
+    install_package "pypy${PYVER}-v${VERSION}-osx64" "https://downloads.python.org/pypy/pypy${PYVER}-v${VERSION}-osx64.tar.bz2#9a97de82037d4be1949ec0c35a4d638ba635e8b34948549ae2fa08abd2cbaa8c" "pypy" "verify_py${PYVER//./}" ensurepip
   else
     { echo
       colorize 1 "ERROR"


### PR DESCRIPTION
### Description
- SHA256 `9a97de82037d4be1949ec0c35a4d638ba635e8b34948549ae2fa08abd2cbaa8c` actually belongs to `pypy2.7-v7.3.6-osx64.tar.bz2`
- SHA256 `8b10442ef31c3b28048816f858adde6d6858a190d9367001a49648e669cbebb6` actually belongs to `pypy2.7-v7.3.5-osx64.tar.bz2`
- [x] Looks like there may have been a simple copy/paste error for these checksums. I have updated them with the appropriate values.

### Tests
- [x] N/A
