### PR TITLE
Auto-resolve prefixes to the latest version

### DIFF
--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Summary: Print the latest installed version with the given prefix
+# Summary: Print the latest installed or known version with the given prefix
 # Usage: pyenv latest [-k|--known] [-q|--quiet] <prefix>
 #
 #   -k/--known      Select from all known versions instead of installed
@@ -41,6 +41,7 @@ IFS=$'\n'
     # fi
     # https://stackoverflow.com/questions/11856054/is-there-an-easy-way-to-pass-a-raw-string-to-grep/63483807#63483807 
     prefix_re="$(sed 's/[^\^]/[&]/g;s/[\^]/\\&/g' <<< "$prefix")"
+    # FIXME: more reliable and readable would probably be to loop over them and transform in pure Bash
     DEFINITION_CANDIDATES=(\
       $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
       grep -Ee "^$prefix_re[-.]" || true))
@@ -49,6 +50,7 @@ IFS=$'\n'
         $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
           sed -E -e '/-dev$/d' -e '/-src$/d' -e '/-latest$/d' -e '/(b|rc)[0-9]+$/d'));
 
+    # Compose a sorting key, followed by | and original value
     DEFINITION_CANDIDATES=(\
         $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
           awk \

--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -43,7 +43,7 @@ IFS=$'\n'
     prefix_re="$(sed 's/[^\^]/[&]/g;s/[\^]/\\&/g' <<< "$prefix")"
     DEFINITION_CANDIDATES=(\
       $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
-      grep -Ee "$prefix_re[-.]" || true))
+      grep -Ee "^$prefix_re[-.]" || true))
 
     DEFINITION_CANDIDATES=(\
         $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \

--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -33,30 +33,45 @@ do
     fi
 
     if [[ -z $FROM_KNOWN ]]; then
-        set -o nullglob
+        shopt -s nullglob
         pushd "$PYENV_ROOT/versions" &>/dev/null
         DEFINITION_CANDIDATES=( "$prefix"-* "$prefix".* )
         popd &>/dev/null
-        set +o nullglob
+        shopt -u nullglob
     else
-        IFS=$'\n' DEFINITION_CANDIDATES=( $(python-build --definitions | grep "^$prefix[.-]") )
+        # https://stackoverflow.com/questions/11856054/is-there-an-easy-way-to-pass-a-raw-string-to-grep/63483807#63483807 
+        prefix_re="$(sed 's/[^\^]/[&]/g;s/[\^]/\\&/g' <<< "$prefix")"
+        IFS=$'\n' DEFINITION_CANDIDATES=( $(python-build --definitions | grep "^$prefix_re[-.]" || true) )
     fi
 
     OLDIFS="$IFS"
     IFS=$'\n'
 
     DEFINITION_CANDIDATES=(\
-        echo "${DEFINITION_CANDIDATES[@]}" | \
-          sed -E -e '/-dev$/d' -e '/-src$/d' -e '/(b|rc)[0-9]+$/d' | \
-          sort -t. -k1,1r -k 2,2nr -k 3,3nr \
+        $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
+          sed -E -e '/-dev$/d' -e '/-src$/d' -e '/-latest$/d' -e '/(b|rc)[0-9]+$/d'));
+
+    DEFINITION_CANDIDATES=(\
+        $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
+          awk \
+            '{ if (match($0,"^[[:alnum:]]+-"))
+               { print substr($0,0,RLENGTH-1) "." substr($0,RLENGTH+1) "..|" $0; }
+             else
+               { print $0 "...|" $0; }
+             }'))
+    DEFINITION_CANDIDATES=(\
+        $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" \
+          | sort -t. -k1,1r -k 2,2nr -k 3,3nr -k4,4nr \
+          | cut -f2 -d $'|' \
         || true))
     DEFINITION="${DEFINITION_CANDIDATES}"
-    VERSION_NAME="${DEFINITION##*/}"
+
+    IFS="$OLDIFS"
 
     if [[ -n "$DEFINITION" ]]; then
         echo "$DEFINITION"
     else
-        echo "pyenv-latest: no $([[ -z $FROM_KNOWN ]] && echo installed || echo known) versions match prefix \`$prefix'" >&2
+        echo "pyenv-latest: no $([[ -z $FROM_KNOWN ]] && echo installed || echo known) versions match the prefix \`$prefix'" >&2
         exitcode=1
     fi
 done

--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Summary: Print the latest installed version with the given prefix
-# Usage: pyenv latest [-k|--known] <prefix>
+# Usage: pyenv latest [-k|--known] [-q|--quiet] <prefix>
 #
 #   -k/--known      Select from all known versions instead of installed
+#   -q/--quiet      Do not print a 
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
@@ -12,6 +13,10 @@ do
     case "$1" in
         -k|--known)
             FROM_KNOWN=1
+            shift
+            ;;
+        -q|--quiet)
+            QUIET=1
             shift
             ;;
         *)
@@ -30,10 +35,10 @@ IFS=$'\n'
     else
         DEFINITION_CANDIDATES=( $(python-build --definitions ) )
     fi
-    if grep -xFe "$prefix" <<<"${DEFINITION_CANDIDATES[@]}"; then
-        echo "$prefix"
-        exit $exitcode
-    fi
+    # if grep -xFe "$prefix" <<<"${DEFINITION_CANDIDATES[@]}"; then
+        # echo "$prefix"
+        # exit $exitcode
+    # fi
     # https://stackoverflow.com/questions/11856054/is-there-an-easy-way-to-pass-a-raw-string-to-grep/63483807#63483807 
     prefix_re="$(sed 's/[^\^]/[&]/g;s/[\^]/\\&/g' <<< "$prefix")"
     DEFINITION_CANDIDATES=(\
@@ -62,7 +67,9 @@ IFS=$'\n'
     if [[ -n "$DEFINITION" ]]; then
         echo "$DEFINITION"
     else
-        echo "pyenv-latest: no $([[ -z $FROM_KNOWN ]] && echo installed || echo known) versions match the prefix \`$prefix'" >&2
+        if [[ -z $QUIET ]]; then
+            echo "pyenv: no $([[ -z $FROM_KNOWN ]] && echo installed || echo known) versions match the prefix \`$prefix'" >&2
+        fi
         exitcode=1
     fi
 

--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Summary: Print the latest installed version with the given prefix
+# Usage: pyenv latest [-k|--known] <prefix> ...
+#
+#   -k/--known      Select from all known versions instead of installed
+#   -u/--unstable   Include prereleases
+
+set -e
+[ -n "$PYENV_DEBUG" ] && set -x
+
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        -k|--known)
+            FROM_KNOWN=1
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+prefixes=("$@")
+
+exitcode=0
+for prefix in "${prefixes[@]}"
+do
+    # An existing version only matches itself
+    if [[ -e $PYENV_ROOT/versions/$prefix ]]; then
+        echo "$prefix"
+        continue
+    fi
+
+    if [[ -z $FROM_KNOWN ]]; then
+        set -o nullglob
+        pushd "$PYENV_ROOT/versions" &>/dev/null
+        DEFINITION_CANDIDATES=( "$prefix"-* "$prefix".* )
+        popd &>/dev/null
+        set +o nullglob
+    else
+        IFS=$'\n' DEFINITION_CANDIDATES=( $(python-build --definitions | grep "^$prefix[.-]") )
+    fi
+
+    OLDIFS="$IFS"
+    IFS=$'\n'
+
+    DEFINITION_CANDIDATES=(\
+        echo "${DEFINITION_CANDIDATES[@]}" | \
+          sed -E -e '/-dev$/d' -e '/-src$/d' -e '/(b|rc)[0-9]+$/d' | \
+          sort -t. -k1,1r -k 2,2nr -k 3,3nr \
+        || true))
+    DEFINITION="${DEFINITION_CANDIDATES}"
+    VERSION_NAME="${DEFINITION##*/}"
+
+    if [[ -n "$DEFINITION" ]]; then
+        echo "$DEFINITION"
+    else
+        echo "pyenv-latest: no $([[ -z $FROM_KNOWN ]] && echo installed || echo known) versions match prefix \`$prefix'" >&2
+        exitcode=1
+    fi
+done
+
+exit $exitcode

--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 # Summary: Print the latest installed version with the given prefix
-# Usage: pyenv latest [-k|--known] <prefix> ...
+# Usage: pyenv latest [-k|--known] <prefix>
 #
 #   -k/--known      Select from all known versions instead of installed
-#   -u/--unstable   Include prereleases
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
@@ -21,31 +20,25 @@ do
     esac
 done
 
-prefixes=("$@")
-
+prefix=$1
 exitcode=0
-for prefix in "${prefixes[@]}"
-do
-    # An existing version only matches itself
-    if [[ -e $PYENV_ROOT/versions/$prefix ]]; then
-        echo "$prefix"
-        continue
-    fi
+
+IFS=$'\n'
 
     if [[ -z $FROM_KNOWN ]]; then
-        shopt -s nullglob
-        pushd "$PYENV_ROOT/versions" &>/dev/null
-        DEFINITION_CANDIDATES=( "$prefix"-* "$prefix".* )
-        popd &>/dev/null
-        shopt -u nullglob
+        DEFINITION_CANDIDATES=( $(pyenv-versions --bare) )
     else
-        # https://stackoverflow.com/questions/11856054/is-there-an-easy-way-to-pass-a-raw-string-to-grep/63483807#63483807 
-        prefix_re="$(sed 's/[^\^]/[&]/g;s/[\^]/\\&/g' <<< "$prefix")"
-        IFS=$'\n' DEFINITION_CANDIDATES=( $(python-build --definitions | grep "^$prefix_re[-.]" || true) )
+        DEFINITION_CANDIDATES=( $(python-build --definitions ) )
     fi
-
-    OLDIFS="$IFS"
-    IFS=$'\n'
+    if grep -xFe "$prefix" <<<"${DEFINITION_CANDIDATES[@]}"; then
+        echo "$prefix"
+        exit $exitcode
+    fi
+    # https://stackoverflow.com/questions/11856054/is-there-an-easy-way-to-pass-a-raw-string-to-grep/63483807#63483807 
+    prefix_re="$(sed 's/[^\^]/[&]/g;s/[\^]/\\&/g' <<< "$prefix")"
+    DEFINITION_CANDIDATES=(\
+      $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
+      grep -Ee "$prefix_re[-.]" || true))
 
     DEFINITION_CANDIDATES=(\
         $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
@@ -64,9 +57,7 @@ do
           | sort -t. -k1,1r -k 2,2nr -k 3,3nr -k4,4nr \
           | cut -f2 -d $'|' \
         || true))
-    DEFINITION="${DEFINITION_CANDIDATES}"
-
-    IFS="$OLDIFS"
+    DEFINITION="${DEFINITION_CANDIDATES[0]}"
 
     if [[ -n "$DEFINITION" ]]; then
         echo "$DEFINITION"
@@ -74,6 +65,5 @@ do
         echo "pyenv-latest: no $([[ -z $FROM_KNOWN ]] && echo installed || echo known) versions match the prefix \`$prefix'" >&2
         exitcode=1
     fi
-done
 
 exit $exitcode

--- a/libexec/pyenv-prefix
+++ b/libexec/pyenv-prefix
@@ -42,6 +42,7 @@ OLDIFS="$IFS"
         exit 1
       fi
     else
+      version="$(pyenv-latest "$version" -q || echo "$version")"
       PYENV_PREFIX_PATH="${PYENV_ROOT}/versions/${version}"
     fi
     if [ -d "$PYENV_PREFIX_PATH" ]; then

--- a/libexec/pyenv-prefix
+++ b/libexec/pyenv-prefix
@@ -42,7 +42,7 @@ OLDIFS="$IFS"
         exit 1
       fi
     else
-      version="$(pyenv-latest "$version" -q || echo "$version")"
+      version="$(pyenv-latest -q "$version" || echo "$version")"
       PYENV_PREFIX_PATH="${PYENV_ROOT}/versions/${version}"
     fi
     if [ -d "$PYENV_PREFIX_PATH" ]; then

--- a/libexec/pyenv-version-name
+++ b/libexec/pyenv-version-name
@@ -34,8 +34,8 @@ OLDIFS="$IFS"
       versions=("${versions[@]}" "${version}")
     elif version_exists "${version#python-}"; then
       versions=("${versions[@]}" "${version#python-}")
-    elif resolved_version="$(pyenv-latest -q "$version")"; then
-      versions=("${versions[@]}" "${resolved_version}")
+    # elif resolved_version="$(pyenv-latest -q "$version")"; then
+      # versions=("${versions[@]}" "${resolved_version}")
     else
       echo "pyenv: version \`$version' is not installed (set by $(pyenv-version-origin))" >&2
       any_not_installed=1

--- a/libexec/pyenv-version-name
+++ b/libexec/pyenv-version-name
@@ -34,8 +34,8 @@ OLDIFS="$IFS"
       versions=("${versions[@]}" "${version}")
     elif version_exists "${version#python-}"; then
       versions=("${versions[@]}" "${version#python-}")
-    elif version="$(pyenv-latest -q "$version")"; then
-      versions=("${versions[@]}" "${version}")
+    elif resolved_version="$(pyenv-latest -q "$version")"; then
+      versions=("${versions[@]}" "${resolved_version}")
     else
       echo "pyenv: version \`$version' is not installed (set by $(pyenv-version-origin))" >&2
       any_not_installed=1

--- a/libexec/pyenv-version-name
+++ b/libexec/pyenv-version-name
@@ -34,6 +34,8 @@ OLDIFS="$IFS"
       versions=("${versions[@]}" "${version}")
     elif version_exists "${version#python-}"; then
       versions=("${versions[@]}" "${version#python-}")
+    elif version="$(pyenv-latest -q "$version")"; then
+      versions=("${versions[@]}" "${version}")
     else
       echo "pyenv: version \`$version' is not installed (set by $(pyenv-version-origin))" >&2
       any_not_installed=1

--- a/libexec/pyenv-version-name
+++ b/libexec/pyenv-version-name
@@ -34,8 +34,8 @@ OLDIFS="$IFS"
       versions=("${versions[@]}" "${version}")
     elif version_exists "${version#python-}"; then
       versions=("${versions[@]}" "${version#python-}")
-    # elif resolved_version="$(pyenv-latest -q "$version")"; then
-      # versions=("${versions[@]}" "${resolved_version}")
+    elif resolved_version="$(pyenv-latest -q "$version")"; then
+      versions=("${versions[@]}" "${resolved_version}")
     else
       echo "pyenv: version \`$version' is not installed (set by $(pyenv-version-origin))" >&2
       any_not_installed=1

--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -145,6 +145,10 @@ IFS=$'\n' scripts=(`pyenv-hooks install`)
 IFS="$OLDIFS"
 for script in "${scripts[@]}"; do source "$script"; done
 
+# Try to resolve a prefix if user indeed gave a prefix.
+# We install the version under the resolved name
+# and hooks also see the resolved name
+DEFINITION="$(pyenv-latest -q -k "$DEFINITION" || echo "$DEFINITION")"
 
 # Set VERSION_NAME from $DEFINITION, if it is not already set. Then
 # compute the installation prefix.

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2054,7 +2054,7 @@ elif [ ! -f "$DEFINITION_PATH" ]; then
   
   search_definitions
   if [ ! -f "$DEFINITION_PATH" ]; then
-    if RESOLVED_DEFINITION_PATH="$(pyenv-latest -k -q "$DEFINITION_PATH")"; then
+    if RESOLVED_DEFINITION_PATH="$(command -v pyenv-latest >/dev/null && pyenv-latest -k -q "$DEFINITION_PATH")"; then
       DEFINITION_PATH="$RESOLVED_DEFINITION_PATH"
       unset RESOLVED_DEFINITION_PATH
       search_definitions

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2042,12 +2042,22 @@ DEFINITION_PATH="${ARGUMENTS[0]}"
 if [ -z "$DEFINITION_PATH" ]; then
   usage 1 >&2
 elif [ ! -f "$DEFINITION_PATH" ]; then
-  for DEFINITION_DIR in "${PYTHON_BUILD_DEFINITIONS[@]}"; do
-    if [ -f "${DEFINITION_DIR}/${DEFINITION_PATH}" ]; then
-      DEFINITION_PATH="${DEFINITION_DIR}/${DEFINITION_PATH}"
-      break
-    fi
-  done
+
+  search_definitions() {
+    for DEFINITION_DIR in "${PYTHON_BUILD_DEFINITIONS[@]}"; do
+      if [ -f "${DEFINITION_DIR}/${DEFINITION_PATH}" ]; then
+        DEFINITION_PATH="${DEFINITION_DIR}/${DEFINITION_PATH}"
+        break
+      fi
+    done
+  }
+  
+  search_definitions
+  if [ ! -f "$DEFINITION_PATH" ]; then
+    DEFINITION_PATH="$(pyenv-latest -q $DEFINITION_PATH)"
+    search_definitions
+  fi
+  unset search_definitions
 
   if [ ! -f "$DEFINITION_PATH" ]; then
     echo "python-build: definition not found: ${DEFINITION_PATH}" >&2

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2054,8 +2054,11 @@ elif [ ! -f "$DEFINITION_PATH" ]; then
   
   search_definitions
   if [ ! -f "$DEFINITION_PATH" ]; then
-    DEFINITION_PATH="$(pyenv-latest -k -q "$DEFINITION_PATH")"
-    search_definitions
+    if RESOLVED_DEFINITION_PATH="$(pyenv-latest -k -q "$DEFINITION_PATH")"; then
+      DEFINITION_PATH="$RESOLVED_DEFINITION_PATH"
+      unset RESOLVED_DEFINITION_PATH
+      search_definitions
+    fi
   fi
   unset search_definitions
 

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2054,7 +2054,7 @@ elif [ ! -f "$DEFINITION_PATH" ]; then
   
   search_definitions
   if [ ! -f "$DEFINITION_PATH" ]; then
-    DEFINITION_PATH="$(pyenv-latest -q $DEFINITION_PATH)"
+    DEFINITION_PATH="$(pyenv-latest -k -q "$DEFINITION_PATH")"
     search_definitions
   fi
   unset search_definitions

--- a/plugins/python-build/share/python-build/3.10.8
+++ b/plugins/python-build/share/python-build/3.10.8
@@ -1,0 +1,9 @@
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1o" "https://www.openssl.org/source/openssl-1.1.1o.tar.gz#9384a2b0570dd80358841464677115df785edb941c71211f75076d72fe6b438f" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.1" "https://ftpmirror.gnu.org/readline/readline-8.1.tar.gz#f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+    install_package "Python-3.10.8" "https://www.python.org/ftp/python/3.10.8/Python-3.10.8.tar.xz#6a30ecde59c47048013eb5a658c9b5dec277203d2793667f578df7671f7f03f3" standard verify_py310 copy_python_gdb ensurepip
+else
+    install_package "Python-3.10.8" "https://www.python.org/ftp/python/3.10.8/Python-3.10.8.tgz#f400c3fb394b8bef1292f6dc1292c5fadc3533039a5bc0c3e885f3e16738029a" standard verify_py310 copy_python_gdb ensurepip
+fi

--- a/plugins/python-build/test/definitions.bats
+++ b/plugins/python-build/test/definitions.bats
@@ -60,7 +60,7 @@ NUM_DEFINITIONS="$(find "$BATS_TEST_DIRNAME"/../share/python-build -maxdepth 1 -
 }
 
 @test "installing nonexistent definition" {
-  stub pyenv-latest
+  stub pyenv-latest false
   run python-build "nonexistent" "${TMP}/install"
   assert [ "$status" -eq 2 ]
   assert_output "python-build: definition not found: nonexistent"

--- a/plugins/python-build/test/definitions.bats
+++ b/plugins/python-build/test/definitions.bats
@@ -60,6 +60,7 @@ NUM_DEFINITIONS="$(find "$BATS_TEST_DIRNAME"/../share/python-build -maxdepth 1 -
 }
 
 @test "installing nonexistent definition" {
+  stub pyenv-latest
   run python-build "nonexistent" "${TMP}/install"
   assert [ "$status" -eq 2 ]
   assert_output "python-build: definition not found: nonexistent"

--- a/plugins/python-build/test/definitions.bats
+++ b/plugins/python-build/test/definitions.bats
@@ -70,10 +70,9 @@ NUM_DEFINITIONS="$(find "$BATS_TEST_DIRNAME"/../share/python-build -maxdepth 1 -
   stub pyenv-latest "echo 2.7.8"
   export PYTHON_BUILD_ROOT="$TMP"
   mkdir -p "${PYTHON_BUILD_ROOT}/share/python-build"
-  echo true > "${PYTHON_BUILD_ROOT}/share/python-build/2.7.8"
+  echo 'echo 2.7.8' > "${PYTHON_BUILD_ROOT}/share/python-build/2.7.8"
   run python-build "2.7" "${TMP}/install"
-  assert_success
-  assert_output_contains "2.7.8"
+  assert_success "2.7.8"
 }
 
 

--- a/plugins/python-build/test/definitions.bats
+++ b/plugins/python-build/test/definitions.bats
@@ -66,7 +66,7 @@ NUM_DEFINITIONS="$(find "$BATS_TEST_DIRNAME"/../share/python-build -maxdepth 1 -
   assert_output "python-build: definition not found: nonexistent"
 }
 
-@test "falls back to pyenv-latest" {
+@test "resolves prefixes via pyenv-latest" {
   stub pyenv-latest "echo 2.7.8"
   export PYTHON_BUILD_ROOT="$TMP"
   mkdir -p "${PYTHON_BUILD_ROOT}/share/python-build"
@@ -75,6 +75,14 @@ NUM_DEFINITIONS="$(find "$BATS_TEST_DIRNAME"/../share/python-build -maxdepth 1 -
   assert_success "2.7.8"
 }
 
+@test "doesn't resolve prefixes if pyenv-latest is unavailable" {
+  export PATH="$(path_without pyenv-latest)"
+  export PYTHON_BUILD_ROOT="$TMP"
+  mkdir -p "${PYTHON_BUILD_ROOT}/share/python-build"
+  echo 'echo 2.7.8' > "${PYTHON_BUILD_ROOT}/share/python-build/2.7.8"
+  run python-build "2.7" "${TMP}/install"
+  assert_failure "python-build: definition not found: 2.7"
+}
 
 @test "sorting Python versions" {
   export PYTHON_BUILD_ROOT="$TMP"

--- a/plugins/python-build/test/definitions.bats
+++ b/plugins/python-build/test/definitions.bats
@@ -67,12 +67,13 @@ NUM_DEFINITIONS="$(find "$BATS_TEST_DIRNAME"/../share/python-build -maxdepth 1 -
 }
 
 @test "falls back to pyenv-latest" {
-  stub pyenv-latest "2.7 : echo 2.7.8"
+  stub pyenv-latest "echo 2.7.8"
   export PYTHON_BUILD_ROOT="$TMP"
   mkdir -p "${PYTHON_BUILD_ROOT}/share/python-build"
-  touch "${PYTHON_BUILD_ROOT}/share/python-build/2.7.8"
+  echo true > "${PYTHON_BUILD_ROOT}/share/python-build/2.7.8"
   run python-build "2.7" "${TMP}/install"
-  assert_success "2.7.8"
+  assert_success
+  assert_output_contains "2.7.8"
 }
 
 

--- a/plugins/python-build/test/definitions.bats
+++ b/plugins/python-build/test/definitions.bats
@@ -65,6 +65,15 @@ NUM_DEFINITIONS="$(find "$BATS_TEST_DIRNAME"/../share/python-build -maxdepth 1 -
   assert_output "python-build: definition not found: nonexistent"
 }
 
+@test "falls back pyenv-latest" {
+  export PYTHON_BUILD_ROOT="$TMP"
+  mkdir -p "${PYTHON_BUILD_ROOT}/share/python-build"
+  touch "${PYTHON_BUILD_ROOT}/share/python-build/2.7.8"
+  run python-build "2.7" "${TMP}/install"
+  assert_success "2.7.8"
+}
+
+
 @test "sorting Python versions" {
   export PYTHON_BUILD_ROOT="$TMP"
   mkdir -p "${PYTHON_BUILD_ROOT}/share/python-build"

--- a/plugins/python-build/test/definitions.bats
+++ b/plugins/python-build/test/definitions.bats
@@ -65,7 +65,8 @@ NUM_DEFINITIONS="$(find "$BATS_TEST_DIRNAME"/../share/python-build -maxdepth 1 -
   assert_output "python-build: definition not found: nonexistent"
 }
 
-@test "falls back pyenv-latest" {
+@test "falls back to pyenv-latest" {
+  stub pyenv-latest "2.7 : echo 2.7.8"
   export PYTHON_BUILD_ROOT="$TMP"
   mkdir -p "${PYTHON_BUILD_ROOT}/share/python-build"
   touch "${PYTHON_BUILD_ROOT}/share/python-build/2.7.8"

--- a/plugins/python-build/test/hooks.bats
+++ b/plugins/python-build/test/hooks.bats
@@ -15,6 +15,7 @@ after_install 'echo after: \$STATUS'
 OUT
   stub pyenv-hooks "install : echo '$HOOK_PATH'/install.bash"
   stub pyenv-rehash "echo rehashed"
+  stub pyenv-latest false
 
   definition="${TMP}/3.6.2"
   cat > "$definition" <<<"echo python-build"

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -10,6 +10,7 @@ setup() {
 
 stub_python_build() {
   stub python-build "--lib : $BATS_TEST_DIRNAME/../bin/python-build --lib" "$@"
+  stub pyenv-latest " : false"
 }
 
 @test "install proper" {
@@ -25,7 +26,8 @@ stub_python_build() {
 
 @test "install resolves a prefix" {
   stub_python_build 'echo python-build "$@"'
-  stub pyenv-latest '3.4 : 3.4.2'
+  stub pyenv-latest '-q -k 3.4 : echo 3.4.2'
+  pyenv-latest || true  # pass through the stub entry added by stub_python_build
 
   run pyenv-install 3.4
   assert_success "python-build 3.4.2 ${PYENV_ROOT}/versions/3.4.2"

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -10,7 +10,6 @@ setup() {
 
 stub_python_build() {
   stub python-build "--lib : $BATS_TEST_DIRNAME/../bin/python-build --lib" "$@"
-  stub pyenv-latest " : false"
 }
 
 @test "install proper" {

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -10,12 +10,25 @@ setup() {
 
 stub_python_build() {
   stub python-build "--lib : $BATS_TEST_DIRNAME/../bin/python-build --lib" "$@"
+  stub pyenv-latest " : false"
 }
 
 @test "install proper" {
   stub_python_build 'echo python-build "$@"'
 
   run pyenv-install 3.4.2
+  assert_success "python-build 3.4.2 ${PYENV_ROOT}/versions/3.4.2"
+
+  unstub python-build
+  unstub pyenv-hooks
+  unstub pyenv-rehash
+}
+
+@test "install resolves a prefix" {
+  stub_python_build 'echo python-build "$@"'
+  stub pyenv-latest '3.4 : 3.4.2'
+
+  run pyenv-install 3.4
   assert_success "python-build 3.4.2 ${PYENV_ROOT}/versions/3.4.2"
 
   unstub python-build

--- a/plugins/python-build/test/test_helper.bash
+++ b/plugins/python-build/test/test_helper.bash
@@ -137,3 +137,29 @@ assert_output_contains() {
     } | flunk
   }
 }
+
+# Output a modified PATH that ensures that the given executable is not present,
+# but in which system utils necessary for pyenv operation are still available.
+path_without() {
+  local path=":${PATH}:"
+  for exe; do 
+    local found alt util
+    for found in $(PATH="$path" type -aP "$exe"); do
+      found="${found%/*}"
+      if [ "$found" != "${PYENV_ROOT}/shims" ]; then
+        alt="${PYENV_TEST_DIR}/$(echo "${found#/}" | tr '/' '-')"
+        mkdir -p "$alt"
+        for util in bash head cut readlink greadlink; do
+          if [ -x "${found}/$util" ]; then
+            ln -s "${found}/$util" "${alt}/$util"
+          fi
+        done
+        path="${path/:${found}:/:${alt}:}"
+      fi
+    done
+  done
+  path="${path#:}"
+  path="${path%:}"
+  echo "$path"
+}
+

--- a/test/latest.bats
+++ b/test/latest.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+create_executable() {
+  local name="$1"
+  local bin="${PYENV_TEST_DIR}/bin"
+  mkdir -p "$bin"
+  sed -Ee '1s/^ +//' > "${bin}/$name"
+  chmod +x "${bin}/$name"
+}
+
+@test "read from installed" {
+  create_executable pyenv-versions <<!
+#!$BASH
+echo 4.5.6
+!
+  run pyenv-latest 4
+  assert_success
+  assert_output <<!
+4.5.6
+!
+}
+
+@test "read from known" {
+  create_executable python-build <<!
+#!$BASH
+echo 4.5.6
+!
+  run pyenv-latest -k 4
+  assert_success
+  assert_output <<!
+4.5.6
+!
+}
+
+@test "sort CPython" {
+  create_executable pyenv-versions <<!
+#!$BASH
+echo 2.7.18
+echo 3.5.6
+echo 3.10.8
+echo 3.10.6
+!
+  run pyenv-latest 3
+  assert_success
+  assert_output <<!
+3.10.8
+!
+}

--- a/test/latest.bats
+++ b/test/latest.bats
@@ -2,6 +2,10 @@
 
 load test_helper
 
+setup() {
+  export PATH="${PYENV_TEST_DIR}/bin:$PATH"
+}
+
 create_executable() {
   local name="$1"
   local bin="${PYENV_TEST_DIR}/bin"

--- a/test/latest.bats
+++ b/test/latest.bats
@@ -57,7 +57,7 @@ pyenv: no installed versions match the prefix \`3.8'
 echo 3.5.6
 echo 3.10.8
 !
-  run pyenv-latest 3.8
+  run pyenv-latest -k 3.8
   assert_failure
   assert_output <<!
 pyenv: no known versions match the prefix \`3.8'

--- a/test/latest.bats
+++ b/test/latest.bats
@@ -38,6 +38,32 @@ echo 4.5.6
 !
 }
 
+@test "installed version not found" {
+  create_executable pyenv-versions <<!
+#!$BASH
+echo 3.5.6
+echo 3.10.8
+!
+  run pyenv-latest 3.8
+  assert_failure
+  assert_output <<!
+pyenv: no installed versions match the prefix \`3.8'
+!
+}
+
+@test "known version not found" {
+  create_executable python-build <<!
+#!$BASH
+echo 3.5.6
+echo 3.10.8
+!
+  run pyenv-latest 3.8
+  assert_failure
+  assert_output <<!
+pyenv: no known versions match the prefix \`3.8'
+!
+}
+
 @test "sort CPython" {
   create_executable pyenv-versions <<!
 #!$BASH

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -113,3 +113,10 @@ OUT
   assert_success
   assert_output "2.7.11"
 }
+
+@test "falls back to pyenv-latest" {
+  create_version "2.7.11"
+  PYENV_VERSION="2.7" run pyenv-version-name
+  assert_success
+  assert_output "2.7.11"
+}


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

When given a prefix rather than full name, Pyenv resolves it to the latest release in the corresponding version line.

It must be a full prefix -- the searched prefix is `<prefix>[-.]`

Other flavors may be sorted incorrectly atm.

### Tests
- [ ] My PR adds the following unit tests (if any)
