### PR TITLE
Make PYENV_DEBUG imply -v for `pyenv install`

### DIFF
--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -73,6 +73,8 @@ unset VERBOSE
 unset HAS_PATCH
 unset DEBUG
 
+[ -n "$PYENV_DEBUG" ] && VERBOSE="-v"
+
 parse_options "$@"
 for option in "${OPTIONS[@]}"; do
   case "$option" in


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

Trace logs without `-v` are usually useless due to
missing the build part.
So this leaves one less thing for users to worry about
when submitting error reports.

Mentioning `-v` in the issue template should stay for some time
since users report on old versions, too.

### Tests
- [x] My PR adds the following unit tests (if any)
N/A