### PR TITLE
Add simple `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+
+# Makefiles always use tabs for indentation
+[Makefile]
+indent_style = tab
+indent_size = unset # Allow user-defined tab width


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

I saw 036fd63bbd9fea17f3363a511a264e7eaf47ce88, and I was inspired to create a very rudimentary and uncontroversial [`.editorconfig`](https://editorconfig.org) file. Although it isn't a strict check, it should limit newline problems in the future. More can be added as desired, but I don't want to impose a style that isn't already present.

### Tests
- [x] My PR adds the following unit tests (if any)
