### PR TITLE
Export detected shell environment in pyenv-init

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Summary: Configure the shell environment for pyenv
-# Usage: eval "$(pyenv init [-|--path] [--no-push-path] [--no-rehash] [<shell>])"
+# Usage: eval "$(pyenv init [-|--path] [--no-push-path] [--detect-shell] [--no-rehash] [<shell>])"
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
@@ -11,6 +11,7 @@ if [ "$1" = "--complete" ]; then
   echo --path
   echo --no-push-path
   echo --no-rehash
+  echo --detect-shell
   echo bash
   echo fish
   echo ksh
@@ -30,6 +31,11 @@ do
 
   if [ "$args" = "--path" ]; then
     mode="path"
+    shift
+  fi
+
+  if [ "$args" = "--detect-shell" ]; then
+    mode="detect-shell"
     shift
   fi
 
@@ -76,12 +82,17 @@ function main() {
     print_shell_function
     exit 0
     ;;
+  "detect-shell")
+    detect_profile
+    print_detect_shell
+    exit 0
+    ;;
   esac
   # should never get here
   exit 2
 }
 
-function help_() {
+function detect_profile() {
   case "$shell" in
   bash )
     if [ -e '~/.bash_profile' ]; then
@@ -105,7 +116,16 @@ function help_() {
     rc='your shell'\''s interactive startup file'
     ;;
   esac
+}
 
+function print_detect_shell() {
+  echo "PYENV_SHELL_DETECT=$shell"
+  echo "PYENV_PROFILE_DETECT=$profile"
+  echo "PYENV_RC_DETECT=$rc"
+}
+
+function help_() {
+  detect_profile
   {
     case "$shell" in
     fish )


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)

### Description
- [x] Here are some details about my PR

The automatic installer have long been requested to edit user's config files automatically(https://github.com/pyenv/pyenv-installer/issues/112).
However, logics for determining user's current shell and configuration files have already implemented in the `pyenv-init` script.
To reduce duplication, this PR enables `pyenv-init` to help detecting user's shell and config files for other scripts.
Once this PR get merged, we are able to proceed in https://github.com/pyenv/pyenv-installer/pull/137

### Tests
- [x] My PR adds the following unit tests (if any)
