### PR TITLE
Fix a regression in include paths when compiling ctypes in 3.6.15/3.7.12

### DIFF
--- a/plugins/python-build/share/python-build/patches/3.6.15/Python-3.6.15/0004-Port-ctypes-and-system-libffi-patches-for-arm64-macO.patch
+++ b/plugins/python-build/share/python-build/patches/3.6.15/Python-3.6.15/0004-Port-ctypes-and-system-libffi-patches-for-arm64-macO.patch
@@ -243,13 +243,12 @@ index 8e03c77997..3b124c4b7b 100644
          include_dirs = []
          extra_compile_args = []
          extra_link_args = []
-@@ -2162,20 +2180,30 @@ class PyBuildExt(build_ext):
+@@ -2162,20 +2180,29 @@ class PyBuildExt(build_ext):
                       libraries=math_libs)
          self.extensions.extend([ext, ext_test])
  
 +        ffi_inc = sysconfig.get_config_var("LIBFFI_INCLUDEDIR")
 +        ffi_lib = None
-+        inc_dirs = self.compiler.include_dirs[:]
 +
          if host_platform == 'darwin':
 -            if '--with-system-ffi' not in sysconfig.get_config_var("CONFIG_ARGS"):
@@ -284,7 +283,7 @@ index 8e03c77997..3b124c4b7b 100644
              with open(ffi_h) as f:
                  for line in f:
                      line = line.strip()
-@@ -2186,15 +2214,22 @@ class PyBuildExt(build_ext):
+@@ -2186,15 +2213,22 @@ class PyBuildExt(build_ext):
                      ffi_inc = None
                      print('Header file {} does not define LIBFFI_H or '
                            'ffi_wrapper_h'.format(ffi_h))

--- a/plugins/python-build/share/python-build/patches/3.7.12/Python-3.7.12/0001-Port-ctypes-and-system-libffi-patches-for-arm64-macO.patch
+++ b/plugins/python-build/share/python-build/patches/3.7.12/Python-3.7.12/0001-Port-ctypes-and-system-libffi-patches-for-arm64-macO.patch
@@ -243,15 +243,13 @@ index bf90600eaa..48ff120e9a 100644
          include_dirs = []
          extra_compile_args = []
          extra_link_args = []
-@@ -2018,30 +2036,49 @@ class PyBuildExt(build_ext):
+@@ -2018,30 +2036,47 @@ class PyBuildExt(build_ext):
                       libraries=['m'])
          self.extensions.extend([ext, ext_test])
  
 +        ffi_inc = sysconfig.get_config_var("LIBFFI_INCLUDEDIR")
 +        ffi_lib = None
 +
-+        #inc_dirs = self.inc_dirs.copy()
-+        inc_dirs = self.compiler.include_dirs[:]
          if host_platform == 'darwin':
 -            if '--with-system-ffi' not in sysconfig.get_config_var("CONFIG_ARGS"):
 +            if not self.use_system_libffi:


### PR DESCRIPTION
### Description

In my previous work on getting Python 3.6.15 and 3.7.12 to compile on Apple M1, I backported logic from newer 3.8.x releases to properly find libffi and related files on macOS.

This regressed compilation on Linux. The include search path was incomplete, and `ffi.h` could not be found, resulting in `ctypes` being disabled.

There was a key difference between the old logic and new logic that led to this regression:

1. In 3.8 and newer, `detect_ctypes()` in `setup.py` took no arguments, and was expected to access instance variables for the include search path.
2. In 3.7 and earlier, `detect_ctypes()` took the path as an argument, and was expected to make use of it.

The backport made use of the instance variables, overriding the provided include path. These were not equivalent. The one on the instance was not complete, lacking the necessary directories to find `ffi.h`. Since this could not be found, `ctypes` support was disabled.

The fix is to simply not overwrite the variables passed to the function, and resume using them as before.

Fixes #2207


### Tests
Compiled 3.6.15 and 3.7.12 on macOS (M1).

Compiled 3.6.15 and 3.7.12 on Linux in a Docker image provided on #2207 that reproduced the failure case.

In all tested environments, `ctypes` compiled and could be imported successfully.