### PR TITLE
Fixes #2430 by checking that the path resolves as a subdirectory versions

### DIFF
--- a/libexec/pyenv-version-file-read
+++ b/libexec/pyenv-version-file-read
@@ -31,7 +31,7 @@ if [ -s "$VERSION_FILE" ]; then
       continue
     elif ! is_version_safe "$version"; then
       # CVE-2022-35861 allowed arbitrary code execution in some contexts and is mitigated by is_version_safe.
-      echo "pyenv: unsafe version name found in \`$VERSION_FILE'" >&2
+      echo "pyenv: invalid version \`$version' ignored in \`$VERSION_FILE'" >&2
       continue
     fi
     printf "%s%s" "$sep" "$version"

--- a/libexec/pyenv-version-file-read
+++ b/libexec/pyenv-version-file-read
@@ -31,6 +31,7 @@ if [ -s "$VERSION_FILE" ]; then
       continue
     elif ! is_version_safe "$version"; then
       # CVE-2022-35861 allowed arbitrary code execution in some contexts and is mitigated by is_version_safe.
+      echo "pyenv: unsafe version name found in \`$VERSION_FILE'" >&2
       continue
     fi
     printf "%s%s" "$sep" "$version"

--- a/libexec/pyenv-version-file-read
+++ b/libexec/pyenv-version-file-read
@@ -5,23 +5,17 @@ set -e
 
 VERSION_FILE="$1"
 
-
 function is_version_safe() {
-  # Check if version string is safe.
+  # As needed, check that the constructed path exists as a child path of PYENV_ROOT/versions
   version="$1"
-  # Only perform extra version string checks as needed
   if [[ "$version" == ".." || "$version" == */* ]]; then
-    # Some users may wish to use child paths of PYENV_ROOT/versions for their venv (#2430). So,
-    # versions that match path-traversal patterns MUST be a child path of PYENV_ROOT/versions.
+    # Sanity check the value of version to prevent malicious path-traversal
     (
-      # Validate version string constructs a valid path
       cd "$PYENV_ROOT/versions/$version" &>/dev/null || exit 1
-      # Check present-working-directory is a child paths of versions and set exit code
       [[ "$PWD" == "$PYENV_ROOT/versions/"* ]]
     )
     return $?
   else
-    # No extra checking required since version does not equal '..' or contain '/'
     return 0
   fi
 }

--- a/libexec/pyenv-version-file-read
+++ b/libexec/pyenv-version-file-read
@@ -5,18 +5,38 @@ set -e
 
 VERSION_FILE="$1"
 
+
+function is_version_safe() {
+  # Check if version string is safe.
+  version="$1"
+  # Only perform extra version string checks as needed
+  if [[ "$version" == ".." || "$version" == */* ]]; then
+    # Some users may wish to use child paths of PYENV_ROOT/versions for their venv (#2430). So,
+    # versions that match path-traversal patterns MUST be a child path of PYENV_ROOT/versions.
+    (
+      # Validate version string constructs a valid path
+      cd "$PYENV_ROOT/versions/$version" &>/dev/null || exit 1
+      # Check present-working-directory is a child paths of versions and set exit code
+      [[ "$PWD" == "$PYENV_ROOT/versions/"* ]]
+    )
+    return $?
+  else
+    # No extra checking required since version does not equal '..' or contain '/'
+    return 0
+  fi
+}
+
 if [ -s "$VERSION_FILE" ]; then
   # Read the first non-whitespace word from the specified version file.
   # Be careful not to load it whole in case there's something crazy in it.
-  IFS="${IFS}"$'\r'
+  IFS="$IFS"$'\r'
   sep=
   while read -n 1024 -r version _ || [[ $version ]]; do
-    if [[ -z $version || $version == \#* ]]; then
+    if [[ -z "$version" || "$version" == \#* ]]; then
       # Skip empty lines and comments
       continue
-    elif [ "$version" = ".." ] || [[ $version == */* ]]; then
-      # The version string is used to construct a path and we skip dubious values.
-      # This prevents issues such as path traversal (CVE-2022-35861).
+    elif ! is_version_safe "$version"; then
+      # CVE-2022-35861 allowed arbitrary code execution in some contexts and is mitigated by is_version_safe.
       continue
     fi
     printf "%s%s" "$sep" "$version"

--- a/test/version-file-read.bats
+++ b/test/version-file-read.bats
@@ -94,3 +94,19 @@ IN
   run pyenv-version-file-read my-version
   assert_success "3.9.3:3.8.9:2.7.16"
 }
+
+@test "allows venv within versions" {
+  venv=3.10.3/envs/test
+  mkdir -p "${PYENV_ROOT}/versions/${venv}"
+  echo -n "${venv}" > my-version
+  run pyenv-version-file-read my-version
+  assert_success "${venv}"
+}
+
+@test "skips venv outside of versions" {
+  venv=../3.10.3/envs/test
+  mkdir -p "${PYENV_ROOT}/versions/${venv}"
+  echo -n "${venv}" > my-version
+  run pyenv-version-file-read my-version
+  assert_failure
+}

--- a/test/version-file-read.bats
+++ b/test/version-file-read.bats
@@ -84,15 +84,21 @@ IN
 }
 
 @test "skips relative path traversal" {
+  echo '..' > my-version
+  run pyenv-version-file-read my-version
+  assert_failure "pyenv: unsafe version name found in \`my-version'"
+}
+
+@test "skips glob path traversal" {
   cat > my-version <<IN
+../*
 3.9.3
-3.8.9
-  ..
-./*
-2.7.16
 IN
   run pyenv-version-file-read my-version
-  assert_success "3.9.3:3.8.9:2.7.16"
+  assert_success <<OUT
+pyenv: unsafe version name found in \`my-version'
+3.9.3
+OUT
 }
 
 @test "allows venv within versions" {

--- a/test/version-file-read.bats
+++ b/test/version-file-read.bats
@@ -83,10 +83,10 @@ IN
   assert_success "3.9.3:3.8.9:2.7.16"
 }
 
-@test "skips relative path traversal" {
+@test "skips \`..' relative path traversal" {
   echo '..' > my-version
   run pyenv-version-file-read my-version
-  assert_failure "pyenv: unsafe version name found in \`my-version'"
+  assert_failure "pyenv: invalid version \`..' ignored in \`my-version'"
 }
 
 @test "skips glob path traversal" {
@@ -96,20 +96,20 @@ IN
 IN
   run pyenv-version-file-read my-version
   assert_success <<OUT
-pyenv: unsafe version name found in \`my-version'
+pyenv: invalid version \`../\*' ignored in \`my-version'
 3.9.3
 OUT
 }
 
-@test "allows venv within versions" {
-  venv=3.10.3/envs/test
+@test "allows relative paths that exist and stay within versions" {
+  venv=3.10.3/envs/../test
   mkdir -p "${PYENV_ROOT}/versions/${venv}"
   echo -n "${venv}" > my-version
   run pyenv-version-file-read my-version
   assert_success "${venv}"
 }
 
-@test "skips venv outside of versions" {
+@test "skips relative paths that lead outside of versions" {
   venv=../3.10.3/envs/test
   mkdir -p "${PYENV_ROOT}/versions/${venv}"
   echo -n "${venv}" > my-version


### PR DESCRIPTION
# Commits
- Fixes #2430 by checking that the path resolves as a child path of PYENV_ROOT/versions while still preventing CVE-2022-35861   
    - If version is `..` or contains `/`,  `is_version_safe` sets PWD to the constructed path and verifies that it is child path of `$PYENV_ROOT/versions`. Otherwise, failure at any steps (e.g., `cd`) means that it is unsafe.
- Closes #2430 by adding tests for child paths (e.g., "3.10.3/envs/test")
    - Added a test for valid use cases and another test for malicious values