### PR TITLE
Add post-install checks for curses, ctypes, lzma, and tkinter

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1788,9 +1788,12 @@ build_package_verify_py27() {
 build_package_verify_py30() {
   verify_python "${2:-3.0}"
   try_python_module "bz2" "bzip2 lib"
+  try_python_module "curses" "ncurses lib"
+  try_python_module "ctypes" "libffi lib"
   try_python_module "readline" "GNU readline lib"
   verify_python_module "ssl" "OpenSSL lib"
   try_python_module "sqlite3" "SQLite3 lib"
+  try_python_module "tkinter" "Tk toolkit"
   verify_python_module "zlib" "zlib"
 }
 
@@ -1807,6 +1810,7 @@ build_package_verify_py32() {
 # Post-install check for Python 3.3.x
 build_package_verify_py33() {
   build_package_verify_py32 "$1" "${2:-3.3}"
+  try_python_module "lzma" "lzma lib"
 }
 
 # Post-install check for Python 3.4.x


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Related to #2137 but seems different enough to not close that issue

### Description
- [x] Here are some details about my PR

I got warnings on one machine that `bz2`, `readline`, and `sqlite3` could not be built. When installing the build dependencies according to the wiki, I realized that some warnings were missing. I've added warnings for [`curses`](https://docs.python.org/3/library/curses.html), [`ctypes`](https://docs.python.org/3/library/ctypes.html), and [`tkinter`](https://docs.python.org/3/library/tkinter.html) for all Python 3 versions and warnings for [`lzma`](https://docs.python.org/3/library/lzma.html) for Python 3.3 and later.

The wording for the warning messages might need to be adjusted, but I tried my best to match the style for similar warnings.

### Tests
- [x] My PR adds the following unit tests (if any)

I tested on Python 3.9.12 and 3.10.4 on CentOS 7 systems both with and without these packages to ensure the warnings work as expected. I also tested Python 3.0.1 and 3.3.7 to ensure I didn't break any older versions with these changes.