### PR TITLE
Add CPython security releases 3.7.14, 3.8.14 and 3.9.14

### DIFF
--- a/plugins/python-build/share/python-build/3.7.14
+++ b/plugins/python-build/share/python-build/3.7.14
@@ -1,0 +1,9 @@
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.1" "https://ftpmirror.gnu.org/readline/readline-8.1.tar.gz#f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-3.7.14" "https://www.python.org/ftp/python/3.7.14/Python-3.7.14.tar.xz#4157ae31eb81af19e81c36882610491b0fb8f50e00fa8a17b095c88908b9c45c" standard verify_py37 copy_python_gdb ensurepip
+else
+  install_package "Python-3.7.14" "https://www.python.org/ftp/python/3.7.14/Python-3.7.14.tgz#82b2abf8978caa61a9011d166eede831b32de9cbebc0db8162900fa23437b709" standard verify_py37 copy_python_gdb ensurepip
+fi

--- a/plugins/python-build/share/python-build/3.8.14
+++ b/plugins/python-build/share/python-build/3.8.14
@@ -1,0 +1,9 @@
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.1" "https://ftpmirror.gnu.org/readline/readline-8.1.tar.gz#f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-3.8.14" "https://www.python.org/ftp/python/3.8.14/Python-3.8.14.tar.xz#5d77e278271ba803e9909a41a4f3baca006181c93ada682a5e5fe8dc4a24c5f3" standard verify_py38 copy_python_gdb ensurepip
+else
+  install_package "Python-3.8.14" "https://www.python.org/ftp/python/3.8.14/Python-3.8.14.tgz#41f959c480c59211feb55d5a28851a56c7e22d02ef91035606ebb21011723c31" standard verify_py38 copy_python_gdb ensurepip
+fi

--- a/plugins/python-build/share/python-build/3.9.14
+++ b/plugins/python-build/share/python-build/3.9.14
@@ -1,0 +1,9 @@
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.1" "https://ftpmirror.gnu.org/readline/readline-8.1.tar.gz#f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+  install_package "Python-3.9.14" "https://www.python.org/ftp/python/3.9.14/Python-3.9.14.tar.xz#651304d216c8203fe0adf1a80af472d8e92c3b0e0a7892222ae4d9f3ae4debcf" standard verify_py39 copy_python_gdb ensurepip
+else
+  install_package "Python-3.9.14" "https://www.python.org/ftp/python/3.9.14/Python-3.9.14.tgz#9201836e2c16361b2b7408680502393737d44f227333fe2e5729c7d5f6041675" standard verify_py39 copy_python_gdb ensurepip
+fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description

- https://www.python.org/downloads/release/python-3714
- https://www.python.org/downloads/release/python-3814
- https://www.python.org/downloads/release/python-3914

### Tests
- [ ] My PR adds the following unit tests (if any)
