### PR TITLE
Update miniconda3-3.9-4.12.0

### DIFF
--- a/plugins/python-build/share/python-build/miniconda3-3.9-4.12.0
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-4.12.0
@@ -12,7 +12,7 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
   install_script "Miniconda3-py39_4.12.0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Linux-x86_64.sh#7843dd7d0a2c53b0df37ca8189672992" "miniconda" verify_py39
   ;;
 "MacOSX-arm64" )
-  install_script "Miniconda3-py39_4.12.0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-MacOSX-arm64.sh#31251793539cf952ee99c18e34c30c7f" "miniconda" verify_py39
+  install_script "Miniconda3-py39_4.12.0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-MacOSX-arm64.sh#f7448cfeb278f2a84ed903db02d5525c" "miniconda" verify_py39
   ;;
 "MacOSX-x86_64" )
   install_script "Miniconda3-py39_4.12.0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-MacOSX-x86_64.sh#143b9bb03b6e4865be4ebbf40b108772" "miniconda" verify_py39


### PR DESCRIPTION
update checksum from https://repo.anaconda.com/miniconda/ Miniconda3-py39_4.12.0-MacOSX-arm64.sh 52.2M 2022-06-01 14:45:20 f7448cfeb278f2a84ed903db02d5525c

Make sure you have checked all steps below.

Prerequisite
 Please consider implementing the feature as a hook script or plugin as a first step.
pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
 Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
 My PR addresses the following pyenv issue (if any)
Closes https://github.com/pyenv/pyenv/issues/XXXX
Description
 Here are some details about my PR
Update checksum from https://repo.anaconda.com/miniconda/ for miniconda3-3.9-4.12.0
Tests
 My PR adds the following unit tests (if any)