### PR TITLE
Don't use Homebrew outside of MacOS

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -1,7 +1,7 @@
-name: macos_tests
+name: macos_build
 on: [pull_request, push]
 jobs:
-  macos_tests:
+  macos_build:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -1,7 +1,7 @@
-name: ubuntu_tests
+name: ubuntu_build
 on: [pull_request, push]
 jobs:
-  ubuntu_tests:
+  ubuntu_build:
     strategy:
       fail-fast: false
       matrix:

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1322,9 +1322,10 @@ configured_with_package_dir() {
 }
 
 use_homebrew() {
+  is_mac || return 1
   # unless Homebrew is at the default /usr/local, need to add its paths to
   # compiler search to be able to use non-keg-only deps from there
-  if command -v brew &>/dev/null; then
+  if is_mac && command -v brew &>/dev/null; then
     local brew_prefix="$(brew --prefix 2>/dev/null || true)"
     # /usr/local/lib:/usr/lib is the default library search path
     if [[ -n $brew_prefix && $brew_prefix != "/usr" && $brew_prefix != "/usr/local" ]]; then
@@ -1340,6 +1341,7 @@ needs_yaml() {
 }
 
 use_homebrew_yaml() {
+  is_mac || return 1
   local libdir="$(brew --prefix libyaml 2>/dev/null || true)"
   if [ -d "$libdir" ]; then
     echo "python-build: use libyaml from homebrew"
@@ -1383,6 +1385,7 @@ has_broken_mac_readline() {
 }
 
 use_homebrew_readline() {
+  is_mac || return 1
   if ! configured_with_package_dir "python" "readline/rlconf.h"; then
     local libdir="$(brew --prefix readline 2>/dev/null || true)"
     if [ -d "$libdir" ]; then
@@ -1423,6 +1426,7 @@ has_broken_mac_openssl() {
 }
 
 use_homebrew_openssl() {
+  is_mac || return 1
   command -v brew >/dev/null || return 1
   for openssl in ${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl}; do
     local ssldir="$(brew --prefix "${openssl}" || true)"
@@ -1522,6 +1526,7 @@ build_package_verify_openssl() {
 }
 
 use_homebrew_zlib() {
+  is_mac || return 1
   local brew_zlib="$(brew --prefix zlib 2>/dev/null || true)"
   if [ -d "$brew_zlib" ]; then
     echo "python-build: use zlib from homebrew"
@@ -1541,6 +1546,7 @@ use_xcode_sdk_zlib() {
 }
 
 use_homebrew_tcltk() {
+  is_mac || return 1
   # get the version from the folder that homebrew versions
   local tcltk_libdir="$(brew --prefix tcl-tk 2>/dev/null || true)"
   if [ -d "$tcltk_libdir" ]; then
@@ -1598,7 +1604,9 @@ get_tcltk_flag_from() {
 }
 
 use_tcltk() {
-  local tcltk_libdir="$(brew --prefix tcl-tk 2>/dev/null || true)"
+  if is_mac; then
+    local tcltk_libdir="$(brew --prefix tcl-tk 2>/dev/null || true)"
+  fi
   local tcl_tk_libs="$(get_tcltk_flag_from "$PYTHON_CONFIGURE_OPTS")"
 
   # if tcltk_ops_flag is in PYTHON_CONFIGURE_OPTS, use user provided tcltk

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -62,7 +62,7 @@ assert_build_log() {
   cached_tarball "yaml-0.1.6"
   cached_tarball "Python-3.6.2"
 
-  for i in {1..4}; do stub uname '-s : echo Linux'; done
+  for i in {1..9}; do stub uname '-s : echo Linux'; done
   stub brew false
   stub_make_install
   stub_make_install
@@ -89,7 +89,7 @@ OUT
   cached_tarball "yaml-0.1.6"
   cached_tarball "Python-3.6.2"
 
-  for i in {1..4}; do stub uname '-s : echo Linux'; done
+  for i in {1..9}; do stub uname '-s : echo Linux'; done
   stub brew false
   stub_make_install
   stub_make_install
@@ -119,14 +119,11 @@ OUT
   cached_tarball "yaml-0.1.6"
   cached_tarball "Python-3.6.2"
 
-  stub uname '-s : echo Linux' '-s : echo Linux'
+  for i in {1..9}; do stub uname '-s : echo Linux'; done
   stub brew false
   stub_make_install
   stub_make_install
   stub patch ' : echo patch "$@" | sed -E "s/\.[[:alnum:]]+$/.XXX/" >> build.log'
-
-  # pyenv/pyenv#1026
-  stub uname false false
 
   TMPDIR="$TMP" install_fixture --patch definitions/needs-yaml <<<"diff --git a/script.py"
   assert_success
@@ -154,7 +151,7 @@ OUT
   BREW_PREFIX="$TMP/homebrew-prefix"
   mkdir -p "$BREW_PREFIX"
 
-  for i in {1..4}; do stub uname '-s : echo Darwin'; done
+  for i in {1..9}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
   stub brew "--prefix : echo '$BREW_PREFIX'" false
   stub_make_install
@@ -164,8 +161,8 @@ install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.
 DEF
   assert_success
 
-  unstub sw_vers
   unstub uname
+  unstub sw_vers
   unstub make
 
   assert_build_log <<OUT
@@ -182,7 +179,7 @@ OUT
   brew_libdir="$TMP/homebrew-yaml"
   mkdir -p "$brew_libdir"
 
-  for i in {1..4}; do stub uname '-s : echo Darwin'; done
+  for i in {1..10}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
   stub brew "--prefix libyaml : echo '$brew_libdir'"
   for i in {1..4}; do stub brew false; done
@@ -191,8 +188,8 @@ OUT
   install_fixture definitions/needs-yaml
   assert_success
 
-  unstub sw_vers
   unstub uname
+  unstub sw_vers
   unstub brew
   unstub make
 
@@ -204,12 +201,41 @@ make install
 OUT
 }
 
+@test "yaml is not linked from Homebrew in non-MacOS" {
+  cached_tarball "yaml-0.1.6"
+  cached_tarball "Python-3.6.2"
+
+  for i in {1..9}; do stub uname '-s : echo Linux'; done
+  stub brew true; brew
+  stub_make_install
+  stub_make_install
+
+  install_fixture definitions/needs-yaml
+  assert_success
+
+  unstub uname
+  unstub brew
+  unstub make
+
+  assert_build_log <<OUT
+yaml-0.1.6: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+yaml-0.1.6: --prefix=${TMP}/install
+make -j 2
+make install
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+make -j 2
+make install
+OUT
+}
+
 @test "readline is linked from Homebrew" {
   cached_tarball "Python-3.6.2"
 
   readline_libdir="$TMP/homebrew-readline"
   mkdir -p "$readline_libdir"
-  stub uname false
+  for i in {1..8}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
   for i in {1..2}; do stub brew false; done
   stub brew "--prefix readline : echo '$readline_libdir'"
   stub brew false
@@ -220,11 +246,37 @@ install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.
 DEF
   assert_success
 
+  unstub uname
+  unstub sw_vers
   unstub brew
   unstub make
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I$readline_libdir/include -I${TMP}/install/include " LDFLAGS="-L$readline_libdir/lib -L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+make -j 2
+make install
+OUT
+}
+
+@test "no library searches performed during normal operation touch homebrew in non-MacOS" {
+  cached_tarball "Python-3.6.2"
+
+  for i in {1..8}; do stub uname '-s : echo Linux'; done
+  stub brew true; brew
+  stub_make_install
+
+  run_inline_definition <<DEF
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub brew
+  unstub make
+
+  assert_build_log <<OUT
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
 Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -239,8 +291,8 @@ OUT
   mkdir -p "$readline_libdir/include/readline"
   touch "$readline_libdir/include/readline/rlconf.h"
 
-  # pyenv/pyenv#1026
-  stub uname false false
+  for i in {1..8}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
 
   for i in {1..3}; do stub brew false; done
   stub_make_install
@@ -251,6 +303,8 @@ install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.
 DEF
   assert_success
 
+  unstub uname
+  unstub sw_vers
   unstub brew
   unstub make
 
@@ -269,10 +323,13 @@ OUT
   mkdir -p "$tcl_tk_libdir/lib"
   echo "TCL_VERSION='$tcl_tk_version'" >>"$tcl_tk_libdir/lib/tclConfig.sh"
 
-  stub uname false
+  for i in {1..10}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
+
   stub brew false
   for i in {1..2}; do stub brew "--prefix tcl-tk : echo '$tcl_tk_libdir'"; done
   for i in {1..2}; do stub brew false; done
+
   stub_make_install
 
   run_inline_definition <<DEF
@@ -280,6 +337,8 @@ install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.
 DEF
   assert_success
 
+  unstub uname
+  unstub sw_vers
   unstub brew
   unstub make
 
@@ -298,8 +357,8 @@ OUT
   tcl_tk_version_long="8.6.10"
   tcl_tk_version="${tcl_tk_version_long%.*}"
 
-  # pyenv/pyenv#1026
-  stub uname false false
+  for i in {1..9}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
 
   for i in {1..4}; do stub brew false; done
   stub_make_install
@@ -310,6 +369,8 @@ install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.
 DEF
   assert_success
 
+  unstub uname
+  unstub sw_vers
   unstub brew
   unstub make
 
@@ -324,14 +385,9 @@ OUT
 @test "number of CPU cores defaults to 2" {
   cached_tarball "Python-3.6.2"
 
-  # yyuu/pyenv#222
-  stub uname '-s : echo Darwin'
-  stub sw_vers '-productVersion : echo 10.10'
+  for i in {1..10}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 10.10'; done
 
-  # yyuu/pyenv#257
-  stub uname '-s : echo Darwin'
-
-  stub uname '-s : echo Darwin' false '-s : echo Darwin'
   stub sysctl false
   stub_make_install
 
@@ -342,6 +398,7 @@ DEF
   assert_success
 
   unstub uname
+  unstub sw_vers
   unstub make
 
   assert_build_log <<OUT
@@ -355,14 +412,9 @@ OUT
 @test "number of CPU cores is detected on Mac" {
   cached_tarball "Python-3.6.2"
 
-  # yyuu/pyenv#222
-  stub uname '-s : echo Darwin'
-  stub sw_vers '-productVersion : echo 10.10'
+  for i in {1..10}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 10.10'; done
 
-  # yyuu/pyenv#257
-  stub uname '-s : echo Darwin'
-
-  stub uname '-s : echo Darwin' false '-s : echo Darwin'
   stub sysctl '-n hw.ncpu : echo 4'
   stub_make_install
 
@@ -373,6 +425,7 @@ DEF
   assert_success
 
   unstub uname
+  unstub sw_vers
   unstub sysctl
   unstub make
 
@@ -387,10 +440,10 @@ OUT
 @test "number of CPU cores is detected on FreeBSD" {
   cached_tarball "Python-3.6.2"
 
-  # pyenv/pyenv#1026
-  stub uname false false
+  for i in {1..7}; do stub uname '-s : echo FreeBSD'; done
+  stub uname '-r : echo 11.0-RELEASE'
+  for i in {1..2}; do stub uname '-s : echo FreeBSD'; done
 
-  stub uname '-s : echo FreeBSD' false false
   stub sysctl '-n hw.ncpu : echo 1'
   stub_make_install
 
@@ -415,10 +468,8 @@ OUT
 @test "setting PYTHON_MAKE_INSTALL_OPTS to a multi-word string" {
   cached_tarball "Python-3.6.2"
 
-  # pyenv/pyenv#1026
-  stub uname false false false
+  for i in {1..8}; do stub uname '-s : echo Linux'; done
 
-  stub uname '-s : echo Linux'
   stub_make_install
 
   export PYTHON_MAKE_INSTALL_OPTS="DOGE=\"such wow\""
@@ -441,10 +492,7 @@ OUT
 @test "setting MAKE_INSTALL_OPTS to a multi-word string" {
   cached_tarball "Python-3.6.2"
 
-  # pyenv/pyenv#1026
-  stub uname false false false
-
-  stub uname '-s : echo Linux'
+  for i in {1..8}; do stub uname '-s : echo Linux'; done
   stub_make_install
 
   export MAKE_INSTALL_OPTS="DOGE=\"such wow\""
@@ -476,10 +524,10 @@ OUT
 @test "make on FreeBSD 9 defaults to gmake" {
   cached_tarball "Python-3.6.2"
 
-  stub uname "-s : echo FreeBSD" "-r : echo 9.1" false
-
-  # pyenv/pyenv#1026
-  stub uname false false false
+  stub uname "-s : echo FreeBSD" "-r : echo 9.1"
+  for i in {1..6}; do stub uname "-s : echo FreeBSD"; done
+  stub uname "-r : echo 9.1"
+  for i in {1..2}; do stub uname "-s : echo FreeBSD"; done
 
   MAKE=gmake stub_make_install
 
@@ -493,10 +541,10 @@ OUT
 @test "make on FreeBSD 10" {
   cached_tarball "Python-3.6.2"
 
-  stub uname "-s : echo FreeBSD" "-r : echo 10.0-RELEASE" false
-
-  # pyenv/pyenv#1026
-  stub uname false false false
+  stub uname "-s : echo FreeBSD" "-r : echo 10.0-RELEASE"
+  for i in {1..6}; do stub uname "-s : echo FreeBSD"; done
+  stub uname "-r : echo 10.0-RELEASE"
+  for i in {1..2}; do stub uname "-s : echo FreeBSD"; done
 
   stub_make_install
 
@@ -509,10 +557,10 @@ OUT
 @test "make on FreeBSD 11" {
   cached_tarball "Python-3.6.2"
 
-  stub uname "-s : echo FreeBSD" "-r : echo 11.0-RELEASE" false
-
-  # pyenv/pyenv#1026
-  stub uname false false false
+  stub uname "-s : echo FreeBSD" "-r : echo 11.0-RELEASE"
+  for i in {1..6}; do stub uname "-s : echo FreeBSD"; done
+  stub uname "-r : echo 11.0-RELEASE"
+  for i in {1..2}; do stub uname "-s : echo FreeBSD"; done
 
   stub_make_install
 
@@ -531,14 +579,9 @@ apply -p1 -i /my/patch.diff
 exec ./configure "\$@"
 CONF
 
-  stub uname '-s : echo Linux'
+  for i in {1..8}; do stub uname '-s : echo Linux'; done
   stub apply 'echo apply "$@" >> build.log'
   stub_make_install
-
-  # yyuu/pyenv#257
-  stub uname '-s : echo Linux'
-  stub uname '-s : echo Linux'
-  stub uname '-s : echo Linux'
 
   export PYTHON_CONFIGURE="${TMP}/custom-configure"
   run_inline_definition <<DEF

--- a/plugins/python-build/test/compiler.bats
+++ b/plugins/python-build/test/compiler.bats
@@ -63,8 +63,8 @@ DEF
   mkdir -p "$INSTALL_ROOT"
   cd "$INSTALL_ROOT"
 
-  for i in {1..5}; do stub uname '-s : echo Darwin'; done
-  for i in {1..4}; do stub sw_vers '-productVersion : echo 10.10'; done
+  for i in {1..10}; do stub uname '-s : echo Darwin'; done
+  for i in {1..3}; do stub sw_vers '-productVersion : echo 10.10'; done
 
   stub cc 'false'
   stub brew 'false'
@@ -85,6 +85,10 @@ exec 4<&1
 build_package_standard python
 DEF
   assert_success
+
+  unstub uname
+  unstub sw_vers
+
   assert_output <<OUT
 ./configure --prefix=$INSTALL_ROOT --libdir=${TMP}/install/lib
 CC=clang

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -315,7 +315,7 @@ EOS
   cached_tarball "Python-3.6.2"
 
   for i in {1..4}; do stub brew false; done
-  for i in {1..3}; do stub uname '-s : echo Linux'; done
+  for i in {1..7}; do stub uname '-s : echo Linux'; done
   stub "$MAKE" \
     " : echo \"$MAKE \$@\" >> build.log" \
     " : echo \"$MAKE \$@\" >> build.log && cat build.log >> '$INSTALL_ROOT/build.log'"
@@ -332,7 +332,6 @@ OUT
 
   unstub make
   unstub uname
-  unstub brew
 }
 
 @test "default MACOSX_DEPLOYMENT_TARGET" {

--- a/plugins/python-build/test/stubs/stub
+++ b/plugins/python-build/test/stubs/stub
@@ -83,15 +83,6 @@ if [ -n "${!_STUB_END}" ]; then
   # the requested index, we failed.
   if [ $index -ge "${!_STUB_INDEX}" ]; then
     eval "${_STUB_RESULT}"=1
-    {
-      echo "index: $index; stub index: ${!_STUB_INDEX}"
-      echo "plan:"
-      cat "${!_STUB_PLAN}"
-      echo "run:"
-      cat "${!_STUB_RUN}"
-      echo "log:"
-      cat "${!_STUB_LOG}"
-    } >&2
   fi
   if [ "${!_STUB_RESULT}" -ne 0 ]; then
     {


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/1479

### Description
- [x] Here are some details about my PR

It turn out, libraries from Homebrew in Linux ("Linuxbrew" henceforth for short)
can't be used out of the box and require additional compiler flags.

Since Linuxbrew is not the primary source of dependency packages in Linux and
the problem seems to happen whether Pyenv itself is Linuxbrew-provided or not,
we'll disable using Homebrew outside of MacOS for now to fix the breakage.

### Tests
- [x] My PR adds the following unit tests (if any)
