### PR TITLE
Build CPython 3.12+ with --with-dsymutil in MacOS

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -779,6 +779,7 @@ build_package_standard_build() {
     else
       use_homebrew_zlib || true
     fi
+    use_dsymutil || true
   fi
 
   ( if [ "${CFLAGS+defined}" ] || [ "${!PACKAGE_CFLAGS+defined}" ]; then
@@ -1623,6 +1624,16 @@ use_tcltk() {
     use_custom_tcltk "$tcl_tk_libs"
   elif [ -d "$tcltk_libdir" ]; then
     use_homebrew_tcltk
+  fi
+}
+
+# Since 3.12, CPython can add DWARF debug information in MacOS
+# using Apple's nonstandard way, `dsymutil', that creates a "dSYM bundle"
+# that's supposed to be installed alongside executables
+# (https://github.com/python/cpython/issues/95973).
+use_dsymutil() {
+  if [[ -n "$PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL" ]] && is_mac; then
+    package_option python configure --with-dsymutil
   fi
 }
 

--- a/plugins/python-build/share/python-build/3.12-dev
+++ b/plugins/python-build/share/python-build/3.12-dev
@@ -1,5 +1,6 @@
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_git "Python-3.12-dev" "https://github.com/python/cpython" main standard verify_py312 copy_python_gdb ensurepip

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -515,14 +515,41 @@ make install DOGE="such wow"
 OUT
 }
 
-@test "setting MAKE_INSTALL_OPTS to a multi-word string" {
+@test "configuring with dSYM in MacOS" {
   cached_tarball "Python-3.6.2"
 
-  for i in {1..8}; do stub uname '-s : echo Linux'; done
+  for i in {1..9}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
+  for i in {1..4}; do stub brew false; done
   stub_make_install
 
-  export MAKE_INSTALL_OPTS="DOGE=\"such wow\""
   run_inline_definition <<DEF
+export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
+DEF
+  assert_success
+
+  unstub sw_vers
+  unstub uname
+  unstub brew
+  unstub make
+
+  assert_build_log <<OUT
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=${TMP}/install/lib --with-dsymutil
+make -j 2
+make install
+OUT
+}
+
+@test "configuring with dSYM has no effect in non-MacOS" {
+  cached_tarball "Python-3.6.2"
+
+  for i in {1..9}; do stub uname '-s : echo Linux'; done
+  stub_make_install
+
+  run_inline_definition <<DEF
+export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
 install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
 DEF
   assert_success
@@ -532,9 +559,41 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=${TMP}/install/lib
 make -j 2
-make install DOGE="such wow"
+make install
+OUT
+}
+
+@test "tcl-tk is not linked from Homebrew when explicitly defined" {
+  cached_tarball "Python-3.6.2"
+
+  # python build
+  tcl_tk_version_long="8.6.10"
+  tcl_tk_version="${tcl_tk_version_long%.*}"
+
+  for i in {1..8}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
+
+  for i in {1..4}; do stub brew false; done
+  stub_make_install
+
+  export PYTHON_CONFIGURE_OPTS="--with-tcltk-libs='-L${TMP}/custom-tcl-tk/lib -ltcl$tcl_tk_version -ltk$tcl_tk_version'"
+  run_inline_definition <<DEF
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub sw_vers
+  unstub brew
+  unstub make
+
+  assert_build_log <<OUT
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --with-tcltk-libs=-L${TMP}/custom-tcl-tk/lib -ltcl8.6 -ltk8.6
+make -j 2
+make install
 OUT
 }
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2466

### Description
- [x] Here are some details about my PR

Allow configuring CPython with --with--dsymutil in MacOS by defining an envvar in installation script.
Do that for 3.12.

### Tests
- [x] My PR adds the following unit tests (if any)

tests for the added logic