### PR TITLE
Update the `$PYENV_ROOT/bin` to `.../shims`

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ easy to fork and contribute any changes back upstream.
         
         ~~~ fish
         set -Ux PYENV_ROOT $HOME/.pyenv
-        set -U fish_user_paths $PYENV_ROOT/bin $fish_user_paths
+        set -U fish_user_paths $PYENV_ROOT/shims $fish_user_paths
         ~~~
 
         And add this to `~/.config/fish/config.fish`:


### PR DESCRIPTION
There is no `bin` folder under `$PYENV_ROOT/`. It should be `$PYENV_ROOT/shims. 
If keep it as `bin`, the `rbenv` will not be set correctly for fish user.

<img width="442" alt="Screen Shot 2022-01-14 at 5 04 37 PM" src="https://user-images.githubusercontent.com/61396191/149488726-458da36e-6414-492b-8dc7-b56d0c19c9dd.png">
