### PR TITLE
Fix compilation error when building OpenSSL 1.1.1q in MacOS 11+ for 3.9.16

### DIFF
--- a/plugins/python-build/share/python-build/patches/3.9.16/openssl-1.1.1q/openssl_1.1.1q_fix_c_include.patch
+++ b/plugins/python-build/share/python-build/patches/3.9.16/openssl-1.1.1q/openssl_1.1.1q_fix_c_include.patch
@@ -1,0 +1,12 @@
+diff --git a/test/v3ext.c b/test/v3ext.c
+index 7a240cd706..6cec6f1a9b 100644
+--- a/test/v3ext.c
++++ b/test/v3ext.c
+@@ -15,6 +15,7 @@
+ #include <openssl/err.h>
+ #include "internal/nelem.h"
+ 
++#include <string.h>
+ #include "testutil.h"
+ 
+ static const char *infile;


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Additional fixes for: #2494 and #2520 

### Description
- [x] Here are some details about my PR
Python released new version of 3.9 few days ago, add support to it
### Tests
- [x] My PR adds the following unit tests (if any)
None