### PR TITLE
README.md, CHANGELOG.md, libexec/pyenv-help: Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@
 * Add documentation for shims command (#2091)
 * Add documentation for hooks command (#2089)
 * Add documentation for root command (#2088)
-* Add documentaion for prefix command (#2087)
+* Add documentation for prefix command (#2087)
 * Update to Pyston's v2 package of the 2.3.1 release (#2078)
 * Add pyston-2.3.1 support (#2075)
 * Don't update conda when installing pip (#2074)

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ See [Advanced configuration](#advanced-configuration) for details and more confi
 
   - For **bash**:
 
-    Stock Bash startup files vary widely between distibutions in which of them source
+    Stock Bash startup files vary widely between distributions in which of them source
     which, under what circumstances, in what order and what additional configuration they perform.
     As such, the most reliable way to get Pyenv in all environments is to append Pyenv
     configuration commands to both `.bashrc` (for interactive shells)
@@ -366,7 +366,7 @@ See [Advanced configuration](#advanced-configuration) for details and more confi
 
 ### Install additional Python versions
 
-To install additonal Python versions, use [`pyenv install`](COMMANDS.md#pyenv-install).
+To install additional Python versions, use [`pyenv install`](COMMANDS.md#pyenv-install).
 
 For example, to download and install Python 3.10.4, run:
 

--- a/libexec/pyenv-help
+++ b/libexec/pyenv-help
@@ -44,7 +44,7 @@ extract_initial_comment_block() {
 }
 
 collect_documentation() {
-  # `tail` prevents "broken pipe" errors due to `head` closing thge pipe without reading everything
+  # `tail` prevents "broken pipe" errors due to `head` closing the pipe without reading everything
   # https://superuser.com/questions/554855/how-can-i-fix-a-broken-pipe-error/642932#642932
   $(type -P gawk awk | tail -n +1 | head -1) '
     /^Summary:/ {


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

My PR fixes several typos in README.md, CHANGELOG.md, libexec/pyenv-help.

### Tests
- [ ] My PR adds the following unit tests (if any)
