### PR TITLE
Don't set `PYENV_VERSION` in the environment of the invoked commmand

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -24,7 +24,7 @@ jobs:
       #    python-version: ${{ matrix.python-version }}
       # ... but in the repo, we want to test pyenv builds on Ubuntu
       - run: |
-          sudo apt-get install -yq make build-essential libssl-dev zlib1g-dev \
+          sudo apt update && sudo apt install -yq make build-essential libssl-dev zlib1g-dev \
           libbz2-dev libreadline-dev libsqlite3-dev curl \
           libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
       # https://github.com/pyenv/pyenv#installation

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -21,6 +21,11 @@ if [ "$1" = "--complete" ]; then
   exec pyenv-shims --short
 fi
 
+declare pyenv_version_set_by_envvar;
+if [[ $(declare -p PYENV_VERSION) =~ ^declare\ -[^[:space:]]*x[^[:space:]]*\  ]]; then
+  pyenv_version_set_by_envvar=1;
+fi
+
 PYENV_VERSION="$(pyenv-version-name)"
 PYENV_COMMAND="$1"
 
@@ -44,6 +49,13 @@ shift 1
 if [ "${PYENV_BIN_PATH#${PYENV_ROOT}}" != "${PYENV_BIN_PATH}" ]; then
   # Only add to $PATH for non-system version.
   export PATH="${PYENV_BIN_PATH}:${PATH}"
+  # Keeping PYENV_VERSION set would undesirably lock into current Python
+  # if the program launches a nested shell.
+  # For the program itself and non-shell subprocesses,
+  # setting PATH already ensures that executables from the selected
+  # version prevail over shims
+  if [[ -z $pyenv_version_set_by_envvar ]]; then
+    unset PYENV_VERSION
+  fi
 fi
-unset PYENV_VERSION
 exec "$PYENV_COMMAND_PATH" "$@"

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -45,4 +45,5 @@ if [ "${PYENV_BIN_PATH#${PYENV_ROOT}}" != "${PYENV_BIN_PATH}" ]; then
   # Only add to $PATH for non-system version.
   export PATH="${PYENV_BIN_PATH}:${PATH}"
 fi
+unset PYENV_VERSION
 exec "$PYENV_COMMAND_PATH" "$@"


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/1675

### Description
- [x] Here are some details about my PR

See https://github.com/pyenv/pyenv/issues/1675#issuecomment-1263585074 for the issue description and https://github.com/pyenv/pyenv/issues/1675#issuecomment-1263652478 for explanation.

> The reason is that Pyenv sets the `PYENV_VERSION` envvar in the environment of the executed command.

That was added in https://github.com/rbenv/rbenv/commit/8ee2f2657a088851d0aa75736c7b0305a10522f1 to ensure the selected version is used when PATH is not changed by `pyenv-exec` (e.g. for the system version).

The envvar ensures that the called subcommands are working with the correct version. AFAICS, it's not _strictly_ needed but it steamlines things -- e.g. avoids a repeated call to `pyenv-version-name`.
But when invoking the command itself, the changed PATH ensures that the right executables are getting the priority.

However, we only add one PATH entry now, for the leading version. If multiple alt versions are selected, we need to add them all to ensure correct selection with just PATH.
If `system` occurs in the middle of the list, we'll probably have to add the following entries to the _tail_ of PATH.
And probably remove `shims` from PATH, for good measure.

Team, do you think we should fix the PATH manipulation now, or wait until users complain, at which point we'll be able to obtain details on the intended behavior?

### Tests
- [ ] My PR adds the following unit tests (if any)
