### PR TITLE
Update anaconda3-2022.05 MacOSX arm64 md5

### DIFF
--- a/plugins/python-build/share/python-build/anaconda3-2022.05
+++ b/plugins/python-build/share/python-build/anaconda3-2022.05
@@ -12,7 +12,7 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
   install_script "Anaconda3-2022.05-Linux-x86_64" "https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-x86_64.sh#a01150aff48fcb6fcd6472381652de04" "anaconda" verify_py39
   ;;
 "MacOSX-arm64" )
-  install_script "Anaconda3-2022.05-MacOSX-arm64" "https://repo.anaconda.com/archive/Anaconda3-2022.05-MacOSX-arm64.sh#c35c8bdbeeda5e5ffa5b79d1f5ee8082" "anaconda" verify_py39
+  install_script "Anaconda3-2022.05-MacOSX-arm64" "https://repo.anaconda.com/archive/Anaconda3-2022.05-MacOSX-arm64.sh#24d985d2d380c51364d4793eb1840d29" "anaconda" verify_py39
   ;;
 "MacOSX-x86_64" )
   install_script "Anaconda3-2022.05-MacOSX-x86_64" "https://repo.anaconda.com/archive/Anaconda3-2022.05-MacOSX-x86_64.sh#5319de6536212892dd2da8b70d602ee1" "anaconda" verify_py39


### PR DESCRIPTION
### Description
- pyenv install anaconda3-2022.05 failed on my mac, error is checksum mismatch
- I go to https://repo.anaconda.com/archive/  and see the checksum is different than what is expected, I guess some update on anaconda after PR.
- the checksum I use is for the version 304.8M | 2022-06-07 12:40:25





### Tests
- I tested on my mac
 Platform information: macOS 12.4
 OS architecture: arm64
 pyenv version: 2.3.1 (latest homebrew)