### PR TITLE
Add Python version 3.11 to the macOS build

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -10,6 +10,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Now that 3.11 is released with pyenv 2.3.6, we should start building against it.