### PR TITLE
Fix resolution of a name that's a prefix of another name

### DIFF
--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -35,6 +35,12 @@ IFS=$'\n'
     else
         DEFINITION_CANDIDATES=( $(python-build --definitions ) )
     fi
+    
+    if printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | grep -qxFe "$prefix"; then
+        echo "$prefix"
+        exit $exitcode;
+    fi
+    
     # https://stackoverflow.com/questions/11856054/is-there-an-easy-way-to-pass-a-raw-string-to-grep/63483807#63483807 
     prefix_re="$(sed 's/[^\^]/[&]/g;s/[\^]/\\&/g' <<< "$prefix")"
     # FIXME: more reliable and readable would probably be to loop over them and transform in pure Bash

--- a/test/latest.bats
+++ b/test/latest.bats
@@ -64,6 +64,21 @@ pyenv: no known versions match the prefix \`3.8'
 !
 }
 
+@test "complete name resolves to itself" {
+  create_executable pyenv-versions <<!
+#!$BASH
+echo foo
+echo foo.bar
+!
+
+run pyenv-latest foo
+assert_success
+assert_output <<!
+foo
+!
+
+}
+
 @test "sort CPython" {
   create_executable pyenv-versions <<!
 #!$BASH


### PR DESCRIPTION
…name

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2519

### Description
- [x] Here are some details about my PR

Makes a complete name resolve to itself before trying to apply it as a prefix.

I hesitated to add this initially because subcommands that use `pyenv-latest` already do that -- if the prefix resolution fails, they fall back to using the original name. However, if there are 2 names like `foo` and `foo.bar`, `pyenv latest foo` undesirably succeeds.

### Tests
- [x] My PR adds the following unit tests (if any)
Test for the new use case