### PR TITLE
Add ability to easily skip all use of Homebrew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
-.PHONY: test test-build
+.PHONY: test test-build test-unit test-plugin
 
 # Do not pass in user flags to build tests.
 unexport PYTHON_CFLAGS
 unexport PYTHON_CONFIGURE_OPTS
 
-test: bats
+test: test-unit test-plugin
+
+test-unit: bats
 	PATH="./bats/bin:$$PATH" test/run
+	
+test-plugin: bats
 	cd plugins/python-build && $(PWD)/bats/bin/bats $${CI:+--tap} test
 
 PYTHON_BUILD_ROOT := $(CURDIR)/plugins/python-build

--- a/plugins/python-build/README.md
+++ b/plugins/python-build/README.md
@@ -113,6 +113,7 @@ You can set certain environment variables to control the build process.
   checksum of the file to the mirror URL.
 * `PYTHON_BUILD_SKIP_MIRROR`, if set, forces python-build to download packages from
   their original source URLs instead of using a mirror.
+* `PYTHON_BUILD_SKIP_HOMEBREW`, if set, will not search for libraries installed by Homebrew on macOS.
 * `PYTHON_BUILD_ROOT` overrides the default location from where build definitions
   in `share/python-build/` are looked up.
 * `PYTHON_BUILD_DEFINITIONS` can be a list of colon-separated paths that get
@@ -231,7 +232,7 @@ the full build log for build failures.
 
 ### Testing new python versions
 
-If you are contributing a new python version for python-build, 
+If you are contributing a new python version for python-build,
 you can test the build in a [docker](https://www.docker.com/) container based on Ubuntu 18.04.
 
 With docker installed:
@@ -249,7 +250,7 @@ docker run -it my_container
 ```
 
 The container will need to be rebuilt whenever you change the repo,
-but after the first build, this will be very fast, 
+but after the first build, this will be very fast,
 as the layer including the build dependencies will be cached.
 
 Changes made inside the container will not be persisted.

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -112,6 +112,11 @@ is_mac() {
   [ $# -eq 0 ] || [ "$(osx_version)" "$@" ]
 }
 
+can_use_homebrew() {
+    [ -z "$PYTHON_BUILD_SKIP_HOMEBREW" ] || return 1
+    is_mac || return 1
+}
+
 #  9.1  -> 901
 # 10.9  -> 1009
 # 10.10 -> 1010
@@ -1322,7 +1327,7 @@ configured_with_package_dir() {
 }
 
 use_homebrew() {
-  is_mac || return 1
+  can_use_homebrew || return 1
   # unless Homebrew is at the default /usr/local, need to add its paths to
   # compiler search to be able to use non-keg-only deps from there
   if is_mac && command -v brew &>/dev/null; then
@@ -1344,7 +1349,7 @@ needs_yaml() {
 }
 
 use_homebrew_yaml() {
-  is_mac || return 1
+  can_use_homebrew || return 1
   local libdir="$(brew --prefix libyaml 2>/dev/null || true)"
   if [ -d "$libdir" ]; then
     echo "python-build: use libyaml from homebrew"
@@ -1388,7 +1393,7 @@ has_broken_mac_readline() {
 }
 
 use_homebrew_readline() {
-  is_mac || return 1
+  can_use_homebrew || return 1
   if ! configured_with_package_dir "python" "readline/rlconf.h"; then
     local libdir="$(brew --prefix readline 2>/dev/null || true)"
     if [ -d "$libdir" ]; then
@@ -1429,7 +1434,7 @@ has_broken_mac_openssl() {
 }
 
 use_homebrew_openssl() {
-  is_mac || return 1
+  can_use_homebrew || return 1
   command -v brew >/dev/null || return 1
   for openssl in ${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl}; do
     local ssldir="$(brew --prefix "${openssl}" || true)"
@@ -1529,7 +1534,7 @@ build_package_verify_openssl() {
 }
 
 use_homebrew_zlib() {
-  is_mac || return 1
+  can_use_homebrew || return 1
   local brew_zlib="$(brew --prefix zlib 2>/dev/null || true)"
   if [ -d "$brew_zlib" ]; then
     echo "python-build: use zlib from homebrew"
@@ -1549,7 +1554,7 @@ use_xcode_sdk_zlib() {
 }
 
 use_homebrew_tcltk() {
-  is_mac || return 1
+  can_use_homebrew || return 1
   # get the version from the folder that homebrew versions
   local tcltk_libdir="$(brew --prefix tcl-tk 2>/dev/null || true)"
   if [ -d "$tcltk_libdir" ]; then
@@ -1591,13 +1596,13 @@ use_custom_tcltk() {
 get_tcltk_flag_from() {
   IFS=$'\n'
   # parse input string into array
-  local opts_arr=( $(xargs -n1 <<<"$1") ) 
+  local opts_arr=( $(xargs -n1 <<<"$1") )
 
   # iterate through `opts_arr`, break if `--with-tcltk-libs=` was found.
   for opts in ${opts_arr[@]}; do
     # `--with-tcltk-libs=` must be the prefix.
     if [[ "$opts" == "--with-tcltk-libs="* ]]; then
-      # return 
+      # return
       echo "$opts"
       break
     fi
@@ -1607,7 +1612,7 @@ get_tcltk_flag_from() {
 }
 
 use_tcltk() {
-  if is_mac; then
+  if can_use_homebrew; then
     local tcltk_libdir="$(brew --prefix tcl-tk 2>/dev/null || true)"
   fi
   local tcl_tk_libs="$(get_tcltk_flag_from "$PYTHON_CONFIGURE_OPTS")"

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1330,7 +1330,7 @@ use_homebrew() {
   can_use_homebrew || return 1
   # unless Homebrew is at the default /usr/local, need to add its paths to
   # compiler search to be able to use non-keg-only deps from there
-  if is_mac && command -v brew &>/dev/null; then
+  if command -v brew &>/dev/null; then
     local brew_prefix="$(brew --prefix 2>/dev/null || true)"
     # /usr/local/lib:/usr/lib is the default library search path
     if [[ -n $brew_prefix && $brew_prefix != "/usr" && $brew_prefix != "/usr/local" ]]; then

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -151,7 +151,7 @@ OUT
   BREW_PREFIX="$TMP/homebrew-prefix"
   mkdir -p "$BREW_PREFIX"
 
-  for i in {1..9}; do stub uname '-s : echo Darwin'; done
+  for i in {1..8}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
   stub brew "--prefix : echo '$BREW_PREFIX'" false
   stub_make_install
@@ -179,7 +179,7 @@ OUT
   brew_libdir="$TMP/homebrew-yaml"
   mkdir -p "$brew_libdir"
 
-  for i in {1..10}; do stub uname '-s : echo Darwin'; done
+  for i in {1..9}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
   stub brew "--prefix libyaml : echo '$brew_libdir'"
   for i in {1..4}; do stub brew false; done
@@ -234,7 +234,7 @@ OUT
 
   readline_libdir="$TMP/homebrew-readline"
   mkdir -p "$readline_libdir"
-  for i in {1..8}; do stub uname '-s : echo Darwin'; done
+  for i in {1..7}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
   for i in {1..2}; do stub brew false; done
   stub brew "--prefix readline : echo '$readline_libdir'"
@@ -317,7 +317,7 @@ OUT
   mkdir -p "$readline_libdir/include/readline"
   touch "$readline_libdir/include/readline/rlconf.h"
 
-  for i in {1..8}; do stub uname '-s : echo Darwin'; done
+  for i in {1..7}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
 
   for i in {1..3}; do stub brew false; done
@@ -349,7 +349,7 @@ OUT
   mkdir -p "$tcl_tk_libdir/lib"
   echo "TCL_VERSION='$tcl_tk_version'" >>"$tcl_tk_libdir/lib/tclConfig.sh"
 
-  for i in {1..10}; do stub uname '-s : echo Darwin'; done
+  for i in {1..9}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
 
   stub brew false
@@ -383,7 +383,7 @@ OUT
   tcl_tk_version_long="8.6.10"
   tcl_tk_version="${tcl_tk_version_long%.*}"
 
-  for i in {1..9}; do stub uname '-s : echo Darwin'; done
+  for i in {1..8}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
 
   for i in {1..4}; do stub brew false; done
@@ -411,7 +411,7 @@ OUT
 @test "number of CPU cores defaults to 2" {
   cached_tarball "Python-3.6.2"
 
-  for i in {1..10}; do stub uname '-s : echo Darwin'; done
+  for i in {1..9}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 10.10'; done
 
   stub sysctl false
@@ -438,7 +438,7 @@ OUT
 @test "number of CPU cores is detected on Mac" {
   cached_tarball "Python-3.6.2"
 
-  for i in {1..10}; do stub uname '-s : echo Darwin'; done
+  for i in {1..9}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 10.10'; done
 
   stub sysctl '-n hw.ncpu : echo 4'

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -283,6 +283,32 @@ make install
 OUT
 }
 
+@test "no library searches performed during normal operation touch homebrew if envvar is set" {
+  cached_tarball "Python-3.6.2"
+
+  for i in {1..4}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
+  stub brew true; brew
+  stub_make_install
+  export PYTHON_BUILD_SKIP_HOMEBREW=1
+
+  run_inline_definition <<DEF
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub brew
+  unstub make
+
+  assert_build_log <<OUT
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+make -j 2
+make install
+OUT
+}
+
 @test "readline is not linked from Homebrew when explicitly defined" {
   cached_tarball "Python-3.6.2"
 

--- a/plugins/python-build/test/compiler.bats
+++ b/plugins/python-build/test/compiler.bats
@@ -63,7 +63,7 @@ DEF
   mkdir -p "$INSTALL_ROOT"
   cd "$INSTALL_ROOT"
 
-  for i in {1..10}; do stub uname '-s : echo Darwin'; done
+  for i in {1..9}; do stub uname '-s : echo Darwin'; done
   for i in {1..3}; do stub sw_vers '-productVersion : echo 10.10'; done
 
   stub cc 'false'


### PR DESCRIPTION
### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - None

### Description

This has been discussed and turned down before ( #1686, #1715) and the [suggestion](https://github.com/pyenv/pyenv/issues/1715#issuecomment-929531904) was to make `brew` a noop. That's what I do but it would be nice if there was a simpler way for `pyenv` to handle this. Having to make `brew` a noop, then fix it for normal use is not hard but it gets tiresome (I compile Python a lot 🤓).

I came up with a solution using an environment variable `PYENV_DISABLE_HOMEBREW`. I wanted to open a PR and discuss adding this to `pyenv`.

If it's something that would be considered, I'd be happy to work on documentation and tests.

### Tests
- [ ] None yet
