### PR TITLE
Add Fig as an autocomplete method

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This project was forked from [rbenv](https://github.com/rbenv/rbenv) and
 * [Upgrading](#upgrading)
 * [Uninstalling pyenv](#uninstalling-pyenv)
 * [Advanced Configuration](#advanced-configuration)
+  * [Autocomplete](#autocomplete)
   * [Using Pyenv without shims](#using-pyenv-without-shims)
   * [Environment variables](#environment-variables)
 * **[Development](#development)**
@@ -562,6 +563,15 @@ that may shadow Pyenv's shims.
   in these distributions because the system's Pip places executables for
   modules installed by a non-root user into those per-user `bin` directories.
 
+### Autocomplete
+
+<a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a> [Fig](https://fig.io/) provides IDE-style autocompletions for pyenv. It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```
 
 ### Using Pyenv without shims
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

[Fig](https://fig.io) provides autocomplete for 300+ CLI tools including pyenv, so we would love to have Fig listed as an autocomplete method in your docs. Thanks so much and please let me know if you have any questions!

### Tests
- [x] My PR adds the following unit tests (if any)
