### PR TITLE
CI: Bump OS versions

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -10,7 +10,7 @@ jobs:
           - 3.8.13
           - 3.9.13
           - 3.10.6
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       # Normally, we would use the superbly maintained...

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ${{fromJson(needs.discover_modified_scripts.outputs.versions)}}
-        os: ["macos-10.15", "macos-11"]
+        os: ["macos-11", "macos-12"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ${{fromJson(needs.discover_modified_scripts.outputs.versions)}}
-        os: ["ubuntu-18.04", "ubuntu-20.04"]
+        os: ["ubuntu-20.04", "ubuntu-22.04"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -82,10 +82,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          sudo apt-get update -q; sudo apt-get install -yq build-essential \
+          sudo apt-get update -q; sudo apt-get install -yq make build-essential \
             libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
-            wget curl llvm libncurses5-dev libncursesw5-dev \
-            xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
+            curl llvm libncurses5-dev libncursesw5-dev \
+            xz-utils tk-dev libffi-dev liblzma-dev
       - run: |
           export PYENV_ROOT="$GITHUB_WORKSPACE"
           echo "PYENV_ROOT=$PYENV_ROOT" >> $GITHUB_ENV

--- a/.github/workflows/pyenv_tests.yml
+++ b/.github/workflows/pyenv_tests.yml
@@ -6,10 +6,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - ubuntu-22.04
           - ubuntu-20.04
-          - ubuntu-18.04
+          - macos-12
           - macos-11
-          - macos-10.15
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -10,7 +10,7 @@ jobs:
           - 3.8.13
           - 3.9.13
           - 3.10.6
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       # Normally, we would use the superbly maintained...

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -19,9 +19,9 @@ jobs:
       #    python-version: ${{ matrix.python-version }}
       # ... but in the repo, we want to test pyenv builds on Ubuntu
       - run: |
-          sudo apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
-              libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-              xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
+          sudo apt-get install -yq make build-essential libssl-dev zlib1g-dev \
+          libbz2-dev libreadline-dev libsqlite3-dev curl \
+          libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
       # https://github.com/pyenv/pyenv#installation
       - run: pwd
       - env:


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)

### Description
- [x] Here are some details about my PR

Github released ubuntu-22.04 and macos-12 from beta
and deprecated ubuntu-18.04 and macos-10.15, due to dropping by 2013.

### Tests
- [x] My PR adds the following unit tests (if any)
N/A