### PR TITLE
docs: fix simple typo, principes -> principles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 General guidance
 ================
 
-* The usual principes of respecting existing conventions and making sure that your changes
+* The usual principles of respecting existing conventions and making sure that your changes
   are in line with the overall product design apply when contributing code to Pyenv.
 
 * We are limited to Bash 3.2 features


### PR DESCRIPTION
There is a small typo in CONTRIBUTING.md.

Should read `principles` rather than `principes`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md