### PR TITLE
Add Cinder 3.8

### DIFF
--- a/plugins/python-build/share/python-build/cinder-3.8-dev
+++ b/plugins/python-build/share/python-build/cinder-3.8-dev
@@ -1,0 +1,5 @@
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+install_git "Cinder-3.8-dev" "https://github.com/facebookincubator/cinder" "cinder/3.8" standard verify_py38 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/cinder-3.8-dev
+++ b/plugins/python-build/share/python-build/cinder-3.8-dev
@@ -1,14 +1,14 @@
 require_distro Fedora 32 &>/dev/null || \
-  echo >&2 <<!
+  cat >&2 <<!
 Warning! The Cinder compiler only officially supports
 Facebook's Docker images which are Fedora 32 - based.
 It is likely to fail to build on a system
 with a different GCC and/or Glibc version.
 !
 
-[[ $(gcc --dumpversion) == 10 ]] || \
+[[ $(gcc -dumpversion) == 10 ]] || \
 { command -v "gcc-10" && export CC=gcc-10; } || \
-echo >&2 <<!
+cat >&2 <<!
 Warning! GCC 10 is not found on PATH.
 The build will likely fail.
 !

--- a/plugins/python-build/share/python-build/cinder-3.8-dev
+++ b/plugins/python-build/share/python-build/cinder-3.8-dev
@@ -2,15 +2,15 @@ require_distro Fedora 32 &>/dev/null || \
   cat >&2 <<!
 Warning! The Cinder compiler only officially supports
 Facebook's Docker images which are Fedora 32 - based.
-It is likely to fail to build on a system
+It may fail to build on a system
 with a different GCC and/or Glibc version.
 !
 
-[[ $(gcc -dumpversion) == 10 ]] || \
-{ command -v "gcc-10" && export CC=gcc-10; } || \
+[[ $(${CC:-gcc} -dumpversion 2>/dev/null) == 10 ]] || \
+{ command -v "gcc-10" >/dev/null && export CC="gcc-10"; } || \
 cat >&2 <<!
 Warning! GCC 10 is not found on PATH.
-The build will likely fail.
+The build may fail.
 !
 
 prefer_openssl11

--- a/plugins/python-build/share/python-build/cinder-3.8-dev
+++ b/plugins/python-build/share/python-build/cinder-3.8-dev
@@ -1,17 +1,28 @@
 require_distro Fedora 32 &>/dev/null || \
+{ echo
+  colorize 1 "WARNING"
   cat >&2 <<!
-Warning! The Cinder compiler only officially supports
+: The Cinder compiler only officially supports
 Facebook's Docker images which are Fedora 32 - based.
 It may fail to build on a system
 with a different GCC and/or Glibc version.
 !
+  echo
+}
 
 [[ $(${CC:-gcc} -dumpversion 2>/dev/null) == 10 ]] || \
-{ command -v "gcc-10" >/dev/null && export CC="gcc-10"; } || \
-cat >&2 <<!
-Warning! GCC 10 is not found on PATH.
+{ command -v "gcc-10" >/dev/null && \
+  export CC="gcc-10" && \
+  echo "python-build: setting the compiler to \`gcc-10'"; } || \
+{
+  echo
+  colorize 1 WARNING
+  cat >&2 <<!
+: GCC 10 is not found on PATH.
 The build may fail.
 !
+  echo
+}
 
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1

--- a/plugins/python-build/share/python-build/cinder-3.8-dev
+++ b/plugins/python-build/share/python-build/cinder-3.8-dev
@@ -1,3 +1,18 @@
+require_distro Fedora 32 &>/dev/null || \
+  echo >&2 <<!
+Warning! The Cinder compiler only officially supports
+Facebook's Docker images which are Fedora 32 - based.
+It is likely to fail to build on a system
+with a different GCC and/or Glibc version.
+!
+
+[[ $(gcc --dumpversion) == 10 ]] || \
+{ command -v "gcc-10" && export CC=gcc-10; } || \
+echo >&2 <<!
+Warning! GCC 10 is not found on PATH.
+The build will likely fail.
+!
+
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2105

### Description
- [x] Adds script for installing Facebook's [Cinder](https://github.com/facebookincubator/cinder/)
- [x] Based on `python3.8-dev` script, adjusted for Cinder's repository
- [x] Cinder does not have any versioned releases currently, so this just uses the repository
- [x] Cinder 3.10 is currently not finished and I couldn't manage to successfully compile it
- [x] According to the README, macOS is *probably* not supported; should I mark this somehow?

### Tests
- [ ] My PR adds the following unit tests (if any)

No tests are added, but I managed to compile this on Debian 11 and run basic Numpy and Flask scripts.
