### PR TITLE
Fix mismatched quote in `latest` subcommand

### DIFF
--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -66,7 +66,7 @@ IFS=$'\n'
         echo "$DEFINITION"
     else
         if [[ -z $QUIET ]]; then
-            echo "pyenv: no $([[ -z $FROM_KNOWN ]] && echo installed || echo known) versions match the prefix \`$prefix'" >&2
+            echo "pyenv: no $([[ -z $FROM_KNOWN ]] && echo installed || echo known) versions match the prefix '$prefix'" >&2
         fi
         exitcode=1
     fi


### PR DESCRIPTION
As per title, there is a mismatched backtick and single quote. I have chosen the single quote as the more common convention.