### PR TITLE
Use version sort in `pyenv versions`

### DIFF
--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -122,11 +122,10 @@ if [ -n "$include_system" ] && \
   print_version system
 fi
 
-# List entries in the versions directory and try to version-sort them
 shopt -s dotglob nullglob
 versions_dir_entries=("$versions_dir"/*)
 if sort --version-sort </dev/null >/dev/null 2>&1; then
-    # system supports version sort -- let's use it
+    # system sort supports version sorting
     OLDIFS="$IFS"
     IFS=$'\n'
     versions_dir_entries=($(

--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -122,8 +122,21 @@ if [ -n "$include_system" ] && \
   print_version system
 fi
 
+# List entries in the versions directory and try to version-sort them
 shopt -s dotglob nullglob
-for path in "$versions_dir"/*; do
+versions_dir_entries=("$versions_dir"/*)
+if sort --version-sort </dev/null >/dev/null 2>&1; then
+    # system supports version sort -- let's use it
+    OLDIFS="$IFS"
+    IFS=$'\n'
+    versions_dir_entries=($(
+        printf "%s\n" "${versions_dir_entries[@]}" |
+        sort --version-sort
+    ))
+    IFS="$OLDIFS"
+fi
+
+for path in "${versions_dir_entries[@]}"; do
   if [ -d "$path" ]; then
     if [ -n "$skip_aliases" ] && [ -L "$path" ]; then
       target="$(realpath "$path")"

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -175,12 +175,12 @@ OUT
   create_version "1.53.0"
   create_version "1.218.0"
 
-  correct_versions_file="$(mktemp)"
+  correct_versions_file="$(mktemp "${PYENV_TEST_DIR}/tmp.XXXXXXXXXX")"
   printf '%s/versions/%s\n' "${PYENV_ROOT}" "1.9.0" >>"$correct_versions_file"
   printf '%s/versions/%s\n' "${PYENV_ROOT}" "1.53.0" >>"$correct_versions_file"
   printf '%s/versions/%s\n' "${PYENV_ROOT}" "1.218.0" >>"$correct_versions_file"
 
-  wrong_versions_file="$(mktemp)"
+  wrong_versions_file="$(mktemp "${PYENV_TEST_DIR}/tmp.XXXXXXXXXX")"
   printf '%s/versions/%s\n' "${PYENV_ROOT}" "1.218.0" >>"$wrong_versions_file"
   printf '%s/versions/%s\n' "${PYENV_ROOT}" "1.53.0" >>"$wrong_versions_file"
   printf '%s/versions/%s\n' "${PYENV_ROOT}" "1.9.0" >>"$wrong_versions_file"

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -170,7 +170,7 @@ OUT
   assert_success ".venv"
 }
 
-@test "system sort supports version sort" {
+@test "sort supports version sorting" {
   create_version "1.9.0"
   create_version "1.53.0"
   create_version "1.218.0"
@@ -193,7 +193,7 @@ SH
 OUT
 }
 
-@test "system sort doesn't support version sort" {
+@test "sort doesn't support version sorting" {
   create_version "1.9.0"
   create_version "1.53.0"
   create_version "1.218.0"

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -194,10 +194,9 @@ OUT
 }
 
 @test "system sort doesn't support version sort" {
-  create_version "c"
-  create_version "b"
-  create_version "a"
-
+  create_version "1.9.0"
+  create_version "1.53.0"
+  create_version "1.218.0"
   create_executable sort <<SH
 #!$BASH
 exit 1
@@ -206,8 +205,8 @@ SH
   run pyenv-versions --bare
   assert_success
   assert_output <<OUT
-a
-b
-c
+1.218.0
+1.53.0
+1.9.0
 OUT
 }

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -200,3 +200,22 @@ SH
 1.218.0
 OUT
 }
+
+@test "always sorts versions at least alphabetically" {
+  create_version "c"
+  create_version "b"
+  create_version "a"
+
+  create_executable sort <<SH
+#!$BASH
+exit 1
+SH
+
+  run pyenv-versions --bare
+  assert_success
+  assert_output <<OUT
+a
+b
+c
+OUT
+}

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -170,25 +170,17 @@ OUT
   assert_success ".venv"
 }
 
-@test "uses version sort when available" {
+@test "system sort supports version sort" {
   create_version "1.9.0"
   create_version "1.53.0"
   create_version "1.218.0"
-
-  correct_versions_file="$(mktemp "${PYENV_TEST_DIR}/tmp.XXXXXXXXXX")"
-  printf '%s/versions/%s\n' "${PYENV_ROOT}" "1.9.0" >>"$correct_versions_file"
-  printf '%s/versions/%s\n' "${PYENV_ROOT}" "1.53.0" >>"$correct_versions_file"
-  printf '%s/versions/%s\n' "${PYENV_ROOT}" "1.218.0" >>"$correct_versions_file"
-
-  wrong_versions_file="$(mktemp "${PYENV_TEST_DIR}/tmp.XXXXXXXXXX")"
-  printf '%s/versions/%s\n' "${PYENV_ROOT}" "1.218.0" >>"$wrong_versions_file"
-  printf '%s/versions/%s\n' "${PYENV_ROOT}" "1.53.0" >>"$wrong_versions_file"
-  printf '%s/versions/%s\n' "${PYENV_ROOT}" "1.9.0" >>"$wrong_versions_file"
-
   create_executable sort <<SH
 #!$BASH
-if [ "\$1" == "--version-sort" ]; then cat $(printf %q "$correct_versions_file")
-else cat $(printf %q "$wrong_versions_file")
+if [ "\$1" == "--version-sort" ]; then
+  echo "${PYENV_ROOT}/versions/1.9.0"
+  echo "${PYENV_ROOT}/versions/1.53.0"
+  echo "${PYENV_ROOT}/versions/1.218.0"
+else exit 1
 fi
 SH
 
@@ -201,7 +193,7 @@ SH
 OUT
 }
 
-@test "always sorts versions at least alphabetically" {
+@test "system sort doesn't support version sort" {
   create_version "c"
   create_version "b"
   create_version "a"


### PR DESCRIPTION
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.

Considered; implementation is too simple for a plugin.

* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.

Is this recommendation still valid? Looks like rbenv's had version sort for months: rbenv/rbenv@28cd6f12

* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2097

### Description
Check if the system `sort` command supports version sort and, if so, use it.

I used `sort --version-sort` as discussed in #2097. `rbenv`'s solution does not depend on `--version-sort`, and would require a little bit more refactoring, but I'd be happy to port it to pyenv if you think it's worth the effort.

### Tests
Should I add any?
