### PR TITLE
Add support for multiple versions in `pyenv uninstall`

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -238,9 +238,9 @@ To install the latest major release for Python 3 try:
 
 ## `pyenv uninstall`
 
-Uninstall a specific Python version.
+Uninstall Python versions.
 
-    Usage: pyenv uninstall [-f|--force] <version>
+    Usage: pyenv uninstall [-f|--force] <version1> <version2> <..>
 
        -f  Attempt to remove the specified version without prompting
            for confirmation. If the version does not exist, do not

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -240,7 +240,7 @@ To install the latest major release for Python 3 try:
 
 Uninstall Python versions.
 
-    Usage: pyenv uninstall [-f|--force] <version1> <version2> <..>
+    Usage: pyenv uninstall [-f|--force] <version> ...
 
        -f  Attempt to remove the specified version without prompting
            for confirmation. If the version does not exist, do not

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ for more details on how the selection works and more information on its usage.
 As time goes on, you will accumulate Python versions in your
 `$(pyenv root)/versions` directory.
 
-To remove old Python versions, use [`pyenv uninstall <version1> <version2> <..>`](COMMANDS.md#pyenv-uninstall).
+To remove old Python versions, use [`pyenv uninstall <versions>`](COMMANDS.md#pyenv-uninstall).
 
 Alternatively, you can simply `rm -rf` the directory of the version you want
 to remove. You can find the directory of a particular Python version

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ for more details on how the selection works and more information on its usage.
 As time goes on, you will accumulate Python versions in your
 `$(pyenv root)/versions` directory.
 
-To remove old Python versions, use [`pyenv uninstall <version>`](COMMANDS.md#pyenv-uninstall).
+To remove old Python versions, use [`pyenv uninstall <version1> <version2> <..>`](COMMANDS.md#pyenv-uninstall).
 
 Alternatively, you can simply `rm -rf` the directory of the version you want
 to remove. You can find the directory of a particular Python version

--- a/man/man1/pyenv.1
+++ b/man/man1/pyenv.1
@@ -455,7 +455,7 @@ $ pyenv versions
 Uninstall Python versions\.
 .IP "" 4
 .nf
-Usage: pyenv uninstall [\-f|\-\-force] <version1> <version2> <..>
+Usage: pyenv uninstall [\-f|\-\-force] <version> ...
 
    \-f  Attempt to remove the specified version without prompting
        for confirmation\. If the version does not exist, do not

--- a/man/man1/pyenv.1
+++ b/man/man1/pyenv.1
@@ -106,7 +106,7 @@ Set or show the shell\-specific Python version
 List existing pyenv shims
 .TP
 .B uninstall
-Uninstall a specific Python version
+Uninstall Python versions
 .TP
 .B version
 Show the current Python version(s) and its origin
@@ -452,10 +452,10 @@ $ pyenv versions
 .fi
 .IP "" 0
 .SS "pyenv uninstall"
-Uninstall a specific Python version\.
+Uninstall Python versions\.
 .IP "" 4
 .nf
-Usage: pyenv uninstall [\-f|\-\-force] <version>
+Usage: pyenv uninstall [\-f|\-\-force] <version1> <version2> <..>
 
    \-f  Attempt to remove the specified version without prompting
        for confirmation\. If the version does not exist, do not

--- a/plugins/python-build/bin/pyenv-uninstall
+++ b/plugins/python-build/bin/pyenv-uninstall
@@ -2,7 +2,7 @@
 #
 # Summary: Uninstall Python versions
 #
-# Usage: pyenv uninstall [-f|--force] <version1> <version2> <..>
+# Usage: pyenv uninstall [-f|--force] <version> ...
 #
 #    -f  Attempt to remove the specified version without prompting
 #        for confirmation. If the version does not exist, do not

--- a/plugins/python-build/bin/pyenv-uninstall
+++ b/plugins/python-build/bin/pyenv-uninstall
@@ -35,6 +35,16 @@ fi
 
 [ "$#" -gt 0 ] || usage 1 >&2
 
+versions=("$@")
+
+for version in "${versions[@]}"; do
+  case "$version" in
+  "" | -* )
+    usage 1 >&2
+    ;;
+  esac
+done
+
 declare -a before_hooks after_hooks
 
 before_uninstall() {
@@ -54,11 +64,6 @@ for script in "${scripts[@]}"; do source "$script"; done
 
 uninstall-python() {
   local DEFINITION="$1"
-  case "$DEFINITION" in
-  "" | -* )
-    usage 1 >&2
-    ;;
-  esac
 
   local VERSION_NAME="${DEFINITION##*/}"
   local PREFIX="${PYENV_ROOT}/versions/${VERSION_NAME}"
@@ -86,8 +91,6 @@ uninstall-python() {
 
   for hook in "${after_hooks[@]}"; do eval "$hook"; done
 }
-
-versions=("$@")
 
 for version in "${versions[@]}"; do
   uninstall-python "$version"

--- a/plugins/python-build/bin/pyenv-uninstall
+++ b/plugins/python-build/bin/pyenv-uninstall
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# Summary: Uninstall a specific Python version
+# Summary: Uninstall Python versions
 #
-# Usage: pyenv uninstall [-f|--force] <version>
+# Usage: pyenv uninstall [-f|--force] <version1> <version2> <..>
 #
 #    -f  Attempt to remove the specified version without prompting
 #        for confirmation. If the version does not exist, do not
@@ -33,14 +33,7 @@ if [ "$1" = "-f" ] || [ "$1" = "--force" ]; then
   shift
 fi
 
-[ "$#" -eq 1 ] || usage 1 >&2
-
-DEFINITION="$1"
-case "$DEFINITION" in
-"" | -* )
-  usage 1 >&2
-  ;;
-esac
+[ "$#" -gt 0 ] || usage 1 >&2
 
 declare -a before_hooks after_hooks
 
@@ -59,29 +52,43 @@ IFS=$'\n' scripts=(`pyenv-hooks uninstall`)
 IFS="$OLDIFS"
 for script in "${scripts[@]}"; do source "$script"; done
 
+uninstall-python() {
+  local DEFINITION="$1"
+  case "$DEFINITION" in
+  "" | -* )
+    usage 1 >&2
+    ;;
+  esac
 
-VERSION_NAME="${DEFINITION##*/}"
-PREFIX="${PYENV_ROOT}/versions/${VERSION_NAME}"
+  local VERSION_NAME="${DEFINITION##*/}"
+  local PREFIX="${PYENV_ROOT}/versions/${VERSION_NAME}"
 
-if [ -z "$FORCE" ]; then
-  if [ ! -d "$PREFIX" ]; then
-    echo "pyenv: version \`$VERSION_NAME' not installed" >&2
-    exit 1
+  if [ -z "$FORCE" ]; then
+    if [ ! -d "$PREFIX" ]; then
+      echo "pyenv: version \`$VERSION_NAME' not installed" >&2
+      exit 1
+    fi
+
+    read -p "pyenv: remove $PREFIX? [y|N] "
+    case "$REPLY" in
+    y | Y | yes | YES ) ;;
+    * ) exit 1 ;;
+    esac
   fi
 
-  read -p "pyenv: remove $PREFIX? [y|N] "
-  case "$REPLY" in
-  y | Y | yes | YES ) ;;
-  * ) exit 1 ;;
-  esac
-fi
+  for hook in "${before_hooks[@]}"; do eval "$hook"; done
 
-for hook in "${before_hooks[@]}"; do eval "$hook"; done
+  if [ -d "$PREFIX" ]; then
+    rm -rf "$PREFIX"
+    pyenv-rehash
+    echo "pyenv: $VERSION_NAME uninstalled"
+  fi
 
-if [ -d "$PREFIX" ]; then
-  rm -rf "$PREFIX"
-  pyenv-rehash
-  echo "pyenv: $VERSION_NAME uninstalled"
-fi
+  for hook in "${after_hooks[@]}"; do eval "$hook"; done
+}
 
-for hook in "${after_hooks[@]}"; do eval "$hook"; done
+versions=("$@")
+
+for version in "${versions[@]}"; do
+  uninstall-python "$version"
+done

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -205,6 +205,20 @@ OUT
   refute [ -d "${PYENV_ROOT}/versions/3.4.2" ]
 }
 
+@test "invalid arguments for pyenv-uninstall" {
+  mkdir -p "${PYENV_ROOT}/versions/3.10.3"
+  mkdir -p "${PYENV_ROOT}/versions/3.10.4"
+
+  run pyenv-uninstall -f 3.10.3 --invalid-option 3.10.4
+  assert_failure
+
+  assert [ -d "${PYENV_ROOT}/versions/3.10.3" ]
+  assert [ -d "${PYENV_ROOT}/versions/3.10.4" ]
+
+  rmdir "${PYENV_ROOT}/versions/3.10.3"
+  rmdir "${PYENV_ROOT}/versions/3.10.4"
+}
+
 @test "show help for pyenv-uninstall" {
   stub pyenv-help 'uninstall : true'
 

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -195,12 +195,14 @@ OUT
   unstub pyenv-help
 }
 
-@test "too many arguments for pyenv-uninstall" {
-  stub pyenv-help 'uninstall : true'
+@test "more than one argument for pyenv-uninstall" {
+  mkdir -p "${PYENV_ROOT}/versions/3.4.1"
+  mkdir -p "${PYENV_ROOT}/versions/3.4.2"
+  run pyenv-uninstall -f 3.4.1 3.4.2
 
-  run pyenv-uninstall 3.4.1 3.4.2
-  assert_failure
-  unstub pyenv-help
+  assert_success
+  refute [ -d "${PYENV_ROOT}/versions/3.4.1" ]
+  refute [ -d "${PYENV_ROOT}/versions/3.4.2" ]
 }
 
 @test "show help for pyenv-uninstall" {


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2336

### Description
- [x] adds support for uninstalling multiple python version at once using `pyenv uninstall`
- [x] updates docs (and man pages entries?)

### Tests
- [x] replaces unit test `too many arguments for pyenv-uninstall` with `more than one argument for pyenv-uninstall`
- [x] adds test for `pyenv-uninstall hooks` for the multiple version scenario 
