### PR TITLE
README.md: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ The previous, more complicated configuration scheme for 2.0.0-2.2.5 still works.
   * You may run `eval "$(pyenv init --path)"` instead to just enable shims, without shell integration
 
 The below setup should work for the vast majority of users for common use cases.
-See [Advanvced configuration](#advanced-configuration) for details and more configuration options.
+See [Advanced configuration](#advanced-configuration) for details and more configuration options.
 
   - For **bash**:
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

My PR fixes a typo in README.md.

### Tests
- [ ] My PR adds the following unit tests (if any)
