### PR TITLE
Update Python 3.11.0 tgz checksum

### DIFF
--- a/plugins/python-build/share/python-build/3.11.0
+++ b/plugins/python-build/share/python-build/3.11.0
@@ -5,5 +5,5 @@ install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.
 if has_tar_xz_support; then
     install_package "Python-3.11.0" "https://www.python.org/ftp/python/3.11.0/Python-3.11.0.tar.xz#a57dc82d77358617ba65b9841cee1e3b441f386c3789ddc0676eca077f2951c3" standard verify_py311 copy_python_gdb ensurepip
 else
-    install_package "Python-3.11.0" "https://www.python.org/ftp/python/3.11.0/Python-3.11.0.tgz#20d77729a64b2a300f08717f7ffcb8da189d02e7c51e6e4a06c0340b619cbf32" standard verify_py311 copy_python_gdb ensurepip
+    install_package "Python-3.11.0" "https://www.python.org/ftp/python/3.11.0/Python-3.11.0.tgz#64424e96e2457abbac899b90f9530985b51eef2905951febd935f0e73414caeb" standard verify_py311 copy_python_gdb ensurepip
 fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description

**TLDR:** For some reason checksum for `Python-3.11.0.tgz` file introduced in 0726e02e3a1b638f6442dffd880abf256e9c2bf7 is invalid. Updated that checksum to ensure `pyenv install 3.11.0` works well on systems without tar.xz support.

---

I have tried to run `pyenv install 3.11.0` on one of my Ubuntu 18.04 boxes and it failed with,

```
BUILD FAILED (Ubuntu 18.04 using python-build 20180424)

Inspect or clean up the working tree at /tmp/python-build.20221025231701.62
Results logged to /tmp/python-build.20221025231701.62.log

Last 10 log lines:
tmp/python-build.20221025231701.62 ~

checksum mismatch: Python-3.11.0.tar.gz (file is corrupt)
expected 20d77729a64b2a300f08717f7ffcb8da189d02e7c51e6e4a06c0340b619cbf32, got 64424e96e2457abbac899b90f9530985b51eef2905951febd935f0e73414caeb
```

This makes me think that, for some reason, checksum for `Python-3.11.0.tgz` file has been invalid in pyenv repo. I can approve this by running following command on same Ubuntu 18.04 box,

```
$ curl -sSL https://www.python.org/ftp/python/3.11.0/Python-3.11.0.tgz | sha256sum -
64424e96e2457abbac899b90f9530985b51eef2905951febd935f0e73414caeb  -
```

And following on my Mac M1,

```
❯ curl -sSL https://www.python.org/ftp/python/3.11.0/Python-3.11.0.tgz | shasum -a 256 -
64424e96e2457abbac899b90f9530985b51eef2905951febd935f0e73414caeb  -
```

Cause of that, I have decided to update `3.11.0` build file with updated checksum for `Python-3.11.0.tgz` file.

ps. And yes, installing `3.11.0` via `tar.xz` file works well for me on my Mac M1 and other Ubuntu boxes with XZ (`xz-utils`) installed.

### Tests
- [ ] My PR adds the following unit tests (if any)
