### PR TITLE
Doc Fix: Escape a hash character causing unwanted GitHub Issue linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ For pyenv to install python correctly you should [**install the Python build dep
       brew update
       brew install pyenv
       ```
-   2. Then follow the rest of the post-installation steps under [Basic GitHub Checkout](https://github.com/pyenv/pyenv#basic-github-checkout), starting with #2 ("Configure your shell's environment for Pyenv").
+   2. Then follow the rest of the post-installation steps under [Basic GitHub Checkout](https://github.com/pyenv/pyenv#basic-github-checkout), starting with #&#8203;2 ("Configure your shell's environment for Pyenv").
 
    3. OPTIONAL. To fix `brew doctor`'s warning _""config" scripts exist outside your system or Homebrew directories"_
    


### PR DESCRIPTION
This PR is _very_ small.

In the README, a reference is made to step "#&#8203;2" of the Basic GitHub Checkout instructions, but GitHub's markdown interpreter automatically links that to Issue #2 of this repo. This PR inserts a zero-width space to prevent that linkage. (This approach comes from [a suggestion I found on StackOverflow](https://stackoverflow.com/a/52463489).)
