### PR TITLE
Add `:latest` syntax to documentation for the `install` command

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -228,6 +228,14 @@ Then install the desired versions:
       2.6.8
     * 2.7.6 (set by /home/yyuu/.pyenv/version)
 
+To install the latest version of Python without giving a specific version use the `:latest` syntax. For example, to install the latest patch version for Python 3.8 you could do:
+
+    pyenv install 3.8:latest
+
+To install the latest major release for Python 3 try:
+
+    pyenv install 3:latest
+
 ## `pyenv uninstall`
 
 Uninstall a specific Python version.


### PR DESCRIPTION
It seems the `:latest` syntax (as added in commit #1831) is not documented anywhere in this file even though it's very useful so i thought it would be useful to add it.

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
