### PR TITLE
Updated patch for 3.6.15 to support Xcode 13.3 - as described at http…

### DIFF
--- a/plugins/python-build/share/python-build/patches/3.6.15/Python-3.6.15/0001-Detect-arm64-in-configure.patch
+++ b/plugins/python-build/share/python-build/patches/3.6.15/Python-3.6.15/0001-Detect-arm64-in-configure.patch
@@ -1,37 +1,18 @@
+From 002501946bad91a308f37a09204393c172f03c3e Mon Sep 17 00:00:00 2001
+From: Takumi Sueda <puhitaku@gmail.com>
+Date: Sat, 11 Sep 2021 16:50:14 +0900
+Subject: [PATCH 2/6] Detect arm64 in configure
+
+---
+ configure    | 3 +++
+ configure.ac | 3 +++
+ 2 files changed, 6 insertions(+)
+
 diff --git a/configure b/configure
-index e39c16eee2..e67ac40214 100755
+index e39c16eee2..8dc1fc7595 100755
 --- a/configure
 +++ b/configure
-@@ -5203,7 +5203,6 @@ $as_echo "$as_me:
- fi
- 
- 
--MULTIARCH=$($CC --print-multiarch 2>/dev/null)
- 
- 
- { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
-@@ -5334,6 +5333,10 @@ $as_echo "none" >&6; }
- fi
- rm -f conftest.c conftest.out
- 
-+if test x$PLATFORM_TRIPLET != xdarwin; then
-+  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
-+fi
-+
- if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
-   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
-     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
-@@ -9218,6 +9221,9 @@ fi
-     	ppc)
-     		MACOSX_DEFAULT_ARCH="ppc"
-     		;;
-+    	arm64)
-+    		MACOSX_DEFAULT_ARCH="arm64"
-+    		;;
-     	*)
-     		as_fn_error $? "Unexpected output of 'arch' on OSX" "$LINENO" 5
-     		;;
-@@ -9230,6 +9236,9 @@ fi
+@@ -9230,6 +9230,9 @@ fi
      	ppc)
      		MACOSX_DEFAULT_ARCH="ppc64"
      		;;
@@ -41,3 +22,20 @@ index e39c16eee2..e67ac40214 100755
      	*)
      		as_fn_error $? "Unexpected output of 'arch' on OSX" "$LINENO" 5
      		;;
+diff --git a/configure.ac b/configure.ac
+index cf280506bd..34846a7df3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2435,6 +2435,9 @@ case $ac_sys_system/$ac_sys_release in
+     	ppc)
+     		MACOSX_DEFAULT_ARCH="ppc64"
+     		;;
++    	arm64) 
++    		MACOSX_DEFAULT_ARCH="arm64" 
++    		;;
+     	*)
+     		AC_MSG_ERROR([Unexpected output of 'arch' on OSX])
+     		;;
+-- 
+2.30.1 (Apple Git-130)
+

--- a/plugins/python-build/share/python-build/patches/3.6.15/Python-3.6.15/0001-Detect-arm64-in-configure.patch
+++ b/plugins/python-build/share/python-build/patches/3.6.15/Python-3.6.15/0001-Detect-arm64-in-configure.patch
@@ -1,18 +1,37 @@
-From 002501946bad91a308f37a09204393c172f03c3e Mon Sep 17 00:00:00 2001
-From: Takumi Sueda <puhitaku@gmail.com>
-Date: Sat, 11 Sep 2021 16:50:14 +0900
-Subject: [PATCH 2/6] Detect arm64 in configure
-
----
- configure    | 3 +++
- configure.ac | 3 +++
- 2 files changed, 6 insertions(+)
-
 diff --git a/configure b/configure
-index e39c16eee2..8dc1fc7595 100755
+index e39c16eee2..e67ac40214 100755
 --- a/configure
 +++ b/configure
-@@ -9230,6 +9230,9 @@ fi
+@@ -5203,7 +5203,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+ 
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+@@ -5334,6 +5333,10 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+@@ -9218,6 +9221,9 @@ fi
+     	ppc)
+     		MACOSX_DEFAULT_ARCH="ppc"
+     		;;
++    	arm64)
++    		MACOSX_DEFAULT_ARCH="arm64"
++    		;;
+     	*)
+     		as_fn_error $? "Unexpected output of 'arch' on OSX" "$LINENO" 5
+     		;;
+@@ -9230,6 +9236,9 @@ fi
      	ppc)
      		MACOSX_DEFAULT_ARCH="ppc64"
      		;;
@@ -22,20 +41,3 @@ index e39c16eee2..8dc1fc7595 100755
      	*)
      		as_fn_error $? "Unexpected output of 'arch' on OSX" "$LINENO" 5
      		;;
-diff --git a/configure.ac b/configure.ac
-index cf280506bd..34846a7df3 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -2435,6 +2435,9 @@ case $ac_sys_system/$ac_sys_release in
-     	ppc)
-     		MACOSX_DEFAULT_ARCH="ppc64"
-     		;;
-+    	arm64) 
-+    		MACOSX_DEFAULT_ARCH="arm64" 
-+    		;;
-     	*)
-     		AC_MSG_ERROR([Unexpected output of 'arch' on OSX])
-     		;;
--- 
-2.30.1 (Apple Git-130)
-

--- a/plugins/python-build/share/python-build/patches/3.6.15/Python-3.6.15/0008-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.6.15/Python-3.6.15/0008-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,86 @@
+From 655f26bb742d6bd32c388e9fea14b64eb25fd4de Mon Sep 17 00:00:00 2001
+From: Ned Deily <nad@python.org>
+Date: Tue, 15 Mar 2022 03:18:39 -0400
+Subject: [PATCH] bpo-45405: Prevent internal configure error when running
+ configure with recent versions of clang. (GH-28845) (GH-31890)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+The Apple Clang included with Xcode 13.3 now supports --print-multiarch
+causing configure to fail without this change.
+
+Co-authored-by: Ned Deily <nad@python.org>
+(cherry picked from commit 9c4766772cda67648184f8ddba546a5fc0167f91)
+
+Co-authored-by: David Bohman <debohman@gmail.com>
+(cherry picked from commit 720bb456dc711b0776bae837d1f9a0b10c28ddf2)
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..13c93d1b8a
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index fb0a499145..67e6e69b5f 100755
+--- a/configure
++++ b/configure
+@@ -5203,9 +5203,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5334,6 +5331,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index d86dad9a7c..468ad6070f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -747,9 +747,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -875,6 +872,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.32.0 (Apple Git-132)
+


### PR DESCRIPTION
…s://bugs.python.org/issue45405

### Solve the following https://bugs.python.org/issue45405 

### Tests
-- pyenv install 3.6.15 (on latest MacOS version)
BEFORE:

python-build: use readline from homebrew
python-build: use zlib from xcode sdk

BUILD FAILED (OS X 12.3 using python-build 2.2.5-4-g986fe1a7)

Inspect or clean up the working tree at /var/folders/n2/d8522dmx2sb2n6cqx1cks2140000gs/T/python-build.20220320191907.55294
Results logged to /var/folders/n2/d8522dmx2sb2n6cqx1cks2140000gs/T/python-build.20220320191907.55294.log

Last 10 log lines:
checking for --with-cxx-main=<compiler>... no
checking for clang++... no
configure:

  By default, distutils will build C++ extension modules with "clang++".
  If this is not intended, then set CXX on the configure command line.

checking for the platform triplet based on compiler characteristics... darwin
configure: error: internal configure error for the platform triplet, please file a bug report
make: *** No targets specified and no makefile found.  Stop.


AFTER:
Install success