### PR TITLE
Patch openssl 1.1.1q on macos for Python 3.8.15 and 3.9.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /src/*.o
 /bats/
 /default-packages
+.idea
+*.un~

--- a/plugins/python-build/share/python-build/patches/3.8.15/openssl-1.1.1q/openssl_1.1.1q_fix_c_include.patch
+++ b/plugins/python-build/share/python-build/patches/3.8.15/openssl-1.1.1q/openssl_1.1.1q_fix_c_include.patch
@@ -1,0 +1,12 @@
+diff --git a/test/v3ext.c b/test/v3ext.c
+index 7a240cd706..6cec6f1a9b 100644
+--- a/test/v3ext.c
++++ b/test/v3ext.c
+@@ -15,6 +15,7 @@
+ #include <openssl/err.h>
+ #include "internal/nelem.h"
+ 
++#include <string.h>
+ #include "testutil.h"
+ 
+ static const char *infile;

--- a/plugins/python-build/share/python-build/patches/3.9.15/openssl-1.1.1q/openssl_1.1.1q_fix_c_include.patch
+++ b/plugins/python-build/share/python-build/patches/3.9.15/openssl-1.1.1q/openssl_1.1.1q_fix_c_include.patch
@@ -1,0 +1,12 @@
+diff --git a/test/v3ext.c b/test/v3ext.c
+index 7a240cd706..6cec6f1a9b 100644
+--- a/test/v3ext.c
++++ b/test/v3ext.c
+@@ -15,6 +15,7 @@
+ #include <openssl/err.h>
+ #include "internal/nelem.h"
+ 
++#include <string.h>
+ #include "testutil.h"
+ 
+ static const char *infile;


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Additional fixes for: https://github.com/pyenv/pyenv/issues/2494

### Description
- [x] Here are some details about my PR
Python updated openssl to version 1.1.1q in 3.8.15, 3.9.15 and 3.11. Python 3.10.7 is at 1.1.1o.
The following PR added a patch for building openssl 1.1.1q on 3.11 but not for 3.8.15 and 3.9.15.
https://github.com/pyenv/pyenv/pull/2500
This applies the openssl 1.1.1q patches to the 3.8.15 and 3.9.15 builds of python.

### Tests
- [x] My PR adds the following unit tests (if any)
N/A