### PR TITLE
describe how to use versions alongside system

### DIFF
--- a/libexec/pyenv-global
+++ b/libexec/pyenv-global
@@ -16,7 +16,12 @@
 # Example: To enable the python2.7 and python3.7 shims to find their
 #          respective executables you could set both versions with:
 #
-# 'pyenv global 3.7.0 2.7.15'
+#     $ pyenv global 3.7.0 2.7.15
+#
+# Example: To enable all shims and the system installed version,
+#          write "system" first.
+#
+#     $ pyenv global system `pyenv versions --bare`
 #
 
 

--- a/libexec/pyenv-local
+++ b/libexec/pyenv-local
@@ -23,8 +23,13 @@
 # Example: To enable the python2.7 and python3.7 shims to find their
 #          respective executables you could set both versions with:
 #
-# 'pyenv local 3.7.0 2.7.15'
-
+#     $ pyenv local 3.7.0 2.7.15
+#
+# Example: To enable all shims and the system installed version,
+#          write "system" first.
+#
+#     $ pyenv local system `pyenv versions --bare`
+#
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x


### PR DESCRIPTION
### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description

The order of the versions for `pyenv global` have a meaning.  #2406 shows this.
This documents what to do to keep the system default python
version as the version to be used for all commands for the major version but at the same time expose the other installed Python versions with their major and minor versions to PATH.
I.e. python3 -> system
python3.10 -> system
python3.9 -> pyenv
python3.8 -> pyenv
...

To use with tox.

I realize that this is something to be discussed in the forum. If that needs to happen first, please close the issue.
Although, this would have saved my some minutes of searching and trying out.

### Tests

none, documentation