### PR TITLE
Allow pypy2 pypy3 patching

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1639,11 +1639,17 @@ build_package_auto_tcltk() {
 
 # extglob must be set at parse time, not at runtime
 # https://stackoverflow.com/questions/49283740/bash-script-throws-syntax-errors-when-the-extglob-option-is-set-inside-a-subsh
+#
+# The function is *parsed* with "extglob" only if an outer `shopt -s exglob`
+# exists; at *runtime* you still need to activate it *within* the function.
+#
 shopt -s extglob
 apply_python_patch() {
   local patchfile
+  # needed at runtime
+  shopt -s extglob
   case "$1" in
-  Python-* | jython-* | pypy-* | pypy[:digit:].+([:digit:])-* | stackless-* )
+  Python-* | jython-* | pypy-* | pypy[0-9].+([0-9])-* | stackless-* )
     patchfile="$(mktemp "${TMP}/python-patch.XXXXXX")"
     cat "${2:--}" >"$patchfile"
 
@@ -1652,6 +1658,7 @@ apply_python_patch() {
     patch -p$striplevel --force -i "$patchfile"
     ;;
   esac
+  shopt -u extglob
 }
 shopt -u extglob
 

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1640,7 +1640,7 @@ build_package_auto_tcltk() {
 apply_python_patch() {
   local patchfile
   case "$1" in
-  Python-* | jython-* | pypy-* | stackless-* )
+  Python-* | jython-* | pypy-* | pypy2.?-* | pypy3.?-* | pypy3.??-* | stackless-* )
     patchfile="$(mktemp "${TMP}/python-patch.XXXXXX")"
     cat "${2:--}" >"$patchfile"
 

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1637,10 +1637,11 @@ build_package_auto_tcltk() {
   fi
 }
 
+# extglob must be set at parse time, not at runtime
+# https://stackoverflow.com/questions/49283740/bash-script-throws-syntax-errors-when-the-extglob-option-is-set-inside-a-subsh
+shopt -s extglob
 apply_python_patch() {
   local patchfile
-  local prev_extglob="$(shopt -p extglob)"
-  shopt -s extglob
   case "$1" in
   Python-* | jython-* | pypy-* | pypy[:digit:].+([:digit:])-* | stackless-* )
     patchfile="$(mktemp "${TMP}/python-patch.XXXXXX")"
@@ -1651,8 +1652,8 @@ apply_python_patch() {
     patch -p$striplevel --force -i "$patchfile"
     ;;
   esac
-  eval "$prev_extglob"
 }
+shopt -u extglob
 
 build_package_symlink_version_suffix() {
   if [[ "$CONFIGURE_OPTS $PYTHON_CONFIGURE_OPTS" == *"--enable-framework"* ]]; then

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1639,8 +1639,10 @@ build_package_auto_tcltk() {
 
 apply_python_patch() {
   local patchfile
+  local prev_extglob="$(shopt -p extglob)"
+  shopt -s extglob
   case "$1" in
-  Python-* | jython-* | pypy-* | pypy2.?-* | pypy3.?-* | pypy3.??-* | stackless-* )
+  Python-* | jython-* | pypy-* | pypy[:digit:].+([:digit:])-* | stackless-* )
     patchfile="$(mktemp "${TMP}/python-patch.XXXXXX")"
     cat "${2:--}" >"$patchfile"
 
@@ -1649,6 +1651,7 @@ apply_python_patch() {
     patch -p$striplevel --force -i "$patchfile"
     ;;
   esac
+  eval "$prev_extglob"
 }
 
 build_package_symlink_version_suffix() {


### PR DESCRIPTION
### Description
Update to modifications after PR https://github.com/pyenv/pyenv/pull/2419 which didn't work due to:
 -  "extglob" mode in BASH doesn't support RegEx-like character classes like `[:digits:]`, you need to
    use `[0-9]` (unless there is another option for *that*...)

 -  BASH `shopt` is *really* strange - it's used by both the parser *and* the runtime: you need to "wrap" 
    `apply_python_patch()` with `shopt -s extglob / shopt -u extglob`, but then *also* call `shopt -s extglob`
    and `shopt -u extglob` *again* within the function.    
    Otherwise it parses the glob pattern, but applies it "literally" (non-extglob-wise) - which won't match 
    anything reasonable. :grin: 

