### PR TITLE
Fix invalid syntax error in `pyenv init -` if PYENV_ROOT has spaces

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -155,7 +155,7 @@ function print_path() {
       # (SSH provides /etc/ssh/sshrc and ~/.ssh/rc for that but no-one seems to use them for some reason).
       # This has caused an infinite `bashrc` execution loop for those people in the below nested Bash invocation (#2367).
       # --norc negates this behavior of such a customized Bash.
-      echo 'PATH="$(bash --norc -xec '\''IFS=:; paths=($PATH); '
+      echo 'PATH="$(bash --norc -ec '\''IFS=:; paths=($PATH); '
       echo 'for i in ${!paths[@]}; do '
       echo 'if [[ ${paths[i]} == "'\'\'"${PYENV_ROOT}/shims"\'\''" ]]; then unset '\'\\\'\''paths[i]'\'\\\'\''; '
       echo 'fi; done; '

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -155,7 +155,11 @@ function print_path() {
       # (SSH provides /etc/ssh/sshrc and ~/.ssh/rc for that but no-one seems to use them for some reason).
       # This has caused an infinite `bashrc` execution loop for those people in the below nested Bash invocation (#2367).
       # --norc negates this behavior of such a customized Bash.
-      echo 'PATH="$(bash --norc -ec '\''IFS=:; paths=($PATH); for i in ${!paths[@]}; do if [[ ${paths[i]} == "'\'"${PYENV_ROOT}/shims"\''" ]]; then unset '\'\\\'\''paths[i]'\'\\\'\''; fi; done; echo "${paths[*]}"'\'')"'
+      echo 'PATH="$(bash --norc -xec '\''IFS=:; paths=($PATH); '
+      echo 'for i in ${!paths[@]}; do '
+      echo 'if [[ ${paths[i]} == "'\'\'"${PYENV_ROOT}/shims"\'\''" ]]; then unset '\'\\\'\''paths[i]'\'\\\'\''; '
+      echo 'fi; done; '
+      echo 'echo "${paths[*]}"'\'')"'
       echo 'export PATH="'"${PYENV_ROOT}"'/shims:${PATH}"'
       ;;
   esac


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2505

### Description
- [x] Here are some details about my PR

Quoting in the code was insufficient for a nested Bash call

### Tests
- [x] My PR adds the following unit tests (if any)
N/A