### PR TITLE
Support `aria2c` being a snap

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -360,12 +360,38 @@ http_head_aria2c() {
 }
 
 http_get_aria2c() {
-  local out="${2:-$(mktemp "out.XXXXXX")}"
-  if aria2c --allow-overwrite=true --no-conf=true -o "${out}" ${ARIA2_OPTS} "$1" >&4; then
+  # aria2c always treats -o argument as a relative path
+  local out dir_out;
+  if [[ -n "$2" ]]; then
+    out="$(basename $2)";
+    dir_out="$(dirname $2)";
+  else
+    out="$(mktemp "out.XXXXXX")";
+    dir_out="$TMPDIR";
+  fi
+
+  # In Ubuntu, aria2c is only available as a snap. Snaps cannot read or write /tmp
+  # (files cannot be found, any write result is silently discarded).
+  local aria2c_is_snap;
+  if [[ $(command -v aria2c) == "/snap/"* ]]; then aria2c_is_snap=1; fi
+
+  if [[ -n $aria2c_is_snap ]]; then
+    local real_dir_out="$dir_out"
+    # presumably, snaps can always write to under $HOME
+    dir_out="$HOME"
+  fi
+
+  if aria2c --allow-overwrite=true --no-conf=true -d "${dir_out}" -o "${out}" ${ARIA2_OPTS} "$1" >&4; then
     [ -n "$2" ] || cat "${out}"
   else
     false
   fi
+  ret=$?
+
+  if [[ -n "$2" && -n $aria2c_is_snap ]]; then
+      mv "$dir_out/$out" "$real_dir_out/$out"
+  fi
+  return "$ret"
 }
 
 http_head_curl() {

--- a/plugins/python-build/test/fetch.bats
+++ b/plugins/python-build/test/fetch.bats
@@ -21,7 +21,7 @@ setup() {
 @test "using aria2c if available" {
   export PYTHON_BUILD_ARIA2_OPTS=
   export -n PYTHON_BUILD_HTTP_CLIENT
-  stub aria2c "--allow-overwrite=true --no-conf=true -d * -o * http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$4"
+  stub aria2c "--allow-overwrite=true --no-conf=true -d * -o * http://example.com/* : cp $FIXTURE_ROOT/\${7##*/} \$6"
 
   install_fixture definitions/without-checksum
   assert_success

--- a/plugins/python-build/test/fetch.bats
+++ b/plugins/python-build/test/fetch.bats
@@ -21,7 +21,7 @@ setup() {
 @test "using aria2c if available" {
   export PYTHON_BUILD_ARIA2_OPTS=
   export -n PYTHON_BUILD_HTTP_CLIENT
-  stub aria2c "--allow-overwrite=true --no-conf=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$4"
+  stub aria2c "--allow-overwrite=true --no-conf=true -d * -o * http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$4"
 
   install_fixture definitions/without-checksum
   assert_success


### PR DESCRIPTION
### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2522

### Description
- [x] Here are some details about my PR

In Ubuntu, `aria2c` is only available as a snap. Snaps cannot write to `/tmp` where we download stuff
(the download succeeds as `strace` shows but the result is silently discarded).

### Tests
- [x] My PR adds the following unit tests (if any)
None