### PR TITLE
Add graalpy-22.3.0

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -938,10 +938,30 @@ pypy_architecture() {
   esac
 }
 
+graalpy_architecture() {
+  case "$(uname -s)" in
+  "Darwin" )
+    case "$(uname -m)" in
+    "x86_64" ) echo "macos-amd64" ;;
+    "arm64" ) echo "macos-aarch64" ;;
+    * ) return 1 ;;
+    esac
+    ;;
+  "Linux" )
+    case "$(uname -m)" in
+    "x86_64" ) echo "linux-amd64" ;;
+    "aarch64" ) echo "linux-aarch64" ;;
+    * ) return 1 ;;
+    esac
+    ;;
+  esac
+}
+
 pyston_architecture() {
   pypy_architecture
 }
 
+# Note: not used by graalpy >= 23.3.0 anymore
 build_package_graalpython() {
     build_package_copy
     ln -fs "${PREFIX_PATH}/bin/graalpython" "${PREFIX_PATH}/bin/python"

--- a/plugins/python-build/share/python-build/graalpy-22.3.0
+++ b/plugins/python-build/share/python-build/graalpy-22.3.0
@@ -1,0 +1,54 @@
+# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+VERSION='22.3.0'
+BUILD=''
+
+graalpy_arch="$(graalpy_architecture 2>/dev/null || true)"
+
+case "$graalpy_arch" in
+"linux-amd64" )
+  checksum="9853036fcde0b115026d8802a4f671b62d7a17fccb269c1e8b5fbf80cef10e23"
+  ;;
+"linux-aarch64" )
+  checksum="c48c5d9ff5699046c0629181a40a3116172e1c508c851f0993dcca45d86349c0"
+  ;;
+"macos-amd64" )
+  checksum="cc8454f460b5730e778d5b8f79385cf92c39321fbf27d44bb9ca90584670f921"
+  ;;
+"macos-aarch64" )
+  checksum="9a388834f28fbb86ff9588d9a150a4d26e9bec28be06c3d60ebe20079f855e41"
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": No binary distribution of GraalPy is available for $(uname -sm)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac
+
+if [ -n "${BUILD}" ]; then
+  urlprefix="https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/${VERSION}-${BUILD}"
+else
+  urlprefix="https://github.com/oracle/graalpython/releases/download/vm-${VERSION}"
+fi
+
+install_package "graalpy-${VERSION}${BUILD}" "${urlprefix}/graalpy-${VERSION}-${graalpy_arch}.tar.gz#${checksum}" "copy" ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)

### Description
Add graalpy 22.3.0, released yesterday. Note it has been renamed upstream from GraalPython to GraalPy. We've also added support for Aarch64 and M1.

CC @timfel 
