### PR TITLE
Replace deprecated git protocol use with https in docs

### DIFF
--- a/plugins/python-build/README.md
+++ b/plugins/python-build/README.md
@@ -24,7 +24,7 @@ Installing python-build as a standalone program will give you access to the
 `python-build` command for precise control over Python version installation. If you
 have pyenv installed, you will also be able to use the `pyenv install` command.
 
-    git clone git://github.com/pyenv/pyenv.git
+    git clone https://github.com/pyenv/pyenv.git
     cd pyenv/plugins/python-build
     ./install.sh
 


### PR DESCRIPTION
As Github deprecated git:// protocol long time ago, we should update the docs. In fact I was not even able to clone using git protocol today as the process was hung, probably the server does not respond anymore.

Reference: https://blog.readthedocs.com/github-git-protocol-deprecation/#:~:text=Last%20year%2C%20GitHub%20announced%20the,project%20)%20to%20clone%20their%20projects.

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
