### PR TITLE
fix(#2451): fixes error for unexpected token '(' line 5

### DIFF
--- a/pyenv.d/install/latest.bash
+++ b/pyenv.d/install/latest.bash
@@ -1,8 +1,7 @@
 DEFINITION_PREFIX="${DEFINITION%%:*}"
 DEFINITION_TYPE="${DEFINITION_PREFIX%%-*}" # TODO: support non-CPython versions
 if [[ "${DEFINITION}" != "${DEFINITION_PREFIX}" ]]; then
-  DEFINITION_CANDIDATES=\
-    ($(python-build --definitions | \
+  DEFINITION_CANDIDATES=($(python-build --definitions | \
       grep -F "${DEFINITION_PREFIX}" | \
       grep "^${DEFINITION_TYPE}" | \
       sed -E -e '/-dev$/d' -e '/-src$/d' -e '/(b|rc)[0-9]+$/d' | \


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2451

### Description
- Fixes "unexpected token '(' on line 5 of pyenv.d/install/latest.bash" introduced by https://github.com/pyenv/pyenv/commit/4e31668c2136bd7c97b30776da62e80e9a376279

### Tests
- [ ] My PR adds the following unit tests (if any)
- [x] Tested fix locally and works as expected
