### PR TITLE
Add CPython 3.11.0rc1

### DIFF
--- a/plugins/python-build/share/python-build/3.11.0rc1
+++ b/plugins/python-build/share/python-build/3.11.0rc1
@@ -3,7 +3,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.11.0b5" "https://www.python.org/ftp/python/3.11.0/Python-3.11.0b5.tar.xz#3810bd22f7dc34a99c2a2eb4b85264a4df4f05ef59c4e0ccc2ea82ee9c491698" standard verify_py311 copy_python_gdb ensurepip
+    install_package "Python-3.11.0rc1" "https://www.python.org/ftp/python/3.11.0/Python-3.11.0rc1.tar.xz#53a5377c37a8a2c6da075b14eb9d63374579f7f3c718fa20f0a1fbb0e94a922b" standard verify_py311 copy_python_gdb ensurepip
 else
-    install_package "Python-3.11.0b5" "https://www.python.org/ftp/python/3.11.0/Python-3.11.0b5.tgz#3f7d1a4ab0e64425f4ffd92d49de192ad2ee1c62bc52e3877e9f7b254c702e60" standard verify_py311 copy_python_gdb ensurepip
+    install_package "Python-3.11.0rc1" "https://www.python.org/ftp/python/3.11.0/Python-3.11.0rc1.tgz#456f32a8d66e7cae226478a74c3ebb358bae09eba0b8537f47d7b2790f65a1f0" standard verify_py311 copy_python_gdb ensurepip
 fi


### PR DESCRIPTION
`3.11.0rc1` was released today (August 8th)

https://www.python.org/downloads/release/python-3110rc1/
