### PR TITLE
Fix non-bash output while detecting shell

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -22,7 +22,6 @@ fi
 mode="help"
 no_rehash=""
 no_push_path=""
-no_config_place_holder=""
 for args in "$@"
 do
   if [ "$args" = "-" ]; then
@@ -37,7 +36,6 @@ do
 
   if [ "$args" = "--detect-shell" ]; then
     mode="detect-shell"
-    no_config_place_holder=1
     shift
   fi
 
@@ -45,7 +43,7 @@ do
     no_push_path=1
     shift
   fi
-  
+
   if [ "$args" = "--no-rehash" ]; then
     no_rehash=1
     shift
@@ -85,7 +83,7 @@ function main() {
     exit 0
     ;;
   "detect-shell")
-    detect_profile
+    detect_profile false
     print_detect_shell
     exit 0
     ;;
@@ -95,6 +93,8 @@ function main() {
 }
 
 function detect_profile() {
+  local use_place_holder="${1:-true}"
+
   case "$shell" in
   bash )
     if [ -e '~/.bash_profile' ]; then
@@ -114,14 +114,12 @@ function detect_profile() {
     rc='~/.profile'
     ;;
   * )
-    # if no_config_place_holder is set,
-    # do not filled in any placehodler for config file
-    if [ -n "$no_config_place_holder" ]; then
-      profile='""'
-      rc='""'
-    else
+    if [ "$use_place_holder" = true ]; then
       profile='your shell'\''s login startup file'
       rc='your shell'\''s interactive startup file'
+    else
+      profile='""'
+      rc='""'
     fi
     ;;
   esac

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -43,7 +43,7 @@ do
     no_push_path=1
     shift
   fi
-
+  
   if [ "$args" = "--no-rehash" ]; then
     no_rehash=1
     shift

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -83,7 +83,7 @@ function main() {
     exit 0
     ;;
   "detect-shell")
-    detect_profile false
+    detect_profile 1
     print_detect_shell
     exit 0
     ;;
@@ -93,7 +93,7 @@ function main() {
 }
 
 function detect_profile() {
-  local use_place_holder="${1:-true}"
+  local detect_for_detect_shell="$1"
 
   case "$shell" in
   bash )
@@ -114,12 +114,12 @@ function detect_profile() {
     rc='~/.profile'
     ;;
   * )
-    if [ "$use_place_holder" = true ]; then
+    if [ -n "$detect_for_detect_shell" ]; then
+      profile=
+      rc=
+    else
       profile='your shell'\''s login startup file'
       rc='your shell'\''s interactive startup file'
-    else
-      profile='""'
-      rc='""'
     fi
     ;;
   esac

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -22,6 +22,7 @@ fi
 mode="help"
 no_rehash=""
 no_push_path=""
+no_config_place_holder=""
 for args in "$@"
 do
   if [ "$args" = "-" ]; then
@@ -36,6 +37,7 @@ do
 
   if [ "$args" = "--detect-shell" ]; then
     mode="detect-shell"
+    no_config_place_holder=1
     shift
   fi
 
@@ -112,8 +114,15 @@ function detect_profile() {
     rc='~/.profile'
     ;;
   * )
-    profile='your shell'\''s login startup file'
-    rc='your shell'\''s interactive startup file'
+    # if no_config_place_holder is set,
+    # do not filled in any placehodler for config file
+    if [ -n "$no_config_place_holder" ]; then
+      profile='""'
+      rc='""'
+    else
+      profile='your shell'\''s login startup file'
+      rc='your shell'\''s interactive startup file'
+    fi
     ;;
   esac
 }

--- a/test/init.bats
+++ b/test/init.bats
@@ -63,6 +63,12 @@ OUT
   assert_line 'pyenv init - | source'
 }
 
+@test "shell detection for installer" {
+  run pyenv-init --detect-shell
+  assert_success
+  assert_line "PYENV_SHELL_DETECT=bash"
+}
+
 @test "option to skip rehash" {
   run pyenv-init - --no-rehash
   assert_success


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.

### Description
- [x] Here are some details about my PR
`pyenv-init --detect-shell` will output non-bash script result while configuration files are not supported, since placeholder values are used for explanation.

### Tests
Test for the new function.