### PR TITLE
Remove stray newline after python-build installation

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -233,9 +233,7 @@ install_package_using() {
   make_package "${make_args[@]}"
   popd >&4
 
-  { echo "Installed ${package_name} to ${PREFIX_PATH}"
-    echo
-  } >&2
+  echo "Installed ${package_name} to ${PREFIX_PATH}" >&2
 }
 
 make_package() {


### PR DESCRIPTION
This makes the output look slightly odd:

```
$ pyenv install 3.10.9
python-build: use openssl@1.1 from homebrew
python-build: use readline from homebrew
Downloading Python-3.10.9.tar.xz...
-> https://www.python.org/ftp/python/3.10.9/Python-3.10.9.tar.xz
Installing Python-3.10.9...
python-build: use readline from homebrew
python-build: use zlib from xcode sdk
Installed Python-3.10.9 to /Users/tklauser/.pyenv/versions/3.10.9

$
```

Remove the stray newline to match other pyenv commands.

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - None

### Description
- [x] Here are some details about my PR
  - Fixes a stray newline at the end of `pyenv install ...` when installing using `python-build`.

### Tests
- [x] My PR adds the following unit tests (if any)
  - None
