### PR TITLE
python-build: add URL for get-pip for Python 3.6

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2204,6 +2204,9 @@ if [ -z "${GET_PIP_URL}" ]; then
     3.5 | 3.5.* )
       GET_PIP_URL="https://bootstrap.pypa.io/pip/3.5/get-pip.py"
       ;;
+    3.6 | 3.6.* )
+      GET_PIP_URL="https://bootstrap.pypa.io/pip/3.6/get-pip.py"
+      ;;
     * )
       GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"
       ;;


### PR DESCRIPTION
Add correct URL for downloading pip for Python 3.6, which, as mentioned in #2237, has been recently deprecated by mainline pip.

In that PR I said that "there are other files in this repo that download get-pip", but most of them were actually in pyenv-virtualenv. The only other file in this pyenv repo that uses that URL is [`/plugins/python-build/test/pyenv_ext.bats`](https://github.com/pyenv/pyenv/blob/master/plugins/python-build/test/pyenv_ext.bats), which looks outdated? I'm not sure what to do about it.