### PR TITLE
Simplify init scheme

### DIFF
--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -6,9 +6,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 2.7.18
-          - 3.5.10
-          - 3.6.15
           - 3.7.10
           - 3.8.10
           - 3.9.5

--- a/.github/workflows/pyenv_tests.yml
+++ b/.github/workflows/pyenv_tests.yml
@@ -24,7 +24,12 @@ jobs:
               # xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
       # https://github.com/pyenv/pyenv#installation
       - run: |
-          if test "$RUNNER_OS" == "macOS"; then brew install coreutils; fi
+          if test "$RUNNER_OS" == "macOS"; then
+            brew install coreutils fish
+          elif [[ $(lsb_release -sr | awk -F. '{print $1}') -ge 20 ]]; then
+            # Ubuntu 18 has fish 2 which lacks many features that facilitate testing
+            sudo apt install fish -yq
+          fi
       - run: pwd
       - env:
           PYENV_ROOT: /home/runner/work/pyenv/pyenv

--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -6,9 +6,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 2.7.18
-          - 3.5.10
-          - 3.6.15
           - 3.7.10
           - 3.8.10
           - 3.9.5

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ opposed to this idea. Here's what `eval "$(pyenv init -)"` actually does:
    for some reason you need `pyenv` to be a real script rather than a
    shell function, you can safely skip it.
 
-`eval "$(pyenv init --path)"` only does item 1.
+`eval "$(pyenv init --path)"` only does items 1 and 3.
 
 To see exactly what happens under the hood for yourself, run `pyenv init -`
 or `pyenv init --path`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project was forked from [rbenv](https://github.com/rbenv/rbenv) and
 ![Terminal output example](/terminal_output.png)
 
 
-### what pyenv _does..._
+### What pyenv _does..._
 
 * Lets you **change the global Python version** on a per-user basis.
 * Provides support for **per-project Python versions**.
@@ -27,11 +27,10 @@ This project was forked from [rbenv](https://github.com/rbenv/rbenv) and
 * **Depend on Python itself.** pyenv was made from pure shell scripts.
     There is no bootstrap problem of Python.
 * **Need to be loaded into your shell.** Instead, pyenv's shim
-    approach works by adding a directory to your `$PATH`.
+    approach works by adding a directory to your `PATH`.
 * **Manage virtualenv.** Of course, you can create [virtualenv](https://pypi.python.org/pypi/virtualenv)
     yourself, or [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv)
     to automate the process.
-
 
 ----
 
@@ -41,19 +40,27 @@ This project was forked from [rbenv](https://github.com/rbenv/rbenv) and
 * **[How It Works](#how-it-works)**
   * [Understanding PATH](#understanding-path)
   * [Understanding Shims](#understanding-shims)
-  * [Choosing the Python Version](#choosing-the-python-version)
-  * [Locating the Python Installation](#locating-the-python-installation)
+  * [Understanding Python version selection](#understanding-python-version-selection)
+  * [Locating Pyenv-provided Python Installations](#locating-pyenv-provided-python-installations)
 * **[Installation](#installation)**
-  * [Prerequisites](#prerequisites)
-  * [Homebrew in macOS](#homebrew-in-macos)
-  * [Windows](#windows)
-  * [Automatic installer](#automatic-installer)
-  * [Basic GitHub Checkout](#basic-github-checkout)
-    * [Upgrading](#upgrading)
-    * [Homebrew on macOS](#homebrew-on-macos)
-    * [Advanced Configuration](#advanced-configuration)
-    * [Uninstalling Python Versions](#uninstalling-python-versions)
-* **[Command Reference](#command-reference)**
+  * [Getting Pyenv](#getting-pyenv)
+    * [Homebrew in macOS](#homebrew-in-macos)
+    * [Windows](#windows)
+    * [Automatic installer](#automatic-installer)
+    * [Basic GitHub Checkout](#basic-github-checkout)
+  * [Set up your shell environment for Pyenv](#set-up-your-shell-environment-for-pyenv)
+  * [Restart your shell](#restart-your-shell)
+  * [Install Python build dependencies](#install-python-build-dependencies)
+* **[Usage](#usage)**
+  * [Install additional Python versions](#install-additional-python-versions)
+  * [Switch between Python versions](#switch-between-python-versions)
+  * [Uninstall Python versions](#uninstall-python-versions)
+  * [Other operations](#other-operations)
+* [Upgrading](#upgrading)
+* [Uninstalling pyenv](#uninstalling-pyenv)
+* [Advanced Configuration](#advanced-configuration)
+  * [Using Pyenv without shims](#using-pyenv-without-shims)
+  * [Environment variables](#environment-variables)
 * **[Development](#development)**
   * [Version History](#version-history)
   * [License](#license)
@@ -69,6 +76,7 @@ executables injected into your `PATH`, determines which Python version
 has been specified by your application, and passes your commands along
 to the correct Python installation.
 
+
 ### Understanding PATH
 
 When you run a command like `python` or `pip`, your operating system
@@ -83,6 +91,7 @@ executable in a directory at the beginning of the list takes
 precedence over another one at the end. In this example, the
 `/usr/local/bin` directory will be searched first, then `/usr/bin`,
 then `/bin`.
+
 
 ### Understanding Shims
 
@@ -104,7 +113,8 @@ operating system will do the following:
 * Run the shim named `pip`, which in turn passes the command along to
   pyenv
 
-### Choosing the Python Version
+
+### Understanding Python version selection
 
 When you execute a shim, pyenv determines which Python version to use by
 reading it from the following sources, in this order:
@@ -122,25 +132,45 @@ reading it from the following sources, in this order:
    directory, until reaching the root of your filesystem.
 
 4. The global `$(pyenv root)/version` file. You can modify this file using
-   the [`pyenv global`](https://github.com/pyenv/pyenv/blob/master/COMMANDS.md#pyenv-global) command. If the global version
-   file is not present, pyenv assumes you want to use the "system"
-   Python. (In other words, whatever version would run if pyenv weren't in your
-   `PATH`.)
+   the [`pyenv global`](https://github.com/pyenv/pyenv/blob/master/COMMANDS.md#pyenv-global) command.
+   If the global version file is not present, pyenv assumes you want to use the "system"
+   Python (see below).
+
+A special version name "`system`" means to use whatever Python is found on `PATH`
+after the shims `PATH` entry (in other words, whatever would be run if Pyenv
+shims weren't on `PATH`). Note that Pyenv considers those installations outside
+its control and does not attempt to inspect or distinguish them in any way.
+So e.g. if you are on MacOS and have OS-bundled Python 3.8.9 and Homebrew-installed
+Python 3.9.12 and 3.10.2 -- for Pyenv, this is still a single "`system`" version,
+and whichever of those is first on `PATH` under the executable name you
+specified will be run.
 
 **NOTE:** You can activate multiple versions at the same time, including multiple
 versions of Python2 or Python3 simultaneously. This allows for parallel usage of
-Python2 and Python3, and is required with tools like `tox`. For example, to set
-your path to first use your `system` Python and Python3 (set to 2.7.9 and 3.4.2
-in this example), but also have Python 3.3.6, 3.2, and 2.5 available on your
-`PATH`, one would first `pyenv install` the missing versions, then set `pyenv
-global system 3.3.6 3.2 2.5`. At this point, one should be able to find the full
-executable path to each of these using `pyenv which`, e.g. `pyenv which python2.5`
-(should display `$(pyenv root)/versions/2.5/bin/python2.5`), or `pyenv which
-python3.4` (should display path to system Python3). You can also specify multiple
-versions in a `.python-version` file, separated by newlines.
-Lines starting with a `#` are ignored.
+Python2 and Python3, and is required with tools like `tox`. For example, to instruct
+Pyenv to first use your system Python and Python3 (which are e.g. 2.7.9 and 3.4.2)
+but also have Python 3.3.6, 3.2.1, and 2.5.2 available, you first `pyenv install`
+the missing versions, then set `pyenv global system 3.3.6 3.2.1 2.5.2`.
+Then you'll be able to invoke any of those versions with an appropriate `pythonX` or
+`pythonX.Y` name.
+You can also specify multiple versions in a `.python-version` file by hand,
+separated by newlines. Lines starting with a `#` are ignored.
 
-### Locating the Python Installation
+[`pyenv which <command>`](COMMANDS.md#pyenv-which) displays which real executable would be
+run when you invoke `<command>` via a shim.
+E.g. if you have 3.3.6, 3.2.1 and 2.5.2 installed of which 3.3.6 and 2.5.2 are selected
+and your system Python is 3.2.5,
+`pyenv which python2.5` should display `$(pyenv root)/versions/2.5.2/bin/python2.5`,
+`pyenv which python3` -- `$(pyenv root)/versions/3.3.6/bin/python3` and
+`pyenv which python3.2` -- path to your system Python due to the fall-through (see below).
+
+Shims also fall through to anything further on `PATH` if the corresponding executable is
+not present in any of the selected Python installations.
+This allows you to use any programs installed elsewhere on the system as long as
+they are not shadowed by a selected Python installation.
+
+
+### Locating Pyenv-provided Python installations
 
 Once pyenv has determined which version of Python your application has
 specified, it passes the command along to the corresponding Python
@@ -158,282 +188,262 @@ For example, you might have these versions installed:
 As far as Pyenv is concerned, version names are simply directories under
 `$(pyenv root)/versions`.
 
-### Managing Virtual Environments
-
-There is a pyenv plugin named [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) which comes with various features to help pyenv users to manage virtual environments created by virtualenv or Anaconda.
-Because the `activate` script of those virtual environments are relying on mutating `$PATH` variable of user's interactive shell, it will intercept pyenv's shim style command execution hooks.
-We'd recommend to install pyenv-virtualenv as well if you have some plan to play with those virtual environments.
-
-
 ----
 
 
 ## Installation
 
-### Prerequisites
-
-For pyenv to install python correctly you should [**install the Python build dependencies**](https://github.com/pyenv/pyenv/wiki#suggested-build-environment).
-
-### Homebrew in macOS
+### Getting Pyenv
+#### Homebrew in macOS
 
    1. Consider installing with [Homebrew](https://brew.sh):
       ```sh
       brew update
       brew install pyenv
       ```
-   2. Then follow the rest of the post-installation steps under [Basic GitHub Checkout](https://github.com/pyenv/pyenv#basic-github-checkout), starting with #&#8203;2 ("Configure your shell's environment for Pyenv").
+   2. Then follow the rest of the post-installation steps, starting with
+      [Set up your shell environment for Pyenv](#set-up-your-shell-environment-for-pyenv).
 
    3. OPTIONAL. To fix `brew doctor`'s warning _""config" scripts exist outside your system or Homebrew directories"_
-   
-      If you're going to build Homebrew formulae from source that link against `libpython`
+
+      If you're going to build Homebrew formulae from source that link against Python
       like Tkinter or NumPy
       _(This is only generally the case if you are a developer of such a formula,
-      or if you have an EOL version of MacOS for which prebuilt bottles are no longer available
-      and are using such a formula)._
-      
+      or if you have an EOL version of MacOS for which prebuilt bottles are no longer provided
+      and you are using such a formula)._
+
       To avoid them accidentally linking against a Pyenv-provided Python,
       add the following line into your interactive shell's configuration:
-      
+
       * Bash/Zsh:
-      
+
         ~~~bash
         alias brew='env PATH="${PATH//$(pyenv root)\/shims:/}" brew'
         ~~~
-      
+
       * Fish:
 
         ~~~fish
         alias brew="env PATH=(string replace (pyenv root)/shims '' \"\$PATH\") brew"
         ~~~
 
-### Windows
+
+#### Windows
 
 Pyenv does not officially support Windows and does not work in Windows outside
 the Windows Subsystem for Linux.
 Moreover, even there, the Pythons it installs are not native Windows versions
-but rather Linux versions run through a compatibility layer --
+but rather Linux versions running in a virtual machine --
 so you won't get Windows-specific functionality.
 
 If you're in Windows, we recommend using @kirankotari's [`pyenv-win`](https://github.com/pyenv-win/pyenv-win) fork --
 which does install native Windows Python versions.
 
 
-### Automatic installer
+#### Automatic installer
 
 Visit our other project:
 https://github.com/pyenv/pyenv-installer
 
 
-### Basic GitHub Checkout
+#### Basic GitHub Checkout
 
 This will get you going with the latest version of Pyenv and make it
 easy to fork and contribute any changes back upstream.
 
-1. **Check out Pyenv where you want it installed.**
+* **Check out Pyenv where you want it installed.**
    A good place to choose is `$HOME/.pyenv` (but you can install it somewhere else):
 
-        git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+       git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 
-   Optionally, try to compile a dynamic Bash extension to speed up Pyenv. Don't
+*  Optionally, try to compile a dynamic Bash extension to speed up Pyenv. Don't
    worry if it fails; Pyenv will still work normally:
 
-        cd ~/.pyenv && src/configure && make -C src
-
-2. **Configure your shell's environment for Pyenv**
-
-   **Note:** The below instructions for specific shells are designed for common shell setups;
-   they also install shell functions into interactive shells only.  
-   If you have an uncommon setup and/or needs and they don't work for you,
-   use the [Advanced Configuration](#advanced-configuration)
-   section below to figure out what you need to do in your specific case.
-   
-   **General MacOS note:**
-   [Make sure that your terminal app is configured to run the shell as a login shell](https://github.com/pyenv/pyenv/wiki/MacOS-login-shell)
-   (especially if you're using an alternative terminal app and/or shell).
-   The configuration samples for MacOS are written under this assumption and won't work otherwise.
-   
-   - For **Bash**:
-
-      - **If your `~/.profile` sources `~/.bashrc` (Debian, Ubuntu, Mint):**
-
-         ~~~bash
-         # the sed invocation inserts the lines at the start of the file
-         # after any initial comment lines
-         sed -Ei -e '/^([^#]|$)/ {a \
-         export PYENV_ROOT="$HOME/.pyenv"
-         a \
-         export PATH="$PYENV_ROOT/bin:$PATH"
-         a \
-         ' -e ':a' -e '$!{n;ba};}' ~/.profile
-         echo 'eval "$(pyenv init --path)"' >>~/.profile
-
-         echo 'eval "$(pyenv init -)"' >> ~/.bashrc
-         ~~~
-
-      - **If your `~/.bash_profile` sources `~/.bashrc` (Red Hat, Fedora, CentOS):**
-
-         ~~~ bash
-         sed -Ei -e '/^([^#]|$)/ {a \
-         export PYENV_ROOT="$HOME/.pyenv"
-         a \
-         export PATH="$PYENV_ROOT/bin:$PATH"
-         a \
-         ' -e ':a' -e '$!{n;ba};}' ~/.bash_profile
-         echo 'eval "$(pyenv init --path)"' >> ~/.bash_profile
-
-         echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.profile
-         echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.profile
-         echo 'eval "$(pyenv init --path)"' >> ~/.profile
-
-         echo 'eval "$(pyenv init -)"' >> ~/.bashrc
-         ~~~
-
-      - **If you have no `~/.bash_profile` and your `/etc/profile` sources `~/.bashrc` (SUSE):**
-
-         ~~~bash
-         echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.profile
-         echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.profile
-         echo 'eval "$(pyenv init --path)"' >> ~/.profile
-
-         echo 'if command -v pyenv >/dev/null; then eval "$(pyenv init -)"; fi' >> ~/.bashrc
-         ~~~
-            
-      - **Otherwise if you have no stock `~/.profile` or `~/.bash_profile` (MacOS):**
-      
-         ~~~bash
-         echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.profile
-         echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.profile
-         echo 'eval "$(pyenv init --path)"' >> ~/.profile
-         echo 'if [ -n "$PS1" -a -n "$BASH_VERSION" ]; then source ~/.bashrc; fi' >> ~/.profile
-
-         echo 'eval "$(pyenv init -)"' >> ~/.bashrc
-         ~~~
-
-         In MacOS, make sure that your terminal app runs the shell as a login shell.
-
-      - **Temporary environments (CI, Docker, batch jobs):**
-
-         In CI/build environments, paths and the environment are usually already set up for you
-         in one of the above ways.
-         You may only need to install Pyenv as a shell function into the (noninteractive) shell
-         that runs the batch script, and only if you need subcommands that require `pyenv`
-         to be a shell function (e.g. `shell` and Pyenv-Virtualenv's `activate`).
-
-         ~~~bash
-         eval "$(pyenv init -)"
-         ~~~
-         
-         If you are installing Pyenv yourself as part of the batch job,
-         after installing the files, run the following in the job's shell
-         to be able to use it.
-         
-         ~~~bash
-         export PYENV_ROOT="$HOME/.pyenv"
-         export PATH="$PYENV_ROOT/bin:$PATH"    # if `pyenv` is not already on PATH
-         eval "$(pyenv init --path)"
-         eval "$(pyenv init -)"
-         ~~~
-
-         
-      **General Bash warning**: There are some systems where the `BASH_ENV` variable is configured
-      to point to `.bashrc`. On such systems, you should almost certainly put the
-      `eval "$(pyenv init -)"` line into `.bash_profile`, and **not** into `.bashrc`. Otherwise, you
-      may observe strange behaviour, such as `pyenv` getting into an infinite loop.
-      See [#264](https://github.com/pyenv/pyenv/issues/264) for details.
+       cd ~/.pyenv && src/configure && make -C src
 
 
-   - For **Zsh**:
+### Set up your shell environment for Pyenv
 
-      - **MacOS, if Pyenv is installed with Homebrew:**
+**Upgrade note:** The startup logic and instructions have been updated for simplicity in 2.3.0.
+The previous, more complicated configuration scheme for 2.0.0-2.2.5 still works.
 
-         ~~~ zsh
-         echo 'eval "$(pyenv init --path)"' >> ~/.zprofile
-      
-         echo 'eval "$(pyenv init -)"' >> ~/.zshrc
-         ~~~
-         
-         Make sure that your terminal app runs the shell as a login shell.
+* Define environment variable `PYENV_ROOT` to point to the path where
+  Pyenv will store its data. `$HOME/.pyenv` is the default.
+  If you installed Pyenv via Git checkout, we recommend
+  to set it to the same location as where you cloned it.
+* Add the `pyenv` executable to your `PATH` if it's not already there
+* run `eval "$(pyenv init -)"` to install `pyenv` into your shell as a shell function, enable shims and autocompletion
+  * You may run `eval "$(pyenv init --path)"` instead to just enable shims, without shell integration
 
+The below setup should work for the vast majority of users for commmon use cases.
+See [Advanvced configuration](#advanced-configuration) for details and more configuration options.
 
-      - **MacOS, if Pyenv is installed with a Git checkout:**
-      
-         ~~~ zsh
-         echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zprofile
-         echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zprofile
-         echo 'eval "$(pyenv init --path)"' >> ~/.zprofile
-      
-         echo 'eval "$(pyenv init -)"' >> ~/.zshrc
-         ~~~
+  - For **bash**:
 
-         Make sure that your terminal app runs the shell as a login shell.
+    Stock Bash startup files vary widely between distibutions in which of them source
+    which, under what circumstances, in what order and what additional configuration they perform.
+    As such, the most reliable way to get Pyenv in all environments is to append Pyenv
+    configuration commands to both `.bashrc` (for interactive shells)
+    and the profile file that Bash would use (for login shells).
 
-      - **Other OSes:**
-      
-         ~~~ zsh
-         echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zprofile
-         echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zprofile
-         echo 'eval "$(pyenv init --path)"' >> ~/.zprofile
-         
-         echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.profile
-         echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.profile
-         echo 'eval "$(pyenv init --path)"' >> ~/.profile
+    First, add the commands to `~/.bashrc`:
 
-         echo 'eval "$(pyenv init -)"' >> ~/.zshrc
-         ~~~
-        
-    - For **Fish shell**:
+    ~~~ bash
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+    echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+    echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+    ~~~
 
-        Execute this interactively:
-        
-        ~~~ fish
-        set -Ux PYENV_ROOT $HOME/.pyenv
-        set -U fish_user_paths $PYENV_ROOT/bin $fish_user_paths
-        ~~~
+    Then, if you have `~/.profile`, `~/.bash_profile` or `~/.bash_login`, add the commands there as well.
+    If you have none of these, add them to `~/.profile`.
 
-        And add this to `~/.config/fish/config.fish`:
-        
-        ~~~ fish
-        status is-login; and pyenv init --path | source
-        status is-interactive; and pyenv init - | source
-        ~~~
+    * to add to `~/.profile`:
+      ~~~ bash
+      echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.profile
+      echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.profile
+      echo 'eval "$(pyenv init -)"' >> ~/.profile
+      ~~~
 
-        If Fish is not your login shell, also follow the Bash/Zsh instructions to add to `~/.profile`.
+    * to add to `~/.bash_profile`:
+      ~~~ bash
+      echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
+      echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
+      echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
+      ~~~
 
-      **Proxy note**: If you use a proxy, export `http_proxy` and `https_proxy`, too.
+  - For **Zsh**:
+    ~~~ zsh
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
+    echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
+    echo 'eval "$(pyenv init -)"' >> ~/.zshrc
+    ~~~
 
+    If you wish to get Pyenv in noninteractive login shells as well, also add the commands to `~/.zprofile` or `~/.zlogin`.
 
-4. **Restart your login session for the changes to profile files to take effect.**
-   E.g. if you're in a GUI session, you need to fully log out and log back in.
-   
-   In MacOS, restarting terminal windows is enough (because MacOS runs shells
-   in them as login shells by default).
+  - For **Fish shell**:
 
-5. [**Install Python build dependencies**](https://github.com/pyenv/pyenv/wiki#suggested-build-environment) before attempting to install a new Python version.
+    Execute this interactively:
 
-6. **Install Python versions into `$(pyenv root)/versions`.**
-   For example, to download and install Python 2.7.8, run:
-    ```sh
-    pyenv install 2.7.8
-    ```
-   **NOTE:** If you need to pass a `configure` option to a build, please use the
-   ```CONFIGURE_OPTS``` environment variable.
+    ~~~ fish
+    set -Ux PYENV_ROOT $HOME/.pyenv
+    set -U fish_user_paths $PYENV_ROOT/bin $fish_user_paths
+    ~~~
 
-   **NOTE:** If you want to use proxy to download, please set the `http_proxy` and `https_proxy`
-   environment variables.
+    And add this to `~/.config/fish/config.fish`:
 
-   **NOTE:** If you are having trouble installing a Python version,
-   please visit the wiki page about
-   [Common Build Problems](https://github.com/pyenv/pyenv/wiki/Common-build-problems).
+    ~~~ fish
+    pyenv init - | source
+    ~~~
+
+   **Bash warning**: There are some systems where the `BASH_ENV` variable is configured
+   to point to `.bashrc`. On such systems, you should almost certainly put the
+   `eval "$(pyenv init -)"` line into `.bash_profile`, and **not** into `.bashrc`. Otherwise, you
+   may observe strange behaviour, such as `pyenv` getting into an infinite loop.
+   See [#264](https://github.com/pyenv/pyenv/issues/264) for details.
+
+   **Proxy note**: If you use a proxy, export `http_proxy` and `https_proxy`, too.
 
 
-#### Upgrading
+### Restart your shell
+
+  for the `PATH` changes to take effect.
+
+  ```sh
+  exec "$SHELL"
+  ```
+
+### Install Python build dependencies
+
+  [**Install Python build dependencies**](https://github.com/pyenv/pyenv/wiki#suggested-build-environment)
+  before attempting to install a new Python version.
+
+  You can now begin using Pyenv.
+
+----
+
+
+## Usage
+
+### Install additional Python versions
+
+To install additonal Python versions, use [`pyenv install`](COMMANDS.md#pyenv-install).
+
+For example, to download and install Python 3.10.4, run:
+
+```sh
+pyenv install 3.10.4
+```
+
+**NOTE:** Most Pyenv-provided Python releases are source releases and are built
+from source as part of installation (that's why you need Python build dependencies preinstalled).
+You can pass options to Python's `configure` and compiler flags to customize the build,
+see [_Special environment variables_ in Python-Build's README](plugins/python-build/README.md#special-environment-variables)
+for details.
+
+**NOTE:** If you want to use proxy for download, please set the `http_proxy` and `https_proxy`
+environment variables.
+
+**NOTE:** If you are having trouble installing a Python version,
+please visit the wiki page about
+[Common Build Problems](https://github.com/pyenv/pyenv/wiki/Common-build-problems).
+
+
+### Switch between Python versions
+
+To select a Pyenv-installed Python as the version to use, run one
+of the following commands:
+
+* [`pyenv shell <version>`](COMMANDS.md#pyenv-shell) -- select just for current shell session
+* [`pyenv local <version>`](COMMANDS.md#pyenv-local) -- automatically select whenever you are in the current directory (or its subdirectories)
+* [`pyenv global <version>`](COMMANDS.md#pyenv-shell) -- select globally for your user account
+
+E.g. to select the above-mentioned newly-installed Python 3.10.4 as your preferred version to use:
+
+~~~bash
+pyenv global 3.10.4
+~~~
+
+Now whenever you invoke `python`, `pip` etc., an executable from the Pyenv-provided
+3.10.4 installation will be run instead of the system Python.
+
+Using "`system`" as a version name would reset the selection to your system-provided Python.
+
+See [Understanding shims](#understanding-shims) and
+[Understanding Python version selection](#understanding-python-version-selection)
+for more details on how the selection works and more information on its usage.
+
+
+### Uninstall Python versions
+
+As time goes on, you will accumulate Python versions in your
+`$(pyenv root)/versions` directory.
+
+To remove old Python versions, use [`pyenv uninstall <version>`](COMMANDS.md#pyenv-uninstall).
+
+Alternatively, you can simply `rm -rf` the directory of the version you want
+to remove. You can find the directory of a particular Python version
+with the `pyenv prefix` command, e.g. `pyenv prefix 2.6.8`.
+Note however that plugins may run additional operations on uninstall
+which you would need to do by hand as well. E.g. Pyenv-Virtualenv also
+removes any virtual environments linked to the version being uninstalled.
+
+
+### Other operations
+
+Run `pyenv commands` to get a list of all available subcommands.
+Run a subcommand with `--help` to get help on it, or see the [Commands Reference](COMMANDS.md).
+
+Note that Pyenv plugins that you install may add their own subcommands.
+
+
+## Upgrading
 
 If you've installed Pyenv using Homebrew, upgrade using:
 ```sh
 brew upgrade pyenv
 ```
 
-If you've installed Pyenv using the instructions above, you can
+If you've installed Pyenv using Pyenv-installer or Git checkout, you can
 upgrade your installation at any time using Git.
 
 To upgrade to the latest development version of pyenv, use `git pull`:
@@ -452,7 +462,7 @@ git tag
 git checkout v0.1.0
 ```
 
-### Uninstalling pyenv
+## Uninstalling pyenv
 
 The simplicity of pyenv makes it easy to temporarily disable it, or
 uninstall from the system.
@@ -462,124 +472,113 @@ uninstall from the system.
   remove Pyenv shims directory from `PATH`, and future invocations like
   `python` will execute the system Python version, as it was before Pyenv.
 
-   `pyenv` will still be accessible on the command line, but your Python
-   apps won't be affected by version switching.
+    `pyenv` will still be accessible on the command line, but your Python
+    apps won't be affected by version switching.
 
-2. To completely **uninstall** Pyenv, remove _all_ configuration lines for it
-   from your shell startup configuration, and then remove
-   its root directory. This will **delete all Python versions** that were
-   installed under `` $(pyenv root)/versions/ `` directory:
-   
-   ```sh
-   rm -rf $(pyenv root)
-   ```
+2. To completely **uninstall** Pyenv, remove _all_ Pyenv configuration lines
+  from your shell startup configuration, and then remove
+  its root directory. This will **delete all Python versions** that were
+  installed under the `` $(pyenv root)/versions/ `` directory:
 
-   If you've installed Pyenv using a package manager, as a final step,
-   perform the Pyenv package removal. For instance, for Homebrew:
+    ```sh
+    rm -rf $(pyenv root)
+    ```
 
-   ```
-   brew uninstall pyenv
-   ```
+    If you've installed Pyenv using a package manager, as a final step,
+    perform the Pyenv package removal. For instance, for Homebrew:
 
-### Advanced Configuration
+    ```
+    brew uninstall pyenv
+    ```
+
+## Advanced Configuration
 
 Skip this section unless you must know what every line in your shell
 profile is doing.
 
-`pyenv init` is the only command that crosses the line of loading
-extra commands into your shell. Coming from RVM, some of you might be
-opposed to this idea.
-
 Also see the [Environment variables](#environment-variables) section
 for the environment variables that control Pyenv's behavior.
 
-
-* `eval "$(pyenv init --path)"`:
-
-   1. **Sets up your shims path.** This is the only requirement for pyenv to
-      function properly. You can do this by hand by prepending
-      `$(pyenv root)/shims` to your `$PATH`.
-   
-   `eval "$(pyenv init --path)"` is supposed to be run in your session's login
-   shell startup script -- so that all processes in the session get access to
-   Pyenv's functionality and it only runs once,
-   avoiding breaking `PATH` in nested shells
-   (e.g. shells started from editors/IDEs).
-   
-   In Linux, GUI managers typically act as a `sh` login shell, running
-   `/etc/profile` and `~/.profile` at their startup. MacOS' GUI doesn't do that,
-   so its terminal emulator apps run their shells as login shells by default
-   to compensate.
+`pyenv init` is the only command that crosses the line of loading
+extra commands into your shell. Coming from RVM, some of you might be
+opposed to this idea. Here's what `eval "$(pyenv init -)"` actually does:
 
 
-* `eval "$(pyenv init -)"`:
+1. **Sets up the shims path.** This is what allows Pyenv to intercept
+   and redirect invocations of `python`, `pip` etc. transparently.
+   It prepends `$(pyenv root)/shims` to your `$PATH`.
+   It also deletes any other instances of `$(pyenv root)/shims` on `PATH`
+   which allows to invoke `eval "$(pyenv init -)"` multiple times without
+   getting duplicate `PATH` entries.
 
-   1. **Installs autocompletion.** This is entirely optional but pretty
-      useful. Sourcing `$(pyenv root)/completions/pyenv.bash` will set that
-      up. There is also a `$(pyenv root)/completions/pyenv.zsh` for Zsh
-      users.
+2. **Installs autocompletion.** This is entirely optional but pretty
+   useful. Sourcing `$(pyenv root)/completions/pyenv.bash` will set that
+   up. There are also completions for Zsh and Fish.
 
-   2. **Rehashes shims.** From time to time you'll need to rebuild your
-      shim files. Doing this on init makes sure everything is up to
-      date. You can always run `pyenv rehash` manually.
+3. **Rehashes shims.** From time to time you'll need to rebuild your
+   shim files. Doing this on init makes sure everything is up to
+   date. You can always run `pyenv rehash` manually.
 
-   3. **Installs `pyenv` into the current shell as a shell function.**
-      This bit is also optional, but allows
-      pyenv and plugins to change variables in your current shell, making
-      commands like `pyenv shell` possible. The sh dispatcher doesn't do
-      anything crazy like override `cd` or hack your shell prompt, but if
-      for some reason you need `pyenv` to be a real script rather than a
-      shell function, you can safely skip it.
-      
-   `eval "$(pyenv init -)"` is supposed to run at any interactive shell's
-   startup (including nested shells) so that you get completion and
-   convenience shell functions.
+4. **Installs `pyenv` into the current shell as a shell function.**
+   This bit is also optional, but allows
+   pyenv and plugins to change variables in your current shell.
+   This is required for some commands like `pyenv shell` to work.
+   The sh dispatcher doesn't do
+   anything crazy like override `cd` or hack your shell prompt, but if
+   for some reason you need `pyenv` to be a real script rather than a
+   shell function, you can safely skip it.
+
+`eval "$(pyenv init --path)"` only does item 1.
 
 To see exactly what happens under the hood for yourself, run `pyenv init -`
 or `pyenv init --path`.
 
+`eval "$(pyenv init -)"` is supposed to run at any interactive shell's
+startup (including nested shells -- e.g. those invoked from editors)
+so that you get completion and convenience shell functions.
+
+`eval "$(pyenv init --path)"` can be used instead of `eval "$(pyenv init -)"`
+to just enable shims, without shell integration. It can also be used to bump shims
+to the front of `PATH` after some other logic has prepended stuff to `PATH`
+that may shadow Pyenv's shims.
+
+* In particular, in Debian-based distributions, the stock `~/.profile`
+  prepends per-user `bin` directories to `PATH` after having sourced `~/.bashrc`.
+  This necessitates appending a `pyenv init` call to `~/.profile` as well as `~/.bashrc`
+  in these distributions because the system's Pip places executables for
+  modules installed by a non-root user into those per-user `bin` directories.
+
+
+### Using Pyenv without shims
+
 If you don't want to use `pyenv init` and shims, you can still benefit
 from pyenv's ability to install Python versions for you. Just run
 `pyenv install` and you will find versions installed in
-`$(pyenv root)/versions`, which you can manually execute or symlink
-as required.
+`$(pyenv root)/versions`.
 
-### Uninstalling Python Versions
+You can manually execute or symlink them as required,
+or you can use [`pyenv exec <command>`](COMMANDS.md#pyenv-exec)
+whenever you want `<command>` to be affected by Pyenv's version selection
+as currently configured.
 
-As time goes on, you will accumulate Python versions in your
-`$(pyenv root)/versions` directory.
-
-To remove old Python versions, `pyenv uninstall` command to automate
-the removal process.
-
-Alternatively, simply `rm -rf` the directory of the version you want
-to remove. You can find the directory of a particular Python version
-with the `pyenv prefix` command, e.g. `pyenv prefix 2.6.8`.
+`pyenv exec` works by prepending `$(pyenv root)/versions/<selected version>/bin`
+to `PATH` in the `<command>`'s environment, the same as what e.g. RVM does.
 
 
-----
+### Environment variables
 
-
-## Command Reference
-
-See [COMMANDS.md](COMMANDS.md).
-
-
-----
-
-## Environment variables
-
-You can affect how pyenv operates with the following settings:
+You can affect how Pyenv operates with the following settings:
 
 name | default | description
 -----|---------|------------
-`PYENV_VERSION` | | Specifies the Python version to be used.<br>Also see [`pyenv shell`](https://github.com/pyenv/pyenv/blob/master/COMMANDS.md#pyenv-shell)
-`PYENV_ROOT` | `~/.pyenv` | Defines the directory under which Python versions and shims reside.<br>Also see `pyenv root`
+`PYENV_VERSION` | | Specifies the Python version to be used.<br>Also see [`pyenv shell`]COMMANDS.md#pyenv-shell)
+`PYENV_ROOT` | `~/.pyenv` | Defines the directory under which Python versions and shims reside.<br>Also see [`pyenv root`](COMMANDS.md#pyenv-root)
 `PYENV_DEBUG` | | Outputs debug information.<br>Also as: `pyenv --debug <subcommand>`
 `PYENV_HOOK_PATH` | [_see wiki_][hooks] | Colon-separated list of paths searched for pyenv hooks.
 `PYENV_DIR` | `$PWD` | Directory to start searching for `.python-version` files.
-`PYTHON_BUILD_ARIA2_OPTS` | | Used to pass additional parameters to [`aria2`](https://aria2.github.io/).<br>If the `aria2c` binary is available on PATH, pyenv uses `aria2c` instead of `curl` or `wget` to download the Python Source code. If you have an unstable internet connection, you can use this variable to instruct `aria2` to accelerate the download.<br>In most cases, you will only need to use `-x 10 -k 1M` as value to `PYTHON_BUILD_ARIA2_OPTS` environment variable
+`PYTHON_BUILD_ARIA2_OPTS` | | Used to pass additional parameters to [`aria2`](https://aria2.github.io/).<br>If the `aria2c` binary is available on `PATH`, pyenv uses `aria2c` instead of `curl` or `wget` to download the Python Source code. If you have an unstable internet connection, you can use this variable to instruct `aria2` to accelerate the download.<br>In most cases, you will only need to use `-x 10 -k 1M` as value to `PYTHON_BUILD_ARIA2_OPTS` environment variable
 
+----
 
 
 ## Development
@@ -597,9 +596,6 @@ Please feel free to submit pull requests and file bugs on the [issue
 tracker](https://github.com/pyenv/pyenv/issues).
 
 
-  [pyenv-virtualenv]: https://github.com/pyenv/pyenv-virtualenv#readme
-  [hooks]: https://github.com/pyenv/pyenv/wiki/Authoring-plugins#pyenv-hooks
-
 ### Version History
 
 See [CHANGELOG.md](CHANGELOG.md).
@@ -607,3 +603,7 @@ See [CHANGELOG.md](CHANGELOG.md).
 ### License
 
 [The MIT License](LICENSE)
+
+
+[pyenv-virtualenv]: https://github.com/pyenv/pyenv-virtualenv#readme
+[hooks]: https://github.com/pyenv/pyenv/wiki/Authoring-plugins#pyenv-hooks

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -61,6 +61,7 @@ function main() {
     ;;
   "print")
     init_dirs
+    print_path
     print_env
     print_completion
     print_shell_function
@@ -74,7 +75,12 @@ function main() {
 function help_() {
   case "$shell" in
   bash )
-    profile='~/.bash_profile'
+    if [ -e '~/.bash_profile' ]; then
+      profile='~/.bash_profile'
+    else
+      profile='~/.profile'
+    fi
+    profile_explain="~/.bash_profile if it exists, otherwise ~/.profile"
     rc='~/.bashrc'
     ;;
   zsh )
@@ -92,10 +98,39 @@ function help_() {
   esac
 
   {
+    case "$shell" in
+    fish )
+      echo "# Add pyenv executable to PATH by running"
+      echo "# the following interactively:"
+      echo
+      echo 'set -Ux PYENV_ROOT $HOME/.pyenv'
+      echo 'set -U fish_user_paths $PYENV_ROOT/bin $fish_user_paths'
+      echo
+      echo "# Load pyenv automatically by appending"
+      echo "# the following to ~/.config/fish/config.fish:"
+      echo
+      echo 'pyenv init - | source'
+      echo
+      ;;
+    * )
+      echo '# Load pyenv automatically by appending'
+      echo -n "# the following to "
+      if [ "$profile" == "$rc" ]; then
+        echo "$profile :"
+      else
+        echo
+        echo "${profile_explain:-$profile} (for login shells)"
+        echo "and $rc (for interactive shells) :"
+      fi
+      echo
+      echo 'export PYENV_ROOT="$HOME/.pyenv"'
+      echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"'
+      echo 'eval "$(pyenv init -)"'
+      ;;
+    esac
     echo
-    echo '# See the README for instructions on how to set up'
-    echo '# your shell environment for Pyenv.'
-    echo 
+    echo '# Restart your shell for the changes to take effect.'
+    echo
   } >&2
 }
 
@@ -104,13 +139,15 @@ function init_dirs() {
 }
 
 function print_path() {
-  # Need to use the login shell rather than the current one
   case "$shell" in
     fish )
-      echo "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
+      echo 'while set index (contains -i -- '\'"${PYENV_ROOT}/shims"\'' $PATH)'
+      echo 'set -eg PATH[$index]; end; set -e index'
+      echo 'set -gx PATH '\'"${PYENV_ROOT}/shims"\'' $PATH'
       ;;
     * )
-      echo 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
+      echo 'PATH="$(bash -ec '\''IFS=:; paths=($PATH); for i in ${!paths[@]}; do if [[ ${paths[i]} == "'\'"${PYENV_ROOT}/shims"\''" ]]; then unset '\'\\\'\''paths[i]'\'\\\'\''; fi; done; echo "${paths[*]}"'\'')"'
+      echo 'export PATH="'"${PYENV_ROOT}"'/shims:${PATH}"'
       ;;
   esac
 }

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -57,6 +57,7 @@ function main() {
     ;;
   "path")
     print_path
+    print_rehash
     exit 0
     ;;
   "print")
@@ -64,6 +65,7 @@ function main() {
     print_path
     print_env
     print_completion
+    print_rehash
     print_shell_function
     exit 0
     ;;
@@ -168,7 +170,9 @@ function print_completion() {
   if [ -r "$completion" ]; then
     echo "source '$completion'"
   fi
+}
 
+function print_rehash() {
   if [ -z "$no_rehash" ]; then
     echo 'command pyenv rehash 2>/dev/null'
   fi

--- a/test/init.bats
+++ b/test/init.bats
@@ -53,7 +53,7 @@ OUT
 @test "fish instructions" {
   run pyenv-init fish
   assert [ "$status" -eq 1 ]
-  assert_line '# See the README for instructions on how to set up'
+  assert_line 'pyenv init - | source'
 }
 
 @test "option to skip rehash" {
@@ -64,30 +64,41 @@ OUT
 
 @test "adds shims to PATH" {
   export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
-  run pyenv-init --path bash
+  run pyenv-init - bash
   assert_success
-  assert_line 0 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
+  assert_line 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
 }
 
 @test "adds shims to PATH (fish)" {
   export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
-  run pyenv-init --path fish
+  run pyenv-init - fish
   assert_success
-  assert_line 0 "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
+  assert_line "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
 }
 
-@test "can add shims to PATH more than once" {
-  export PATH="${PYENV_ROOT}/shims:$PATH"
-  run pyenv-init --path bash
+@test "removes existing shims from PATH" {
+  OLDPATH="$PATH"
+  export PATH="${BATS_TEST_DIRNAME}/nonexistent:${PYENV_ROOT}/shims:$PATH"
+  run bash -e <<!
+eval "\$(pyenv-init -)"
+echo "\$PATH"
+!
   assert_success
-  assert_line 0 'export PATH="'${PYENV_ROOT}'/shims:${PATH}"'
+  assert_output "${PYENV_ROOT}/shims:${BATS_TEST_DIRNAME}/nonexistent:${OLDPATH//${PYENV_ROOT}\/shims:/}"
 }
 
-@test "can add shims to PATH more than once (fish)" {
-  export PATH="${PYENV_ROOT}/shims:$PATH"
-  run pyenv-init --path fish
+@test "removes existing shims from PATH (fish)" {
+  command -v fish >/dev/null || skip "-- fish not installed"
+  OLDPATH="$PATH"
+  export PATH="${BATS_TEST_DIRNAME}/nonexistent:${PYENV_ROOT}/shims:$PATH"
+  # fish 2 (Ubuntu Bionic) adds spurious messages when setting PATH, messing up the output
+  run fish <<!
+set -x PATH "$PATH"
+pyenv init - | source
+echo "\$PATH"
+!
   assert_success
-  assert_line 0 "set -gx PATH '${PYENV_ROOT}/shims' \$PATH"
+  assert_output "${PYENV_ROOT}/shims:${BATS_TEST_DIRNAME}/nonexistent:${OLDPATH//${PYENV_ROOT}\/shims:/}"
 }
 
 @test "outputs sh-compatible syntax" {

--- a/test/init.bats
+++ b/test/init.bats
@@ -17,6 +17,13 @@ load test_helper
   assert_line "command pyenv rehash 2>/dev/null"
 }
 
+@test "auto rehash for --path" {
+  run pyenv-init --path
+  assert_success
+  assert_line "command pyenv rehash 2>/dev/null"
+}
+
+
 @test "setup shell completions" {
   root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
   run pyenv-init - bash

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -84,7 +84,8 @@ assert_line() {
     for line in "${lines[@]}"; do
       if [ "$line" = "$1" ]; then return 0; fi
     done
-    flunk "expected line \`$1'"
+    flunk "expected line \`$1'" $'\n'\
+    "output: $output"
   fi
 }
 
@@ -98,7 +99,8 @@ refute_line() {
     local line
     for line in "${lines[@]}"; do
       if [ "$line" = "$1" ]; then
-        flunk "expected to not find line \`$line'"
+        flunk "expected to not find line \`$line'" $'\n'\
+        "output: $output"
       fi
     done
   fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2220
  - Closes https://github.com/pyenv/pyenv/issues/2213
  - Closes https://github.com/pyenv/pyenv/issues/2206
  - Closes https://github.com/pyenv/pyenv/issues/2198
  - Closes https://github.com/pyenv/pyenv/issues/2085
  - Closes https://github.com/pyenv/pyenv/issues/2299
  - Closes https://github.com/pyenv/pyenv/pull/2326

### Description
- [x] Here are some details about my PR

Now it's add to both rc and profile:
1) Add `pyenv` to PATH if not already there
2) set PYENV_ROOT if not already set
3) eval "$(pyenv init -)"

Not a breaking change, old setup will continue to work.

TBD:
* <s>script for installer</s> -- `pyenv init` output cannot be used as installation script, will be done separately as part of https://github.com/pyenv/pyenv-installer/issues/112

### Tests
- [x] My PR adds the following unit tests (if any)
For changed `init` functionality