### PR TITLE
CI: support Micropython, deleted scripts; build with -v

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           echo $PYENV_ROOT
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
-          bin/pyenv install ${{ matrix.python-version }}
+          bin/pyenv install -v ${{ matrix.python-version }}
           bin/pyenv global ${{ matrix.python-version }}
           bin/pyenv rehash
       - run: python --version

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -38,7 +38,7 @@ jobs:
           echo "PYENV_ROOT=$PYENV_ROOT" >> $GITHUB_ENV
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
       - run: |
-          pyenv install ${{ matrix.python-version }}
+          pyenv install -v ${{ matrix.python-version }}
           pyenv global ${{ matrix.python-version }}
       # Micropython doesn't support --version
       - run: >
@@ -91,7 +91,7 @@ jobs:
           echo "PYENV_ROOT=$PYENV_ROOT" >> $GITHUB_ENV
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
       - run: |
-          pyenv install ${{ matrix.python-version }}
+          pyenv install -v ${{ matrix.python-version }}
           pyenv global ${{ matrix.python-version }}
       # Micropython doesn't support --version
       - run: >

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -12,7 +12,7 @@ jobs:
         run: >
           versions=$(git diff "origin/$GITHUB_BASE_REF" --name-only -z
           | perl -ne 'BEGIN {$\="\n";$/="\0";} chomp;
-            if (/^plugins\/python-build\/share\/python-build\/(?:([^\/]+)|patches\/([^\/]+)\/.*)$/)
+            if (/^plugins\/python-build\/share\/python-build\/(?:([^\/]+)|patches\/([^\/]+)\/.*)$/ and -e $& )
                 { print $1.$2; }' \
           | sort -u);
           echo -e "versions<<!\\n$versions\\n!" >> $GITHUB_ENV

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -40,20 +40,31 @@ jobs:
       - run: |
           pyenv install ${{ matrix.python-version }}
           pyenv global ${{ matrix.python-version }}
-      - run: |
-          python --version
-          python -m pip --version
-      - shell: python  # Prove that actual Python == expected Python
-        env:
+      # Micropython doesn't support --version
+      - run: >
+          if [[ "${{ matrix.python-version }}" == "micropython-"* ]]; then
+            python -c 'import sys; print(sys.version)'
+          else
+            python --version;
+            python -m pip --version
+          fi
+      # Micropython doesn't support sys.executable, os.path, older versions even os
+      - env:
           EXPECTED_PYTHON: ${{ matrix.python-version }}
         run: |
-          import os, sys, os.path
-          correct_dir = os.path.join(
-              os.environ['PYENV_ROOT'],
-              'versions',
-              os.environ['EXPECTED_PYTHON'],
-              'bin')
-          assert os.path.dirname(sys.executable) == correct_dir
+          if [[ "${{ matrix.python-version }}" == "micropython-"* ]]; then
+            [[ $(pyenv which python) == "${{ env.PYENV_ROOT }}/versions/${{ matrix.python-version }}/bin/python" ]] || exit 1
+            python -c 'import sys; assert sys.implementation.name == "micropython"'
+          else
+            python -c 'if True:
+            import os, sys, os.path
+            correct_dir = os.path.join(
+              os.environ["PYENV_ROOT"],
+              "versions",
+              os.environ["EXPECTED_PYTHON"],
+              "bin")
+            assert os.path.dirname(sys.executable) == correct_dir'
+          fi
       # bundled executables in some Anaconda releases cause the post-run step to hang in MacOS
       - run: |
           pyenv global system
@@ -82,16 +93,28 @@ jobs:
       - run: |
           pyenv install ${{ matrix.python-version }}
           pyenv global ${{ matrix.python-version }}
-      - run: python --version
-      - run: python -m pip --version
-      - shell: python  # Prove that actual Python == expected Python
-        env:
+      # Micropython doesn't support --version
+      - run: >
+          if [[ "${{ matrix.python-version }}" == "micropython-"* ]]; then
+            python -c 'import sys; print(sys.version)'
+          else
+            python --version;
+            python -m pip --version
+          fi
+      # Micropython doesn't support sys.executable, os.path, older versions even os
+      - env:
           EXPECTED_PYTHON: ${{ matrix.python-version }}
         run: |
-          import os, sys, os.path
-          correct_dir = os.path.join(
-              os.environ['PYENV_ROOT'],
-              'versions',
-              os.environ['EXPECTED_PYTHON'],
-              'bin')
-          assert os.path.dirname(sys.executable) == correct_dir
+          if [[ "${{ matrix.python-version }}" == "micropython-"* ]]; then
+            [[ $(pyenv which python) == "${{ env.PYENV_ROOT }}/versions/${{ matrix.python-version }}/bin/python" ]] || exit 1
+            python -c 'import sys; assert sys.implementation.name == "micropython"'
+          else
+            python -c 'if True:
+            import os, sys, os.path
+            correct_dir = os.path.join(
+              os.environ["PYENV_ROOT"],
+              "versions",
+              os.environ["EXPECTED_PYTHON"],
+              "bin")
+            assert os.path.dirname(sys.executable) == correct_dir'
+          fi

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           echo $PYENV_ROOT
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
-          bin/pyenv install ${{ matrix.python-version }}
+          bin/pyenv install -v ${{ matrix.python-version }}
           bin/pyenv global ${{ matrix.python-version }}
           bin/pyenv rehash
       - run: python --version


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

* Fix modified script test for Micropython which doesn't support `--version`
* Exclude scripts deleted by a PR from the modified scripts check (which fails because they are deleted)

### Tests
- [x] My PR adds the following unit tests (if any)
N/A