### PR TITLE
Revert "Disable coreutils on M1 Apple Silicon with arm64 (#2020)"

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -112,13 +112,6 @@ is_mac() {
   [ $# -eq 0 ] || [ "$(osx_version)" "$@" ]
 }
 
-is_arm64_apple() {
-  if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
-    return 0
-  fi
-  return 1
-}
-
 #  9.1  -> 901
 # 10.9  -> 1009
 # 10.10 -> 1010
@@ -1614,29 +1607,6 @@ use_tcltk() {
     use_custom_tcltk "$tcl_tk_libs"
   elif [ -d "$tcltk_libdir" ]; then
     use_homebrew_tcltk
-  fi
-}
-
-# CPython 3.9.1+ and 3.8.10+ have old config.sub that doesn't support "arm64" arch
-# which is what Gnu uname (but not Apple uname) produces on Apple M1
-# (https://github.com/pyenv/pyenv/pull/2020#issuecomment-891911842)
-build_package_arm64_apple_disable_homebrew_coreutils() {
-  if is_arm64_apple; then
-    local brew_coreutils="$(brew --prefix coreutils 2>/dev/null || true)"
-    if [ -d "$brew_coreutils" ]; then
-      local after_list=()
-      # Bash 3 ignores IFS set for command when doing expansions so have to set it separately
-      IFS=':'; local -a list=(${PATH}); IFS="$OLDIFS"
-      for str in "${list[@]}"; do
-        if [[ "$str" != "$brew_coreutils"/* ]]; then
-          after_list+=("$str")
-        else
-          echo "python-build: excluding \`$str' from PATH"
-        fi
-      done
-      # Bash 3 ignores IFS set for command when doing expansions so have to set it separately
-      IFS=':'; export PATH="${after_list[*]}"; IFS="$OLDIFS"
-    fi
   fi
 }
 

--- a/plugins/python-build/share/python-build/3.8-dev
+++ b/plugins/python-build/share/python-build/3.8-dev
@@ -3,4 +3,4 @@ prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_git "Python-3.8-dev" "https://github.com/python/cpython" "3.8" arm64_apple_disable_homebrew_coreutils standard verify_py38 copy_python_gdb ensurepip
+install_git "Python-3.8-dev" "https://github.com/python/cpython" "3.8" standard verify_py38 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.8.10
+++ b/plugins/python-build/share/python-build/3.8.10
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tar.xz#6af24a66093dd840bcccf371d4044a3027e655cf24591ce26e48022bc79219d9" arm64_apple_disable_homebrew_coreutils standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tar.xz#6af24a66093dd840bcccf371d4044a3027e655cf24591ce26e48022bc79219d9" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz#b37ac74d2cbad2590e7cd0dd2b3826c29afe89a734090a87bf8c03c45066cb65" arm64_apple_disable_homebrew_coreutils standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.10" "https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz#b37ac74d2cbad2590e7cd0dd2b3826c29afe89a734090a87bf8c03c45066cb65" standard verify_py38 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.8.11
+++ b/plugins/python-build/share/python-build/3.8.11
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.1" "https://ftpmirror.gnu.org/readline/readline-8.1.tar.gz#f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.8.11" "https://www.python.org/ftp/python/3.8.11/Python-3.8.11.tar.xz#fb1a1114ebfe9e97199603c6083e20b236a0e007a2c51f29283ffb50c1420fb2" arm64_apple_disable_homebrew_coreutils standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.11" "https://www.python.org/ftp/python/3.8.11/Python-3.8.11.tar.xz#fb1a1114ebfe9e97199603c6083e20b236a0e007a2c51f29283ffb50c1420fb2" standard verify_py38 copy_python_gdb ensurepip
 else
-  install_package "Python-3.8.11" "https://www.python.org/ftp/python/3.8.11/Python-3.8.11.tgz#b77464ea80cec14581b86aeb7fb2ff02830e0abc7bcdc752b7b4bdfcd8f3e393" arm64_apple_disable_homebrew_coreutils standard verify_py38 copy_python_gdb ensurepip
+  install_package "Python-3.8.11" "https://www.python.org/ftp/python/3.8.11/Python-3.8.11.tgz#b77464ea80cec14581b86aeb7fb2ff02830e0abc7bcdc752b7b4bdfcd8f3e393" standard verify_py38 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.9-dev
+++ b/plugins/python-build/share/python-build/3.9-dev
@@ -3,4 +3,4 @@ prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_git "Python-3.9-dev" "https://github.com/python/cpython" 3.9 arm64_apple_disable_homebrew_coreutils standard verify_py39 copy_python_gdb ensurepip
+install_git "Python-3.9-dev" "https://github.com/python/cpython" 3.9 standard verify_py39 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.9.1
+++ b/plugins/python-build/share/python-build/3.9.1
@@ -4,8 +4,8 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.9.1" "https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tar.xz#991c3f8ac97992f3d308fefeb03a64db462574eadbff34ce8bc5bb583d9903ff" arm64_apple_disable_homebrew_coreutils standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.1" "https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tar.xz#991c3f8ac97992f3d308fefeb03a64db462574eadbff34ce8bc5bb583d9903ff" standard verify_py39 copy_python_gdb ensurepip
 else
-    install_package "Python-3.9.1" "https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tgz#29cb91ba038346da0bd9ab84a0a55a845d872c341a4da6879f462e94c741f117" arm64_apple_disable_homebrew_coreutils standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.1" "https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tgz#29cb91ba038346da0bd9ab84a0a55a845d872c341a4da6879f462e94c741f117" standard verify_py39 copy_python_gdb ensurepip
 fi
 

--- a/plugins/python-build/share/python-build/3.9.2
+++ b/plugins/python-build/share/python-build/3.9.2
@@ -4,8 +4,8 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1i" "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.9.2" "https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tar.xz#3c2034c54f811448f516668dce09d24008a0716c3a794dd8639b5388cbde247d" arm64_apple_disable_homebrew_coreutils standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.2" "https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tar.xz#3c2034c54f811448f516668dce09d24008a0716c3a794dd8639b5388cbde247d" standard verify_py39 copy_python_gdb ensurepip
 else
-    install_package "Python-3.9.2" "https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tgz#7899e8a6f7946748830d66739f2d8f2b30214dad956e56b9ba216b3de5581519" arm64_apple_disable_homebrew_coreutils standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.2" "https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tgz#7899e8a6f7946748830d66739f2d8f2b30214dad956e56b9ba216b3de5581519" standard verify_py39 copy_python_gdb ensurepip
 fi
 

--- a/plugins/python-build/share/python-build/3.9.4
+++ b/plugins/python-build/share/python-build/3.9.4
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.9.4" "https://www.python.org/ftp/python/3.9.4/Python-3.9.4.tar.xz#4b0e6644a76f8df864ae24ac500a51bbf68bd098f6a173e27d3b61cdca9aa134" arm64_apple_disable_homebrew_coreutils standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.4" "https://www.python.org/ftp/python/3.9.4/Python-3.9.4.tar.xz#4b0e6644a76f8df864ae24ac500a51bbf68bd098f6a173e27d3b61cdca9aa134" standard verify_py39 copy_python_gdb ensurepip
 else
-    install_package "Python-3.9.4" "https://www.python.org/ftp/python/3.9.4/Python-3.9.4.tgz#66c4de16daa74a825cf9da9ddae1fe020b72c3854b73b1762011cc33f9e4592f" arm64_apple_disable_homebrew_coreutils standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.4" "https://www.python.org/ftp/python/3.9.4/Python-3.9.4.tgz#66c4de16daa74a825cf9da9ddae1fe020b72c3854b73b1762011cc33f9e4592f" standard verify_py39 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.9.5
+++ b/plugins/python-build/share/python-build/3.9.5
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.9.5" "https://www.python.org/ftp/python/3.9.5/Python-3.9.5.tar.xz#0c5a140665436ec3dbfbb79e2dfb6d192655f26ef4a29aeffcb6d1820d716d83" arm64_apple_disable_homebrew_coreutils standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.5" "https://www.python.org/ftp/python/3.9.5/Python-3.9.5.tar.xz#0c5a140665436ec3dbfbb79e2dfb6d192655f26ef4a29aeffcb6d1820d716d83" standard verify_py39 copy_python_gdb ensurepip
 else
-    install_package "Python-3.9.5" "https://www.python.org/ftp/python/3.9.5/Python-3.9.5.tgz#e0fbd5b6e1ee242524430dee3c91baf4cbbaba4a72dd1674b90fda87b713c7ab" arm64_apple_disable_homebrew_coreutils standard verify_py39 copy_python_gdb ensurepip
+    install_package "Python-3.9.5" "https://www.python.org/ftp/python/3.9.5/Python-3.9.5.tgz#e0fbd5b6e1ee242524430dee3c91baf4cbbaba4a72dd1674b90fda87b713c7ab" standard verify_py39 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.9.6
+++ b/plugins/python-build/share/python-build/3.9.6
@@ -4,7 +4,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.1" "https://ftpmirror.gnu.org/readline/readline-8.1.tar.gz#f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-  install_package "Python-3.9.6" "https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tar.xz#397920af33efc5b97f2e0b57e91923512ef89fc5b3c1d21dbfc8c4828ce0108a" arm64_apple_disable_homebrew_coreutils standard verify_py39 copy_python_gdb ensurepip
+  install_package "Python-3.9.6" "https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tar.xz#397920af33efc5b97f2e0b57e91923512ef89fc5b3c1d21dbfc8c4828ce0108a" standard verify_py39 copy_python_gdb ensurepip
 else
-  install_package "Python-3.9.6" "https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz#d0a35182e19e416fc8eae25a3dcd4d02d4997333e4ad1f2eee6010aadc3fe866" arm64_apple_disable_homebrew_coreutils standard verify_py39 copy_python_gdb ensurepip
+  install_package "Python-3.9.6" "https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz#d0a35182e19e416fc8eae25a3dcd4d02d4997333e4ad1f2eee6010aadc3fe866" standard verify_py39 copy_python_gdb ensurepip
 fi


### PR DESCRIPTION
This reverts commit 90d0d20508a91e7ea1e609e8aa9f9d1a28bb563e.

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)

### Description
- [x] Here are some details about my PR

After further consideration, we've decided to remove this workaround:
* It only has an effect if the user has added `gnubin` from Homebrew Coreutils to PATH which is an unsupported setup
* It was intended to be applied only to a few select 3.8 and 3.9 versions that officially support Apple Silicon and only fail with Homebrew Coreutils in PATH because they have `config.*` from a too old version of Autoconf that doesn't support the Arm64 arch -- but
  * CPython devs [didn't actually fix the problem in 3.10, either, only in 3.11](https://github.com/pyenv/pyenv/pull/2157#issuecomment-968055387), so we'd need to apply it to all 3.10 releases, too
  * users started pushing this workaround into other unrelated branches because they were using the above unsupported setup. See https://github.com/pyenv/pyenv/pull/2190#pullrequestreview-835221952 for discussion.

### Tests
- [ ] My PR adds the following unit tests (if any)
