### PR TITLE
Add micropython 1.18 and 1.19.1

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -899,7 +899,7 @@ build_package_micropython() {
     "$MAKE" $MAKE_OPTS
     cd ../ports/unix
     "$MAKE" $MAKE_OPTS axtls
-    "$MAKE" $MAKE_OPTS CFLAGS_EXTRA="-DMICROPY_PY_SYS_PATH_DEFAULT='\"${PREFIX_PATH}/lib/micropython\"' $CFLAGS_EXTRA"
+    "$MAKE" $MAKE_OPTS CFLAGS_EXTRA="-DMICROPY_PY_SYS_PATH_DEFAULT='\".frozen:${PREFIX_PATH}/lib/micropython\"' $CFLAGS_EXTRA"
     "$MAKE" install $MAKE_INSTALL_OPTS PREFIX="${PREFIX_PATH}"
     ln -fs micropython "${PREFIX_PATH}/bin/python"
     mkdir -p "${PREFIX_PATH}/lib/micropython"

--- a/plugins/python-build/share/python-build/micropython-1.18
+++ b/plugins/python-build/share/python-build/micropython-1.18
@@ -1,0 +1,4 @@
+has_tar_xz_support \
+  && { install=install_package; src="https://micropython.org/resources/source/micropython-1.18.tar.xz#96fc71b42ed331c64e1adc5a830ec4f29f2975c23e8751109c03f32b80fa3eb4"; } \
+  || { install=install_zip; src="https://micropython.org/resources/source/micropython-1.18.zip#90fa8049cf275310638b9e9c77121f6042f7250b814ef622f9522befde009f57"; }
+$install micropython-1.18 "$src" micropython

--- a/plugins/python-build/share/python-build/micropython-1.19.1
+++ b/plugins/python-build/share/python-build/micropython-1.19.1
@@ -1,0 +1,4 @@
+has_tar_xz_support \
+  && { install=install_package; src="https://micropython.org/resources/source/micropython-1.19.1.tar.xz#940e3815e8c425c6eaed3a2aa30d320220cc012a2654b6e086e1b6f0567df350"; } \
+  || { install=install_zip; src="https://micropython.org/resources/source/micropython-1.19.1.zip#7047ce208627457c6881850527edb78189a1855a974aa34e2d929c9a3b3c5cc3"; }
+$install micropython-1.19.1 "$src" micropython

--- a/plugins/python-build/test/compiler.bats
+++ b/plugins/python-build/test/compiler.bats
@@ -115,6 +115,6 @@ DEF
 
     #assert_success
     assert_output <<OUT
-CFLAGS_EXTRA=-DMICROPY_PY_SYS_PATH_DEFAULT='"${TMP}/install/lib/micropython"' -Wno-floating-conversion
+CFLAGS_EXTRA=-DMICROPY_PY_SYS_PATH_DEFAULT='".frozen:${TMP}/install/lib/micropython"' -Wno-floating-conversion
 OUT
 }


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
  * N/A
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
  * N/A
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2440

### Description
This commit will add fresh versions of microptyhon: 1.18 and 1.19.1.

### Tests
- [X] My PR adds the following unit tests (if any)
  * N/A
