### PR TITLE
Fix: patterns for pypy2.*/pypy3.* versions

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1640,7 +1640,7 @@ build_package_auto_tcltk() {
 apply_python_patch() {
   local patchfile
   case "$1" in
-  Python-* | jython-* | pypy-* | stackless-* )
+  Python-* | jython-* | pypy-* | pypy2.?-* | pypy3.?-* | pypy3.??-* | stackless-* )
     patchfile="$(mktemp "${TMP}/python-patch.XXXXXX")"
     cat "${2:--}" >"$patchfile"
 

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1637,10 +1637,11 @@ build_package_auto_tcltk() {
   fi
 }
 
+# extglob must be set at parse time, not at runtime
+# https://stackoverflow.com/questions/49283740/bash-script-throws-syntax-errors-when-the-extglob-option-is-set-inside-a-subsh
+shopt -s extglob
 apply_python_patch() {
   local patchfile
-  local prev_extglob="$(shopt -p extglob)"
-  shopt -s extglob
   case "$1" in
   Python-* | jython-* | pypy-* | pypy[:digit:].+([:digit:])-* | stackless-* )
     patchfile="$(mktemp "${TMP}/python-patch.XXXXXX")"
@@ -1651,8 +1652,8 @@ apply_python_patch() {
     patch -p$striplevel --force -i "$patchfile"
     ;;
   esac
-  eval "$prev_extglob"
 }
+shopt -u extglob
 
 build_package_symlink_version_suffix() {
   if [[ "$CONFIGURE_OPTS $PYTHON_CONFIGURE_OPTS" == *"--enable-framework"* ]]; then

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1639,8 +1639,10 @@ build_package_auto_tcltk() {
 
 apply_python_patch() {
   local patchfile
+  local prev_extglob="$(shopt -p extglob)"
+  shopt -s extglob
   case "$1" in
-  Python-* | jython-* | pypy-* | pypy2.?-* | pypy3.?-* | pypy3.??-* | stackless-* )
+  Python-* | jython-* | pypy-* | pypy[:digit:].+([:digit:])-* | stackless-* )
     patchfile="$(mktemp "${TMP}/python-patch.XXXXXX")"
     cat "${2:--}" >"$patchfile"
 
@@ -1649,6 +1651,7 @@ apply_python_patch() {
     patch -p$striplevel --force -i "$patchfile"
     ;;
   esac
+  eval "$prev_extglob"
 }
 
 build_package_symlink_version_suffix() {


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
   * It's Python specific / python-build plugin.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * see above
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2418

### Description
Allows PyPy versions named like `pypy<CPython-compatible-version>-<actual version>` to be patched.

### Tests
None. Trivial change (hopefully).
