### PR TITLE
Clean up defining DEFINITION_CANDIDATES

### DIFF
--- a/pyenv.d/install/latest.bash
+++ b/pyenv.d/install/latest.bash
@@ -1,13 +1,16 @@
 DEFINITION_PREFIX="${DEFINITION%%:*}"
 DEFINITION_TYPE="${DEFINITION_PREFIX%%-*}" # TODO: support non-CPython versions
 if [[ "${DEFINITION}" != "${DEFINITION_PREFIX}" ]]; then
-  DEFINITION_CANDIDATES=\
-    ($(python-build --definitions | \
-      grep -F "${DEFINITION_PREFIX}" | \
-      grep "^${DEFINITION_TYPE}" | \
-      sed -E -e '/-dev$/d' -e '/-src$/d' -e '/(b|rc)[0-9]+$/d' | \
-      sort -t. -k1,1r -k 2,2nr -k 3,3nr \
-    || true))
+  DEFINITION_CANDIDATES=()
+  while IFS='' read -r line; do
+      DEFINITION_CANDIDATES+=("$line")
+  done < <(\
+      python-build --definitions \
+      | grep -F "${DEFINITION_PREFIX}" \
+      | grep "^${DEFINITION_TYPE}" \
+      | sed -E -e '/-dev$/d' -e '/-src$/d' -e '/(b|rc)[0-9]+$/d' \
+      | sort -t. -k1,1r -k 2,2nr -k 3,3nr || true \
+  )
   DEFINITION="${DEFINITION_CANDIDATES}"
   VERSION_NAME="${DEFINITION##*/}"
 fi


### PR DESCRIPTION
### Description
- I've noticed some of my builds failing that use pyenv and it appears to be due to a syntax error around defining DEFINITION_CANDIDATES (`/opt/hostedtoolcache/pyenv/pyenv.d/install/latest.bash: line 5: syntax error near unexpected token (`). This PR aims to fix this issue and the workflows that ran on my pyenv fork seem to support that this issue is now fixed https://github.com/cavcrosby/pyenv/actions.
