### PR TITLE
Fixed relative path traversal due to using version string in path

### DIFF
--- a/libexec/pyenv-version-file-read
+++ b/libexec/pyenv-version-file-read
@@ -11,9 +11,16 @@ if [ -s "$VERSION_FILE" ]; then
   IFS="${IFS}"$'\r'
   sep=
   while read -n 1024 -r version _ || [[ $version ]]; do
-      [[ -z $version || $version == \#* ]] && continue
-      printf "%s%s" "$sep" "$version"
-      sep=:
+    if [[ -z $version || $version == \#* ]]; then
+      # Skip empty lines and comments
+      continue
+    elif [ "$version" = ".." ] || [[ $version == */* ]]; then
+      # The version string is used to construct a path and we skip dubious values.
+      # This prevents issues such as path traversal (CVE-2022-35861).
+      continue
+    fi
+    printf "%s%s" "$sep" "$version"
+    sep=:
   done <"$VERSION_FILE"
   [[ $sep ]] && { echo; exit; }
 fi

--- a/test/version-file-read.bats
+++ b/test/version-file-read.bats
@@ -82,3 +82,15 @@ IN
   run pyenv-version-file-read my-version
   assert_success "3.9.3:3.8.9:2.7.16"
 }
+
+@test "skips relative path traversal" {
+  cat > my-version <<IN
+3.9.3
+3.8.9
+  ..
+./*
+2.7.16
+IN
+  run pyenv-version-file-read my-version
+  assert_success "3.9.3:3.8.9:2.7.16"
+}


### PR DESCRIPTION

### Description
- It looks like rbenv addressed the [path traversal vulnerability some time ago.](https://github.com/rbenv/rbenv/commit/370c26a6c9ee0511972ea04904fcc89014a22987)
- There are some additional change available in rbenv that simplify the read logic. Even so, my changes are functionally the same.

