### PR TITLE
Fix to add the pyenv shims to the PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ easy to fork and contribute any changes back upstream.
          echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zprofile
          echo 'eval "$(pyenv init --path)"' >> ~/.zprofile
       
-         echo 'eval "$(pyenv init -)"' >> ~/.zshrc
+         echo 'eval "$(pyenv init --path)"' >> ~/.zshrc
          ~~~
 
          Make sure that your terminal app runs the shell as a login shell.
@@ -372,13 +372,9 @@ easy to fork and contribute any changes back upstream.
          ~~~ zsh
          echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zprofile
          echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zprofile
-         echo 'eval "$(pyenv init --path)"' >> ~/.zprofile
-         
-         echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.profile
-         echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.profile
-         echo 'eval "$(pyenv init --path)"' >> ~/.profile
+         echo 'eval "$(pyenv init --path)"' >> ~/.zprofile               
 
-         echo 'eval "$(pyenv init -)"' >> ~/.zshrc
+         echo 'eval "$(pyenv init --path)"' >> ~/.zshrc
          ~~~
         
     - For **Fish shell**:


### PR DESCRIPTION
For some reason, the init command needs the argument '--path' to add the shims path to the PATH var env.

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)
