### PR TITLE
Add miniforge3 and mambaforge 22.9.0-2

### DIFF
--- a/plugins/python-build/share/python-build/mambaforge-22.9.0-2
+++ b/plugins/python-build/share/python-build/mambaforge-22.9.0-2
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-22.9.0-2-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-2/Mambaforge-22.9.0-2-Linux-aarch64.sh#26cf4a5cd3a3b9085f75911b459b969d6ff8ab426ef9a8e7ce3b47cc683ead86" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-22.9.0-2-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-2/Mambaforge-22.9.0-2-Linux-ppc64le.sh#e13044cdbce8542896dd8b7128a00b691c119e7ad6e872c7de93ec9954b4775d" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-22.9.0-2-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-2/Mambaforge-22.9.0-2-Linux-x86_64.sh#d2bb6c33f2373131fc71283baae9eb81a279708d007e55d627d85abe30c2d0eb" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-22.9.0-2-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-2/Mambaforge-22.9.0-2-MacOSX-arm64.sh#21959f1a17a662b3f260e8b04fe2dfe82f1246746875a72f513d39159d8b816b" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-22.9.0-2-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-2/Mambaforge-22.9.0-2-MacOSX-x86_64.sh#844fc1ac61967990f0cfb9e516e8b0704ac2e500854588fd9851d2790d817bab" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-22.9.0-2
+++ b/plugins/python-build/share/python-build/miniforge3-22.9.0-2
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-22.9.0-2-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-2/Miniforge3-22.9.0-2-Linux-aarch64.sh#3d75758c4d98181946b29d391323209752c5a111530738b5e36eba77e8e026aa" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-22.9.0-2-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-2/Miniforge3-22.9.0-2-Linux-ppc64le.sh#e84ffc9f018d5b23601106f299fefd25a75afb6fdd3416037ce4b561781156fc" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-22.9.0-2-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-2/Miniforge3-22.9.0-2-Linux-x86_64.sh#180aefcbcf8a9f24123adb9e64e16c9bb16bc3f129bd79a5912ff44f295cc405" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-22.9.0-2-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-2/Miniforge3-22.9.0-2-MacOSX-arm64.sh#6ac610dabf9a64574ec83b158b2eb6023bc3de0de9a0c528d4fa876df2a27d13" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-22.9.0-2-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-2/Miniforge3-22.9.0-2-MacOSX-x86_64.sh#d7f50abd340f63515b2059ed462548f5d395e2f9d7847a98c5428998504f5bff" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
These are available, but only as the latest (rolling) version, thanks to https://github.com/pyenv/pyenv/pull/2019. However, it's also useful to be able to get these more recent versions specifically, so we can pin them.

I am not sure how to comprehensively test this, but it works on my machine 😃 

```shell
$ bin/pyenv install miniforge3-22.9.0-2
Downloading Miniforge3-22.9.0-2-Linux-x86_64.sh.sh...
-> https://github.com/conda-forge/miniforge/releases/download/22.9.0-2/Miniforge3-22.9.0-2-Linux-x86_64.sh
Installing Miniforge3-22.9.0-2-Linux-x86_64.sh...
Collecting package metadata (current_repodata.json): done
Solving environment: done


==> WARNING: A newer version of conda exists. <==
  current version: 22.9.0
  latest version: 22.11.1

Please update conda by running

    $ conda update -n base -c conda-forge conda



## Package Plan ##

  environment location: /home/smcgivern/.pyenv/versions/miniforge3-22.9.0-2

  added / updated specs:
    - conda=22.9.0
    - pip


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    ca-certificates-2022.12.7  |       ha878542_0         143 KB  conda-forge
    certifi-2022.12.7          |     pyhd8ed1ab_0         147 KB  conda-forge
    openssl-3.0.7              |       h0b41bf4_1         2.5 MB  conda-forge
    ------------------------------------------------------------
                                           Total:         2.8 MB

The following packages will be UPDATED:

  ca-certificates                      2022.9.24-ha878542_0 --> 2022.12.7-ha878542_0 None
  certifi                            2022.9.24-pyhd8ed1ab_0 --> 2022.12.7-pyhd8ed1ab_0 None
  openssl                                  3.0.7-h166bdaf_0 --> 3.0.7-h0b41bf4_1 None



Downloading and Extracting Packages
ca-certificates-2022 | 143 KB    | : 100% 1.0/1 [00:00<00:00,  2.99it/s]
certifi-2022.12.7    | 147 KB    | : 100% 1.0/1 [00:00<00:00,  4.97it/s]
openssl-3.0.7        | 2.5 MB    | : 100% 1.0/1 [00:00<00:00,  1.78it/s]
Preparing transaction: done
Verifying transaction: done
Executing transaction: done
Retrieving notices: ...working... done
Installed Miniforge3-22.9.0-2-Linux-x86_64.sh to /home/smcgivern/.pyenv/versions/miniforge3-22.9.0-2

$ bin/pyenv local miniforge3-22.9.0-2
$ python3 -V
Python 3.10.6
$ bin/pyenv which python3
/home/smcgivern/.pyenv/versions/miniforge3-22.9.0-2/bin/python3
```

I also have a script similar to https://github.com/pyenv/pyenv/blob/master/plugins/python-build/scripts/add_miniconda.py that I used to add this. I can submit that in a separate PR if needed.

- - -

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
