### PR TITLE
Support XCode 13.3 (Apple Cang 13.1.6) in all releases that officiall…

### DIFF
--- a/plugins/python-build/share/python-build/patches/3.10.0/Python-3.10.0/0002-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.10.0/Python-3.10.0/0002-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From c8ee4dc57dd995e96ef9af0a04957b61ae1a7ac9 Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index cc37185068..f238470c17 100755
+--- a/configure
++++ b/configure
+@@ -5226,9 +5226,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5387,6 +5384,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index 3e6c07c279..dd68777b6a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -717,9 +717,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -875,6 +872,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.29.2.windows.2
+

--- a/plugins/python-build/share/python-build/patches/3.7.10/Python-3.7.10/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.7.10/Python-3.7.10/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 35ddc7ad61b20a18496ba9410aa31b405e23fe78 Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index 829dd69bb8..455481bc50 100755
+--- a/configure
++++ b/configure
+@@ -5183,9 +5183,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5342,6 +5339,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index f1cc8e9bcb..1afcba3307 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -724,9 +724,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -880,6 +877,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.29.2.windows.2
+

--- a/plugins/python-build/share/python-build/patches/3.7.11/Python-3.7.11/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.7.11/Python-3.7.11/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 0c2fd7c1de5121ea636134f131cf7ebada023acf Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index 829dd69bb8..455481bc50 100755
+--- a/configure
++++ b/configure
+@@ -5183,9 +5183,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5342,6 +5339,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index f1cc8e9bcb..1afcba3307 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -724,9 +724,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -880,6 +877,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.29.2.windows.2
+

--- a/plugins/python-build/share/python-build/patches/3.7.8/Python-3.7.8/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.7.8/Python-3.7.8/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 5b79a7da20953f107657dea5192ed77cc8554ff0 Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index c807c98e56..51a7d60f54 100755
+--- a/configure
++++ b/configure
+@@ -5183,9 +5183,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5342,6 +5339,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index 805c0bba08..ede2197cb3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -724,9 +724,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -880,6 +877,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.29.2.windows.2
+

--- a/plugins/python-build/share/python-build/patches/3.7.9/Python-3.7.9/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.7.9/Python-3.7.9/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 1d6f94126d0af2370ba0e4c7d8befc1c7ecf35d8 Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index 829dd69bb8..455481bc50 100755
+--- a/configure
++++ b/configure
+@@ -5183,9 +5183,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5342,6 +5339,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index f1cc8e9bcb..1afcba3307 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -724,9 +724,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -880,6 +877,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.29.2.windows.2
+

--- a/plugins/python-build/share/python-build/patches/3.8.10/Python-3.8.10/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.8.10/Python-3.8.10/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 8ced1a904558ff9499673083cf13abf03a76b7d0 Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index 936f3d4596..c091865aff 100755
+--- a/configure
++++ b/configure
+@@ -5160,9 +5160,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5321,6 +5318,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index e02cc2c656..de83332dd3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -719,9 +719,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -877,6 +874,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+

--- a/plugins/python-build/share/python-build/patches/3.8.11/Python-3.8.11/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.8.11/Python-3.8.11/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 7f35b41fa1e13fb9915fd476eaec2b15e2082c4f Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index 936f3d4596..c091865aff 100755
+--- a/configure
++++ b/configure
+@@ -5160,9 +5160,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5321,6 +5318,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index e02cc2c656..de83332dd3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -719,9 +719,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -877,6 +874,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+

--- a/plugins/python-build/share/python-build/patches/3.8.12/Python-3.8.12/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.8.12/Python-3.8.12/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From c4379ecd43dab0d2c836787d82bce4f20eed892b Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index 936f3d4596..c091865aff 100755
+--- a/configure
++++ b/configure
+@@ -5160,9 +5160,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5321,6 +5318,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index e02cc2c656..de83332dd3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -719,9 +719,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -877,6 +874,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+

--- a/plugins/python-build/share/python-build/patches/3.8.4/Python-3.8.4/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.8.4/Python-3.8.4/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 3af555f75a53a82fa074572b24cb6516d3db0645 Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index 96dcd0dcd5..1fb735bf8b 100755
+--- a/configure
++++ b/configure
+@@ -5167,9 +5167,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5328,6 +5325,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index 18a044629a..6d841d928d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -706,9 +706,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -864,6 +861,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+

--- a/plugins/python-build/share/python-build/patches/3.8.5/Python-3.8.5/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.8.5/Python-3.8.5/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 988821dfd8b087368dfee462d73f518ca4cfbfe0 Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index 96dcd0dcd5..1fb735bf8b 100755
+--- a/configure
++++ b/configure
+@@ -5167,9 +5167,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5328,6 +5325,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index 18a044629a..6d841d928d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -706,9 +706,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -864,6 +861,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+

--- a/plugins/python-build/share/python-build/patches/3.8.6/Python-3.8.6/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.8.6/Python-3.8.6/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 7ec2de6bb20a934424df28c6566e6fc3a5eab6d4 Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index 96dcd0dcd5..1fb735bf8b 100755
+--- a/configure
++++ b/configure
+@@ -5167,9 +5167,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5328,6 +5325,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index 18a044629a..6d841d928d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -706,9 +706,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -864,6 +861,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+

--- a/plugins/python-build/share/python-build/patches/3.8.7/Python-3.8.7/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.8.7/Python-3.8.7/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 97f07c98cac3d095c5c3f5816e4c7b3fe7b9c251 Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index c164d68c4e..dcc0795296 100755
+--- a/configure
++++ b/configure
+@@ -5167,9 +5167,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5328,6 +5325,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index fc082a3cd2..5c9bee2850 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -706,9 +706,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -864,6 +861,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+

--- a/plugins/python-build/share/python-build/patches/3.8.8/Python-3.8.8/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.8.8/Python-3.8.8/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From cb51d8b90c5668e77b9ed8ded562eeaabf518f5c Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index c164d68c4e..dcc0795296 100755
+--- a/configure
++++ b/configure
+@@ -5167,9 +5167,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5328,6 +5325,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index fc082a3cd2..5c9bee2850 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -706,9 +706,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -864,6 +861,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+

--- a/plugins/python-build/share/python-build/patches/3.8.9/Python-3.8.9/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.8.9/Python-3.8.9/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 9d066808637164f1386ece0d3b26b8e4262c4dfd Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index c737256c15..97a371c6da 100755
+--- a/configure
++++ b/configure
+@@ -5155,9 +5155,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5316,6 +5313,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index 040ddfc791..0969bb5b0c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -713,9 +713,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -871,6 +868,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+

--- a/plugins/python-build/share/python-build/patches/3.9.0/Python-3.9.0/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.9.0/Python-3.9.0/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From b8f6adaf38973076542c54e5d9a4fd7c6665c8f2 Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index 9e6fd46583..80c3a6589a 100755
+--- a/configure
++++ b/configure
+@@ -5193,9 +5193,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5354,6 +5351,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index d60f05251a..110318545d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -718,9 +718,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -876,6 +873,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+

--- a/plugins/python-build/share/python-build/patches/3.9.1/Python-3.9.1/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.9.1/Python-3.9.1/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 8ada29fb655f9803bab4777308c77db8c1f74735 Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index 2d379feb4b..e36d8d523d 100755
+--- a/configure
++++ b/configure
+@@ -5193,9 +5193,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5354,6 +5351,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index c968d149c2..a16e475bc2 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -718,9 +718,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -876,6 +873,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+

--- a/plugins/python-build/share/python-build/patches/3.9.2/Python-3.9.2/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.9.2/Python-3.9.2/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 9e317124ae4d1f133c18485e83b952360741519d Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index 1252335472..0da9fa285e 100755
+--- a/configure
++++ b/configure
+@@ -5193,9 +5193,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5354,6 +5351,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index 972287a9c4..76252ad36c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -718,9 +718,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -876,6 +873,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+

--- a/plugins/python-build/share/python-build/patches/3.9.4/Python-3.9.4/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.9.4/Python-3.9.4/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From d93aaf050384705ac744a4e6cbbab1408e770c0a Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index c7a7291fea..708c9215e4 100755
+--- a/configure
++++ b/configure
+@@ -5193,9 +5193,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5354,6 +5351,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index 45e0af4493..559a40eda9 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -725,9 +725,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -883,6 +880,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+

--- a/plugins/python-build/share/python-build/patches/3.9.5/Python-3.9.5/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.9.5/Python-3.9.5/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 16a65fb399eb8d1a5cfecd597e579a4402b2e4c8 Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index 8dcdbf1989..ac03aff210 100755
+--- a/configure
++++ b/configure
+@@ -5196,9 +5196,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5357,6 +5354,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index b1e4c6ce19..94102dd324 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -727,9 +727,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -885,6 +882,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+

--- a/plugins/python-build/share/python-build/patches/3.9.6/Python-3.9.6/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.9.6/Python-3.9.6/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 9b7f2f9ce024d2cceb90f9a9d939b37090c525e2 Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index ffa61c1dc5..18597d4de8 100755
+--- a/configure
++++ b/configure
+@@ -5196,9 +5196,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5357,6 +5354,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index 8fe5fa5742..577ce9040f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -727,9 +727,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -885,6 +882,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+

--- a/plugins/python-build/share/python-build/patches/3.9.7/Python-3.9.7/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.9.7/Python-3.9.7/0001-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,80 @@
+From 785de1ab8b4ab8b89d0e62ffd7521b5b2636923a Mon Sep 17 00:00:00 2001
+From: David Bohman <debohman@gmail.com>
+Date: Tue, 12 Oct 2021 17:10:26 -0700
+Subject: [PATCH] bpo-45405: Prevent ``internal configure error`` when running
+ ``configure``  with recent versions of non-Apple clang. (#28845)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+
+Co-authored-by: Ned Deily <nad@python.org>
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..a2dc5bcc32
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of non-Apple clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index ffa61c1dc5..18597d4de8 100755
+--- a/configure
++++ b/configure
+@@ -5196,9 +5196,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5357,6 +5354,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index 8fe5fa5742..577ce9040f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -727,9 +727,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -885,6 +882,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.36.0
+


### PR DESCRIPTION
…y support MacOS 11

There are no new platform incompatibilities in MacOS 12 so those releases likely run in it as well

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Addresses https://github.com/pyenv/pyenv/issues/2143
  - Closes https://github.com/pyenv/pyenv/issues/2338
  - Closes https://github.com/pyenv/pyenv/issues/2312
  - Closes https://github.com/pyenv/pyenv/issues/2343
  - Closes https://github.com/pyenv/pyenv/issues/2340
  - Closes https://github.com/pyenv/pyenv/issues/2285
  - Closes https://github.com/pyenv/pyenv/issues/2284
  - Closes https://github.com/pyenv/pyenv/issues/2280
  - Closes https://github.com/pyenv/pyenv/issues/2317
  - Closes https://github.com/pyenv/pyenv/issues/2306

### Description
- [x] Here are some details about my PR

As per https://github.com/pyenv/pyenv/issues/2143#issuecomment-1072032647, backports https://github.com/python/cpython/commit/9c4766772cda67648184f8ddba546a5fc0167f91 to all releases that officially support MacOS 11 (https://github.com/pyenv/pyenv/issues/1737#issuecomment-794592631).
For some later releases, the patch is not needed.

Rationale:
* MacOS 12 does not introduce any (glaring) new incompatibilities, so those versions should technically run in it as well -- the reason for the error is the new compiler rather than the OS.
* Users have reported that they try to use a multitude of those versions in MacOS 12

### Tests
- [x] My PR adds the following unit tests (if any)
N/A