### PR TITLE
fix issue 2236 for CPython 3.6.15 and 3.7.12

### DIFF
--- a/plugins/python-build/share/python-build/patches/3.6.15/Python-3.6.15/0007-bpo-42351-Avoid-error-when-opening-header-with-non-U.patch
+++ b/plugins/python-build/share/python-build/patches/3.6.15/Python-3.6.15/0007-bpo-42351-Avoid-error-when-opening-header-with-non-U.patch
@@ -1,0 +1,30 @@
+From d9782f66445c9fa5d835ad29c23b22be85cde354 Mon Sep 17 00:00:00 2001
+From: Ronald Oussoren <ronaldoussoren@mac.com>
+Date: Sat, 14 Nov 2020 16:07:47 +0100
+Subject: [PATCH] bpo-42351: Avoid error when opening header with non-UTF8
+ encoding (GH-23279)
+
+grep_headers_for() would error out when a header contained
+text that cannot be interpreted as UTF-8.
+
+cherry-picked from 7a27c7ed4b by Pedro Fonini <fonini@ip.tv>
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 4aaa51e0d4..3556bbe041 100644
+--- a/setup.py
++++ b/setup.py
+@@ -184,7 +184,7 @@ def is_macosx_sdk_path(path):
+ 
+ def grep_headers_for(function, headers):
+     for header in headers:
+-        with open(header, 'r') as f:
++        with open(header, 'r', errors='surrogateescape') as f:
+             if function in f.read():
+                 return True
+     return False
+-- 
+2.34.1
+

--- a/plugins/python-build/share/python-build/patches/3.7.12/Python-3.7.12/0003-bpo-42351-Avoid-error-when-opening-header-with-non-U.patch
+++ b/plugins/python-build/share/python-build/patches/3.7.12/Python-3.7.12/0003-bpo-42351-Avoid-error-when-opening-header-with-non-U.patch
@@ -1,0 +1,30 @@
+From 245427d207ee88a4ba26a66c3de350bcbcc036f2 Mon Sep 17 00:00:00 2001
+From: Ronald Oussoren <ronaldoussoren@mac.com>
+Date: Sat, 14 Nov 2020 16:07:47 +0100
+Subject: [PATCH] bpo-42351: Avoid error when opening header with non-UTF8
+ encoding (GH-23279)
+
+grep_headers_for() would error out when a header contained
+text that cannot be interpreted as UTF-8.
+
+cherry-picked from 7a27c7ed4b by Pedro Fonini <fonini@ip.tv>
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index f211989aac..467362813d 100644
+--- a/setup.py
++++ b/setup.py
+@@ -159,7 +159,7 @@ def is_macosx_sdk_path(path):
+ 
+ def grep_headers_for(function, headers):
+     for header in headers:
+-        with open(header, 'r') as f:
++        with open(header, 'r', errors='surrogateescape') as f:
+             if function in f.read():
+                 return True
+     return False
+-- 
+2.34.1
+


### PR DESCRIPTION
### Prerequisite
* [x] My PR addresses the following pyenv issue
  - Closes https://github.com/pyenv/pyenv/issues/2236

### Description

I:

* checked out CPython tag v3.7.12, applied patches from pyenv's `plugins/python-build/share/python-build/patches/3.7.12/Python-3.7.12` with `git am`;
* cherry-picked [python/cpython@7a27c7e](https://github.com/python/cpython/commit/7a27c7ed4b2b45bb9ea27d3f5c4f423495d6e939), as suggested by @chipx86;
* created a new patch with `git format-patch`, and placed it on `plugins/python-build/share/python-build/patches/3.7.12/Python-3.7.12`;
* repeated all of it for 3.6.15, cherry-picking the same commit;

Also, I tested, and now CPython 3.7.12 builds successfully on my machine.

As for 3.6.15, I have two notes. The first is that I had to make the following correction:

```
diff --git a/plugins/python-build/bin/python-build b/plugins/python-build/bin/python-build
index 7e3834f0..39886b1b 100755
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2204,6 +2204,9 @@ if [ -z "${GET_PIP_URL}" ]; then
     3.5 | 3.5.* )
       GET_PIP_URL="https://bootstrap.pypa.io/pip/3.5/get-pip.py"
       ;;
+    3.6 | 3.6.* )
+      GET_PIP_URL="https://bootstrap.pypa.io/pip/3.6/get-pip.py"
+      ;;
     * )
       GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"
       ;;
```

I believe this belongs to a separate PR, as there are other files in this repo that use that URL, and I'm not sure if all should be updated (but please tell me if I should include it here).

The second note is that even though `pyenv install 3.6.15` did complete successfully, returning code 0 and all, it displays the following error message:

```
...
Installing collected packages: setuptools                                                     
Successfully installed setuptools-40.6.2                                                      
/home/iptv/.local/lib/pyenv/plugins/python-build/bin/python-build: line 1899: 1109106 Segmentation fault      (core dumped) "$PYTHON_BIN" -s -m ensurepip ${ensurepip_opts} > /dev/null 2>&1
Installing pip from https://bootstrap.pypa.io/pip/3.6/get-pip.py...
Collecting pip<22.0                                                                           
  Using cached pip-21.3.1-py3-none-any.whl (1.7 MB)             
...         
```

The installed Python binary apparently runs fine, with no segfaults, though I didn't test it much.

Did I miss anything?