### PR TITLE
Update 3.11-dev and add 3.12-dev

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1849,6 +1849,11 @@ build_package_verify_py311() {
   build_package_verify_py310 "$1" "${2:-3.11}"
 }
 
+# Post-install check for Python 3.12.x
+build_package_verify_py312() {
+  build_package_verify_py311 "$1" "${2:-3.12}"
+}
+
 # Post-install check for Python 3.x rolling release scripts
 # XXX: Will need splitting into project-specific ones if there emerge
 # multiple rolling-release scripts with different checks needed

--- a/plugins/python-build/share/python-build/3.12-dev
+++ b/plugins/python-build/share/python-build/3.12-dev
@@ -3,4 +3,4 @@ prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_git "Python-3.11-dev" "https://github.com/python/cpython" 3.11 standard verify_py311 copy_python_gdb ensurepip
+install_git "Python-3.12-dev" "https://github.com/python/cpython" main standard verify_py312 copy_python_gdb ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [n/a] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

Python 3.11 is in beta, which means it has moved from `main` to `3.11`
* https://github.com/python/cpython/tree/3.11

`main` is now open as the Python 3.12 branch
* https://github.com/python/cpython

This PR is based on https://github.com/pyenv/pyenv/pull/1897 (update 3.10-dev and add 3.11-dev)

(After the upstream branching, I was a little surprised when I installed `3.11-dev` and it installed Python 3.12 because it went from `main` :)

### Tests
- [n/a] My PR adds the following unit tests (if any)
