### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,14 +258,14 @@ easy to fork and contribute any changes back upstream.
 
 * **Check out Pyenv where you want it installed.**
    A good place to choose is `$HOME/.pyenv` (but you can install it somewhere else):
-
-       git clone https://github.com/pyenv/pyenv.git ~/.pyenv
-
+    ```
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+    ```
 *  Optionally, try to compile a dynamic Bash extension to speed up Pyenv. Don't
    worry if it fails; Pyenv will still work normally:
-
-       cd ~/.pyenv && src/configure && make -C src
-
+    ```
+    cd ~/.pyenv && src/configure && make -C src
+    ```
 
 ### Set up your shell environment for Pyenv
 


### PR DESCRIPTION
Fix markdown because there was a space at the beginning of the `git clone` command
