### PR TITLE
fix(dependence): bump openssl 1.1 to 1.1.1n for CPython 3.7 3.8 3.9

### DIFF
--- a/plugins/python-build/share/python-build/3.10-dev
+++ b/plugins/python-build/share/python-build/3.10-dev
@@ -1,6 +1,6 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_git "Python-3.10-dev" "https://github.com/python/cpython" 3.10 standard verify_py310 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.10.0
+++ b/plugins/python-build/share/python-build/3.10.0
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.10.0" "https://www.python.org/ftp/python/3.10.0/Python-3.10.0.tar.xz#5a99f8e7a6a11a7b98b4e75e0d1303d3832cada5534068f69c7b6222a7b1b002" standard verify_py310 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.10.1
+++ b/plugins/python-build/share/python-build/3.10.1
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.10.1" "https://www.python.org/ftp/python/3.10.1/Python-3.10.1.tar.xz#a7f1265b6e1a5de1ec5c3ec7019ab53413469934758311e9d240c46e5ae6e177" standard verify_py310 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.10.2
+++ b/plugins/python-build/share/python-build/3.10.2
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.10.2" "https://www.python.org/ftp/python/3.10.2/Python-3.10.2.tar.xz#17de3ac7da9f2519aa9d64378c603a73a0e9ad58dffa8812e45160c086de64c7" standard verify_py310 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.10.3
+++ b/plugins/python-build/share/python-build/3.10.3
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.10.3" "https://www.python.org/ftp/python/3.10.3/Python-3.10.3.tar.xz#596c72de998dc39205bc4f70ef0dbf7edec740a306d09b49a9bd0a77806730dc" standard verify_py310 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.11.0a6
+++ b/plugins/python-build/share/python-build/3.11.0a6
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.11.0a6" "https://www.python.org/ftp/python/3.11.0/Python-3.11.0a6.tar.xz#1c53a2ff75879633e30cac29d2aa6b7a010e355b95f0bf9ac691beccf5f9d12a" standard verify_py311 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.7.13
+++ b/plugins/python-build/share/python-build/3.7.13
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.1" "https://ftpmirror.gnu.org/readline/readline-8.1.tar.gz#f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.7.13" "https://www.python.org/ftp/python/3.7.13/Python-3.7.13.tar.xz#99f106275df8899c3e8cb9d7c01ce686c202ef275953301427194693de5bef84" standard verify_py37 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.8.13
+++ b/plugins/python-build/share/python-build/3.8.13
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.1" "https://ftpmirror.gnu.org/readline/readline-8.1.tar.gz#f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.8.13" "https://www.python.org/ftp/python/3.8.13/Python-3.8.13.tar.xz#6f309077012040aa39fe8f0c61db8c0fa1c45136763299d375c9e5756f09cf57" standard verify_py38 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.9.11
+++ b/plugins/python-build/share/python-build/3.9.11
@@ -1,7 +1,7 @@
 #require_gcc
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-1.1.1l" "https://www.openssl.org/source/openssl-1.1.1l.tar.gz#0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.1" "https://ftpmirror.gnu.org/readline/readline-8.1.tar.gz#f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.9.11" "https://www.python.org/ftp/python/3.9.11/Python-3.9.11.tar.xz#66767a35309d724f370df9e503c172b4ee444f49d62b98bc4eca725123e26c49" standard verify_py39 copy_python_gdb ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)

---

OpenSSL of CPython 3.7 3.8 3.9 should also be bumped to 1.1.1n according to [here](https://github.com/python/cpython/blob/2de452f8bf2f78417e04bcf7919beb502c53a0e2/Misc/NEWS.d/3.9.11.rst).