### PR TITLE
Add Anaconda 2019.10, 2021.04, 2022.05; support Anaconda in add_miniconda.py

### DIFF
--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -33,22 +33,27 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           brew install openssl openssl@1.1 readline sqlite3 xz zlib
-      # https://github.com/pyenv/pyenv#installation
-      - run: pwd
-      - env:
-          PYENV_ROOT: /Users/runner/work/pyenv/pyenv
-        run: |
+      - run: |
+          echo "PYENV_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+      - run: |
           echo $PYENV_ROOT
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
-          bin/pyenv install ${{ matrix.python-version }}
-          bin/pyenv global ${{ matrix.python-version }}
-          bin/pyenv rehash
+      - run: |
+          pyenv install ${{ matrix.python-version }}
+          pyenv global ${{ matrix.python-version }}
       - run: python --version
       - run: python -m pip --version
       - shell: python  # Prove that actual Python == expected Python
         env:
           EXPECTED_PYTHON: ${{ matrix.python-version }}
-        run: import os, sys ; assert sys.version.startswith(os.getenv("EXPECTED_PYTHON"))
+        run: |
+          import os, sys, os.path
+          correct_dir = os.path.join(
+              os.environ['PYENV_ROOT'],
+              'versions',
+              os.environ['EXPECTED_PYTHON'],
+              'bin')
+          assert os.path.dirname(sys.executable) == correct_dir
 
   ubuntu_build:
     needs: discover_modified_scripts
@@ -66,19 +71,24 @@ jobs:
             libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
             wget curl llvm libncurses5-dev libncursesw5-dev \
             xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
-      # https://github.com/pyenv/pyenv#installation
-      - run: pwd
-      - env:
-          PYENV_ROOT: /home/runner/work/pyenv/pyenv
-        run: |
+      - run: |
+          echo "PYENV_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+      - run: |
           echo $PYENV_ROOT
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
-          bin/pyenv install ${{ matrix.python-version }}
-          bin/pyenv global ${{ matrix.python-version }}
-          bin/pyenv rehash
+      - run: |
+          pyenv install ${{ matrix.python-version }}
+          pyenv global ${{ matrix.python-version }}
       - run: python --version
       - run: python -m pip --version
       - shell: python  # Prove that actual Python == expected Python
         env:
           EXPECTED_PYTHON: ${{ matrix.python-version }}
-        run: import os, sys ; assert sys.version.startswith(os.getenv("EXPECTED_PYTHON"))
+        run: |
+          import os, sys, os.path
+          correct_dir = os.path.join(
+              os.environ['PYENV_ROOT'],
+              'versions',
+              os.environ['EXPECTED_PYTHON'],
+              'bin')
+          assert os.path.dirname(sys.executable) == correct_dir

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -34,15 +34,15 @@ jobs:
       - run: |
           brew install openssl openssl@1.1 readline sqlite3 xz zlib
       - run: |
-          echo "PYENV_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-      - run: |
-          echo $PYENV_ROOT
+          export PYENV_ROOT="$GITHUB_WORKSPACE"
+          echo "PYENV_ROOT=$PYENV_ROOT" >> $GITHUB_ENV
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
       - run: |
           pyenv install ${{ matrix.python-version }}
           pyenv global ${{ matrix.python-version }}
-      - run: python --version
-      - run: python -m pip --version
+      - run: |
+          python --version
+          python -m pip --version
       - shell: python  # Prove that actual Python == expected Python
         env:
           EXPECTED_PYTHON: ${{ matrix.python-version }}
@@ -54,6 +54,10 @@ jobs:
               os.environ['EXPECTED_PYTHON'],
               'bin')
           assert os.path.dirname(sys.executable) == correct_dir
+      # bundled executables in some Anaconda releases cause the post-run step to hang in MacOS
+      - run: |
+          pyenv global system
+          rm -f "$(pyenv root)"/shims/*
 
   ubuntu_build:
     needs: discover_modified_scripts
@@ -72,9 +76,8 @@ jobs:
             wget curl llvm libncurses5-dev libncursesw5-dev \
             xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
       - run: |
-          echo "PYENV_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-      - run: |
-          echo $PYENV_ROOT
+          export PYENV_ROOT="$GITHUB_WORKSPACE"
+          echo "PYENV_ROOT=$PYENV_ROOT" >> $GITHUB_ENV
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
       - run: |
           pyenv install ${{ matrix.python-version }}

--- a/plugins/python-build/share/python-build/anaconda2-2019.10
+++ b/plugins/python-build/share/python-build/anaconda2-2019.10
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-ppc64le" )
+  install_script "Anaconda2-2019.10-Linux-ppc64le" "https://repo.anaconda.com/archive/Anaconda2-2019.10-Linux-ppc64le.sh#6b9809bf5d36782bfa1e35b791d983a0" "anaconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda2-2019.10-Linux-x86_64" "https://repo.anaconda.com/archive/Anaconda2-2019.10-Linux-x86_64.sh#69c64167b8cf3a8fc6b50d12d8476337" "anaconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda2-2019.10-MacOSX-x86_64" "https://repo.anaconda.com/archive/Anaconda2-2019.10-MacOSX-x86_64.sh#311aeb49cbe6d296f499efcd01a73f5e" "anaconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/anaconda3-2021.04
+++ b/plugins/python-build/share/python-build/anaconda3-2021.04
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Anaconda3-2021.04-Linux-aarch64" "https://repo.anaconda.com/archive/Anaconda3-2021.04-Linux-aarch64.sh#14f48f5d1310478b11940a3b96eec7b6" "anaconda" verify_py38
+  ;;
+"Linux-ppc64le" )
+  install_script "Anaconda3-2021.04-Linux-ppc64le" "https://repo.anaconda.com/archive/Anaconda3-2021.04-Linux-ppc64le.sh#e5c8220526b95293e669734f91194acc" "anaconda" verify_py38
+  ;;
+"Linux-s390x" )
+  install_script "Anaconda3-2021.04-Linux-s390x" "https://repo.anaconda.com/archive/Anaconda3-2021.04-Linux-s390x.sh#e61fac26bf61bc5c3e3c1a93abc4d8e2" "anaconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda3-2021.04-Linux-x86_64" "https://repo.anaconda.com/archive/Anaconda3-2021.04-Linux-x86_64.sh#230f2c3c343ee58073bf41bd896dd76c" "anaconda" verify_py38
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda3-2021.04-MacOSX-x86_64" "https://repo.anaconda.com/archive/Anaconda3-2021.04-MacOSX-x86_64.sh#3caed29ad5564b3567676504669342dc" "anaconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/anaconda3-2022.05
+++ b/plugins/python-build/share/python-build/anaconda3-2022.05
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Anaconda3-2022.05-Linux-aarch64" "https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-aarch64.sh#7e822f5622fa306c0aa42430ba884454" "anaconda" verify_py39
+  ;;
+"Linux-ppc64le" )
+  install_script "Anaconda3-2022.05-Linux-ppc64le" "https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-ppc64le.sh#166b576c7e9d438b0a80840f94b44827" "anaconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Anaconda3-2022.05-Linux-s390x" "https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-s390x.sh#00ba3bf29ac51db5e0954b6f217fa468" "anaconda" verify_py39
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda3-2022.05-Linux-x86_64" "https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-x86_64.sh#a01150aff48fcb6fcd6472381652de04" "anaconda" verify_py39
+  ;;
+"MacOSX-arm64" )
+  install_script "Anaconda3-2022.05-MacOSX-arm64" "https://repo.anaconda.com/archive/Anaconda3-2022.05-MacOSX-arm64.sh#c35c8bdbeeda5e5ffa5b79d1f5ee8082" "anaconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda3-2022.05-MacOSX-x86_64" "https://repo.anaconda.com/archive/Anaconda3-2022.05-MacOSX-x86_64.sh#5319de6536212892dd2da8b70d602ee1" "anaconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2369

### Description
- [x] Here are some details about my PR

Support Anaconda and arbitrary dot-separated version numbers in add_miniconda.py

Add resulting generated versions.

### Tests
- [x] My PR adds the following unit tests (if any)
N/A