### PR TITLE
Add miniconda 4.12.0

### DIFF
--- a/plugins/python-build/scripts/add_miniconda.py
+++ b/plugins/python-build/scripts/add_miniconda.py
@@ -77,7 +77,10 @@ class SupportedOS(StrEnum):
 
 
 class SupportedArch(StrEnum):
+    AARCH64 = "aarch64"
+    ARM64 = "arm64"
     PPC64LE = "ppc64le"
+    S390X = "s390x"
     X86_64 = "x86_64"
     X86 = "x86"
 

--- a/plugins/python-build/share/python-build/miniconda3-3.7-4.10.1
+++ b/plugins/python-build/share/python-build/miniconda3-3.7-4.10.1
@@ -1,0 +1,16 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py37_4.10.1-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.1-Linux-aarch64.sh#bcb84cfe1f5ccf477fa73fc87d2f4125" "miniconda" verify_py37
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py37_4.10.1-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.1-Linux-s390x.sh#0738d7c00290860d60870103c710e4c2" "miniconda" verify_py37
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.7-4.10.3
+++ b/plugins/python-build/share/python-build/miniconda3-3.7-4.10.3
@@ -1,6 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py37_4.10.3-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Linux-aarch64.sh#19815e497b045246307f9317bcb4fb93" "miniconda" verify_py37
+  ;;
 "Linux-ppc64le" )
   install_script "Miniconda3-py37_4.10.3-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Linux-ppc64le.sh#a926bbaf28d59ac1264799e3ca770a44" "miniconda" verify_py37
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py37_4.10.3-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Linux-s390x.sh#a82215f8abf68e44a8666a658ac4cdf9" "miniconda" verify_py37
   ;;
 "Linux-x86_64" )
   install_script "Miniconda3-py37_4.10.3-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh#9f186c1d86c266acc47dbc1603f0e2ed" "miniconda" verify_py37

--- a/plugins/python-build/share/python-build/miniconda3-3.7-4.11.0
+++ b/plugins/python-build/share/python-build/miniconda3-3.7-4.11.0
@@ -1,6 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py37_4.11.0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.11.0-Linux-aarch64.sh#07e8dfaf467e5432d402a79b11085783" "miniconda" verify_py37
+  ;;
 "Linux-ppc64le" )
   install_script "Miniconda3-py37_4.11.0-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.11.0-Linux-ppc64le.sh#cf7cbccc16bf82365bbf0129f646ff45" "miniconda" verify_py37
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py37_4.11.0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.11.0-Linux-s390x.sh#1dc6dbf1951e65217d07cf30887360a8" "miniconda" verify_py37
   ;;
 "Linux-x86_64" )
   install_script "Miniconda3-py37_4.11.0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.11.0-Linux-x86_64.sh#7675bd23411179956bcc4692f16ef27d" "miniconda" verify_py37

--- a/plugins/python-build/share/python-build/miniconda3-3.7-4.12.0
+++ b/plugins/python-build/share/python-build/miniconda3-3.7-4.12.0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py37_4.12.0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.12.0-Linux-aarch64.sh#dbac5ea2d2a1dfcf864f5ad0ac775647" "miniconda" verify_py37
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py37_4.12.0-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.12.0-Linux-ppc64le.sh#57a654d3f143db5230d181cad7a938c1" "miniconda" verify_py37
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py37_4.12.0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.12.0-Linux-s390x.sh#2f6c9cb12b37dca5d7d29a4b5d04ffdd" "miniconda" verify_py37
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py37_4.12.0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.12.0-Linux-x86_64.sh#770bac2587bc7380198b4f0741115b11" "miniconda" verify_py37
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py37_4.12.0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.12.0-MacOSX-x86_64.sh#161c0c4b88410149beb73d1eea6ec937" "miniconda" verify_py37
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.7-4.9.2
+++ b/plugins/python-build/share/python-build/miniconda3-3.7-4.9.2
@@ -1,6 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py37_4.9.2-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-aarch64.sh#eb76394f962a84fb6af4ed8bf115b904" "miniconda" verify_py37
+  ;;
 "Linux-ppc64le" )
   install_script "Miniconda3-py37_4.9.2-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-ppc64le.sh#5bdc8650a2d1b32c8fd6eed9ed61aef5" "miniconda" verify_py37
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py37_4.9.2-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-s390x.sh#aa9207a1111352af948b8932d7823dce" "miniconda" verify_py37
   ;;
 "Linux-x86_64" )
   install_script "Miniconda3-py37_4.9.2-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-x86_64.sh#3143b1116f2d466d9325c206b7de88f7" "miniconda" verify_py37

--- a/plugins/python-build/share/python-build/miniconda3-3.8-4.10.1
+++ b/plugins/python-build/share/python-build/miniconda3-3.8-4.10.1
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py38_4.10.1-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.1-Linux-aarch64.sh#34aba2af867e5411eff7fddd80982aa9" "miniconda" verify_py38
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py38_4.10.1-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.1-Linux-s390x.sh#ff0ed5428dd94a6f5c64c92a59a73165" "miniconda" verify_py38
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py38_4.10.1-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.1-MacOSX-arm64.sh#1bb73c5cd765d135e2b874fc0f08d50c" "miniconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.8-4.10.3
+++ b/plugins/python-build/share/python-build/miniconda3-3.8-4.10.3
@@ -1,6 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py38_4.10.3-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-aarch64.sh#1b84ae526853a0301d0c04b68b718ea8" "miniconda" verify_py38
+  ;;
 "Linux-ppc64le" )
   install_script "Miniconda3-py38_4.10.3-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-ppc64le.sh#12ddb1b94f30f8fc633c3223b0398d2f" "miniconda" verify_py38
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py38_4.10.3-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-s390x.sh#44e34b6ee8a47db8c28834f86ada6d41" "miniconda" verify_py38
   ;;
 "Linux-x86_64" )
   install_script "Miniconda3-py38_4.10.3-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh#14da4a9a44b337f7ccb8363537f65b9c" "miniconda" verify_py38

--- a/plugins/python-build/share/python-build/miniconda3-3.8-4.11.0
+++ b/plugins/python-build/share/python-build/miniconda3-3.8-4.11.0
@@ -1,9 +1,18 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py38_4.11.0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.11.0-Linux-aarch64.sh#18344281ba44bdd1e38c8ae0f05a8758" "miniconda" verify_py38
+  ;;
 "Linux-ppc64le" )
   install_script "Miniconda3-py38_4.11.0-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.11.0-Linux-ppc64le.sh#adec9893a69557f1eaadce56f24f6614" "miniconda" verify_py38
   ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py38_4.11.0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.11.0-Linux-s390x.sh#b337e6834c940774e762cfb420ec7b91" "miniconda" verify_py38
+  ;;
 "Linux-x86_64" )
   install_script "Miniconda3-py38_4.11.0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.11.0-Linux-x86_64.sh#252d3b0c863333639f99fbc465ee1d61" "miniconda" verify_py38
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py38_4.11.0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.11.0-MacOSX-arm64.sh#1075216b8a7458b8fb86f6386dc5a4a9" "miniconda" verify_py38
   ;;
 "MacOSX-x86_64" )
   install_script "Miniconda3-py38_4.11.0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.11.0-MacOSX-x86_64.sh#e0ab9762f3d20d23bbff4b804a03cb08" "miniconda" verify_py38

--- a/plugins/python-build/share/python-build/miniconda3-3.8-4.12.0
+++ b/plugins/python-build/share/python-build/miniconda3-3.8-4.12.0
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py38_4.12.0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-Linux-aarch64.sh#72cb127e8f455b692e3c8a9009b34f7c" "miniconda" verify_py38
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py38_4.12.0-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-Linux-ppc64le.sh#2023a9a4008a9e1c4c317f3b1a6a99cd" "miniconda" verify_py38
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py38_4.12.0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-Linux-s390x.sh#f5692dec773b021dea5074b6f6bc3464" "miniconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py38_4.12.0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-Linux-x86_64.sh#9986028a26f489f99af4398eac966d36" "miniconda" verify_py38
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py38_4.12.0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-MacOSX-arm64.sh#c8796b213b0dee4426e442f6eb059b40" "miniconda" verify_py38
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py38_4.12.0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-MacOSX-x86_64.sh#215d80a3912d71c2272e37c63340f48a" "miniconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.8-4.9.2
+++ b/plugins/python-build/share/python-build/miniconda3-3.8-4.9.2
@@ -1,6 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py38_4.9.2-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Linux-aarch64.sh#2359284ff562247fc2da4b68334ccac7" "miniconda" verify_py38
+  ;;
 "Linux-ppc64le" )
   install_script "Miniconda3-py38_4.9.2-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Linux-ppc64le.sh#b05f6c543ce0c593761bbfb4e6548ff6" "miniconda" verify_py38
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py38_4.9.2-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Linux-s390x.sh#29a7a50a29954d26a64e1a651a9e6f83" "miniconda" verify_py38
   ;;
 "Linux-x86_64" )
   install_script "Miniconda3-py38_4.9.2-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh#122c8c9beb51e124ab32a0fa6426c656" "miniconda" verify_py38

--- a/plugins/python-build/share/python-build/miniconda3-3.9-4.10.1
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-4.10.1
@@ -1,0 +1,16 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py39_4.10.1-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.1-Linux-aarch64.sh#67fb85a56aa7fda6e2fc5cdeb2aafec0" "miniconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py39_4.10.1-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.1-Linux-s390x.sh#089da98e758bbc4a0e784d75340ec5d0" "miniconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.9-4.10.3
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-4.10.3
@@ -1,6 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py39_4.10.3-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Linux-aarch64.sh#d4e7afa2783cd85532d59d7ccb9ec268" "miniconda" verify_py39
+  ;;
 "Linux-ppc64le" )
   install_script "Miniconda3-py39_4.10.3-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Linux-ppc64le.sh#07ea41c691bdcc7d9c71cae1a1a88151" "miniconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py39_4.10.3-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Linux-s390x.sh#633ae4c5382ca883f1f38a7d8c472f85" "miniconda" verify_py39
   ;;
 "Linux-x86_64" )
   install_script "Miniconda3-py39_4.10.3-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Linux-x86_64.sh#8c69f65a4ae27fb41df0fe552b4a8a3b" "miniconda" verify_py39

--- a/plugins/python-build/share/python-build/miniconda3-3.9-4.11.0
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-4.11.0
@@ -1,9 +1,18 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py39_4.11.0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-Linux-aarch64.sh#f25b8ff2dbebe0285360ef1b4c883da6" "miniconda" verify_py39
+  ;;
 "Linux-ppc64le" )
   install_script "Miniconda3-py39_4.11.0-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-Linux-ppc64le.sh#305e55110a3ad9384230e5fe396ccd89" "miniconda" verify_py39
   ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py39_4.11.0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-Linux-s390x.sh#26e904d1f42bf8cece2b99a698c10a46" "miniconda" verify_py39
+  ;;
 "Linux-x86_64" )
   install_script "Miniconda3-py39_4.11.0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-Linux-x86_64.sh#4e2f31e0b2598634c80daa12e4981647" "miniconda" verify_py39
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py39_4.11.0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-MacOSX-arm64.sh#c19959eafcb84a26e00af5d9f55826eb" "miniconda" verify_py39
   ;;
 "MacOSX-x86_64" )
   install_script "Miniconda3-py39_4.11.0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-MacOSX-x86_64.sh#d1303e5c7510b2ef444b9ba474551733" "miniconda" verify_py39

--- a/plugins/python-build/share/python-build/miniconda3-3.9-4.12.0
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-4.12.0
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py39_4.12.0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Linux-aarch64.sh#9baf936183f3479c97bff16fe62fb56c" "miniconda" verify_py39
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py39_4.12.0-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Linux-ppc64le.sh#2244290b6c899106901bbefad21aa49d" "miniconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py39_4.12.0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Linux-s390x.sh#f8d3b0ad1cf6a3a7175cd76d7e121820" "miniconda" verify_py39
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py39_4.12.0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Linux-x86_64.sh#7843dd7d0a2c53b0df37ca8189672992" "miniconda" verify_py39
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py39_4.12.0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-MacOSX-arm64.sh#31251793539cf952ee99c18e34c30c7f" "miniconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py39_4.12.0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-MacOSX-x86_64.sh#143b9bb03b6e4865be4ebbf40b108772" "miniconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.9-4.9.2
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-4.9.2
@@ -1,6 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py39_4.9.2-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.9.2-Linux-aarch64.sh#af1c16d821569ebf1bdaf549fcba7d27" "miniconda" verify_py39
+  ;;
 "Linux-ppc64le" )
   install_script "Miniconda3-py39_4.9.2-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.9.2-Linux-ppc64le.sh#73b8d60454389905b1d209f1b0c211d9" "miniconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py39_4.9.2-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.9.2-Linux-s390x.sh#ae66aa46e565c97bf3485275b370c7e5" "miniconda" verify_py39
   ;;
 "Linux-x86_64" )
   install_script "Miniconda3-py39_4.9.2-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.9.2-Linux-x86_64.sh#b4e46fcc8029e2cfa731b788f25b1d36" "miniconda" verify_py39


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

I used `add_miniconda.py` to generate installation files for `miniconda3-3.7-4.12.0`, `miniconda3-3.8-4.12.0`, and `miniconda3-3.9-4.12.0`.

In addition, I realized that `add_miniconda.py` was missing support for three architectures: `aarch64`, `arm64`, and `s390x`. I added support for them and updated the existing Miniconda versions accordingly.

### Tests
- [x] My PR adds the following unit tests (if any)
