### PR TITLE
Allow multiple versions for pyenv-install

### DIFF
--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -2,7 +2,7 @@
 #
 # Summary: Install a Python version using python-build
 #
-# Usage: pyenv install [-f] [-kvp] <version>
+# Usage: pyenv install [-f] [-kvp] <version>...
 #        pyenv install [-f] [-kvp] <definition-file>
 #        pyenv install -l|--list
 #        pyenv install --version
@@ -113,17 +113,15 @@ for option in "${OPTIONS[@]}"; do
   esac
 done
 
-[ "${#ARGUMENTS[@]}" -le 1 ] || usage 1 >&2
-
 unset VERSION_NAME
 
 # The first argument contains the definition to install. If the
 # argument is missing, try to install whatever local app-specific
 # version is specified by pyenv. Show usage instructions if a local
 # version is not specified.
-DEFINITION="${ARGUMENTS[0]}"
-[ -n "$DEFINITION" ] || DEFINITION="$(pyenv-local 2>/dev/null || true)"
-[ -n "$DEFINITION" ] || usage 1 >&2
+DEFINITIONS=("${ARGUMENTS[@]}")
+[ -n "${DEFINITIONS[*]}" ] || DEFINITIONS=($(pyenv-local 2>/dev/null || true))
+[ -n "${DEFINITIONS[*]}" ] || usage 1 >&2
 
 # Define `before_install` and `after_install` functions that allow
 # plugin hooks to register a string of code for execution before or
@@ -140,106 +138,6 @@ after_install() {
   after_hooks["${#after_hooks[@]}"]="$hook"
 }
 
-OLDIFS="$IFS"
-IFS=$'\n' scripts=(`pyenv-hooks install`)
-IFS="$OLDIFS"
-for script in "${scripts[@]}"; do source "$script"; done
-
-# Try to resolve a prefix if user indeed gave a prefix.
-# We install the version under the resolved name
-# and hooks also see the resolved name
-DEFINITION="$(pyenv-latest -q -k "$DEFINITION" || echo "$DEFINITION")"
-
-# Set VERSION_NAME from $DEFINITION, if it is not already set. Then
-# compute the installation prefix.
-[ -n "$VERSION_NAME" ] || VERSION_NAME="${DEFINITION##*/}"
-[ -n "$DEBUG" ] && VERSION_NAME="${VERSION_NAME}-debug"
-PREFIX="${PYENV_ROOT}/versions/${VERSION_NAME}"
-
-[ -d "${PREFIX}" ] && PREFIX_EXISTS=1
-
-# If the installation prefix exists, prompt for confirmation unless
-# the --force option was specified.
-if [ -d "${PREFIX}/bin" ]; then
-  if [ -z "$FORCE" ] && [ -z "$SKIP_EXISTING" ]; then
-    echo "pyenv: $PREFIX already exists" >&2
-    read -p "continue with installation? (y/N) "
-
-    case "$REPLY" in
-    y | Y | yes | YES ) ;;
-    * ) exit 1 ;;
-    esac
-  elif [ -n "$SKIP_EXISTING" ]; then
-    # Since we know the python version is already installed, and are opting to
-    # not force installation of existing versions, we just `exit 0` here to
-    # leave things happy
-    exit 0
-  fi
-fi
-
-# If PYENV_BUILD_ROOT is set, always pass keep options to python-build.
-if [ -n "${PYENV_BUILD_ROOT}" ]; then
-  export PYTHON_BUILD_BUILD_PATH="${PYENV_BUILD_ROOT}/${VERSION_NAME}"
-  KEEP="-k"
-fi
-
-# Set PYTHON_BUILD_CACHE_PATH to $PYENV_ROOT/cache, if the directory
-# exists and the variable is not already set.
-if [ -z "${PYTHON_BUILD_CACHE_PATH}" ] && [ -d "${PYENV_ROOT}/cache" ]; then
-  export PYTHON_BUILD_CACHE_PATH="${PYENV_ROOT}/cache"
-fi
-
-if [ -z "${PYENV_BOOTSTRAP_VERSION}" ]; then
-  case "${VERSION_NAME}" in
-  [23]"."* )
-    # Default PYENV_VERSION to the friendly Python version. (The
-    # CPython installer requires an existing Python installation to run. An
-    # unsatisfied local .python-version file can cause the installer to
-    # fail.)
-    for version_info in "${VERSION_NAME%-dev}" "${VERSION_NAME%.*}" "${VERSION_NAME%%.*}"; do
-      # Anaconda's `curl` doesn't work on platform where `/etc/pki/tls/certs/ca-bundle.crt` isn't available (e.g. Debian)
-      for version in $(pyenv-whence "python${version_info}" 2>/dev/null || true); do
-        if [[ "${version}" != "anaconda"* ]] && [[ "${version}" != "miniconda"* ]]; then
-          PYENV_BOOTSTRAP_VERSION="${version}"
-          break 2
-        fi
-      done
-    done
-    ;;
-  "pypy"*"-dev" | "pypy"*"-src" )
-    # PyPy/PyPy3 requires existing Python 2.7 to build
-    if [ -n "${PYENV_RPYTHON_VERSION}" ]; then
-      PYENV_BOOTSTRAP_VERSION="${PYENV_RPYTHON_VERSION}"
-    else
-      for version in $(pyenv-versions --bare | sort -r); do
-        if [[ "${version}" == "2.7"* ]]; then
-          PYENV_BOOTSTRAP_VERSION="$version"
-          break
-        fi
-      done
-    fi
-    if [ -n "$PYENV_BOOTSTRAP_VERSION" ]; then
-      for dep in pycparser; do
-        if ! PYENV_VERSION="$PYENV_BOOTSTRAP_VERSION" pyenv-exec python -c "import ${dep}" 1>/dev/null 2>&1; then
-          echo "pyenv-install: $VERSION_NAME: PyPy requires \`${dep}' in $PYENV_BOOTSTRAP_VERSION to build from source." >&2
-          exit 1
-        fi
-      done
-    else
-      echo "pyenv-install: $VERSION_NAME: PyPy requires Python 2.7 to build from source." >&2
-      exit 1
-    fi
-    ;;
-  esac
-fi
-
-if [ -n "${PYENV_BOOTSTRAP_VERSION}" ]; then
-  export PYENV_VERSION="${PYENV_BOOTSTRAP_VERSION}"
-fi
-
-# Execute `before_install` hooks.
-for hook in "${before_hooks[@]}"; do eval "$hook"; done
-
 # Plan cleanup on unsuccessful installation.
 cleanup() {
   [ -z "${PREFIX_EXISTS}" ] && rm -rf "$PREFIX"
@@ -247,43 +145,147 @@ cleanup() {
 
 trap cleanup SIGINT
 
-# Invoke `python-build` and record the exit status in $STATUS.
-STATUS=0
-python-build $KEEP $VERBOSE $HAS_PATCH $DEBUG "$DEFINITION" "$PREFIX" || STATUS="$?"
 
-# Display a more helpful message if the definition wasn't found.
-if [ "$STATUS" == "2" ]; then
-  { candidates="$(definitions "$DEFINITION")"
-    here="$(dirname "${0%/*}")/../.."
-    if [ -n "$candidates" ]; then
+OLDIFS="$IFS"
+IFS=$'\n' scripts=(`pyenv-hooks install`)
+IFS="$OLDIFS"
+for script in "${scripts[@]}"; do source "$script"; done
+
+for DEFINITION in "${DEFINITIONS[@]}";do
+  # Try to resolve a prefix if user indeed gave a prefix.
+  # We install the version under the resolved name
+  # and hooks also see the resolved name
+  DEFINITION="$(pyenv-latest -q -k "$DEFINITION" || echo "$DEFINITION")"
+
+  # Set VERSION_NAME from $DEFINITION. Then compute the installation prefix.
+  VERSION_NAME="${DEFINITION##*/}"
+  [ -n "$DEBUG" ] && VERSION_NAME="${VERSION_NAME}-debug"
+  PREFIX="${PYENV_ROOT}/versions/${VERSION_NAME}"
+
+  [ -d "${PREFIX}" ] && PREFIX_EXISTS=1
+
+  # If the installation prefix exists, prompt for confirmation unless
+  # the --force option was specified.
+  if [ -d "${PREFIX}/bin" ]; then
+    if [ -z "$FORCE" ] && [ -z "$SKIP_EXISTING" ]; then
+      echo "pyenv: $PREFIX already exists" >&2
+      read -p "continue with installation? (y/N) "
+
+      case "$REPLY" in
+      y | Y | yes | YES ) ;;
+      * ) exit 1 ;;
+      esac
+    elif [ -n "$SKIP_EXISTING" ]; then
+      # Since we know the python version is already installed, and are opting to
+      # not force installation of existing versions, we just `exit 0` here to
+      # leave things happy
+      continue
+    fi
+  fi
+
+  # If PYENV_BUILD_ROOT is set, always pass keep options to python-build.
+  if [ -n "${PYENV_BUILD_ROOT}" ]; then
+    export PYTHON_BUILD_BUILD_PATH="${PYENV_BUILD_ROOT}/${VERSION_NAME}"
+    KEEP="-k"
+  fi
+
+  # Set PYTHON_BUILD_CACHE_PATH to $PYENV_ROOT/cache, if the directory
+  # exists and the variable is not already set.
+  if [ -z "${PYTHON_BUILD_CACHE_PATH}" ] && [ -d "${PYENV_ROOT}/cache" ]; then
+    export PYTHON_BUILD_CACHE_PATH="${PYENV_ROOT}/cache"
+  fi
+
+  if [ -z "${PYENV_BOOTSTRAP_VERSION}" ]; then
+    case "${VERSION_NAME}" in
+    [23]"."* )
+      # Default PYENV_VERSION to the friendly Python version. (The
+      # CPython installer requires an existing Python installation to run. An
+      # unsatisfied local .python-version file can cause the installer to
+      # fail.)
+      for version_info in "${VERSION_NAME%-dev}" "${VERSION_NAME%.*}" "${VERSION_NAME%%.*}"; do
+        # Anaconda's `curl` doesn't work on platform where `/etc/pki/tls/certs/ca-bundle.crt` isn't available (e.g. Debian)
+        for version in $(pyenv-whence "python${version_info}" 2>/dev/null || true); do
+          if [[ "${version}" != "anaconda"* ]] && [[ "${version}" != "miniconda"* ]]; then
+            PYENV_BOOTSTRAP_VERSION="${version}"
+            break 2
+          fi
+        done
+      done
+      ;;
+    "pypy"*"-dev" | "pypy"*"-src" )
+      # PyPy/PyPy3 requires existing Python 2.7 to build
+      if [ -n "${PYENV_RPYTHON_VERSION}" ]; then
+        PYENV_BOOTSTRAP_VERSION="${PYENV_RPYTHON_VERSION}"
+      else
+        for version in $(pyenv-versions --bare | sort -r); do
+          if [[ "${version}" == "2.7"* ]]; then
+            PYENV_BOOTSTRAP_VERSION="$version"
+            break
+          fi
+        done
+      fi
+      if [ -n "$PYENV_BOOTSTRAP_VERSION" ]; then
+        for dep in pycparser; do
+          if ! PYENV_VERSION="$PYENV_BOOTSTRAP_VERSION" pyenv-exec python -c "import ${dep}" 1>/dev/null 2>&1; then
+            echo "pyenv-install: $VERSION_NAME: PyPy requires \`${dep}' in $PYENV_BOOTSTRAP_VERSION to build from source." >&2
+            exit 1
+          fi
+        done
+      else
+        echo "pyenv-install: $VERSION_NAME: PyPy requires Python 2.7 to build from source." >&2
+        exit 1
+      fi
+      ;;
+    esac
+  fi
+
+  if [ -n "${PYENV_BOOTSTRAP_VERSION}" ]; then
+    export PYENV_VERSION="${PYENV_BOOTSTRAP_VERSION}"
+  fi
+
+  # Execute `before_install` hooks.
+  for hook in "${before_hooks[@]}"; do eval "$hook"; done
+
+  # Invoke `python-build` and record the exit status in $STATUS.
+  STATUS=0
+  python-build $KEEP $VERBOSE $HAS_PATCH $DEBUG "$DEFINITION" "$PREFIX" || STATUS="$?"
+
+  # Display a more helpful message if the definition wasn't found.
+  if [ "$STATUS" == "2" ]; then
+    { candidates="$(definitions "$DEFINITION")"
+      here="$(dirname "${0%/*}")/../.."
+      if [ -n "$candidates" ]; then
+        echo
+        echo "The following versions contain \`$DEFINITION' in the name:"
+        echo "$candidates" | indent
+      fi
       echo
-      echo "The following versions contain \`$DEFINITION' in the name:"
-      echo "$candidates" | indent
-    fi
-    echo
-    echo "See all available versions with \`pyenv install --list'."
-    echo
-    echo -n "If the version you need is missing, try upgrading pyenv"
-    if [ "$here" != "${here#$(brew --prefix 2>/dev/null)}" ]; then
-      printf ":\n\n"
-      echo "  brew update && brew upgrade pyenv"
-    elif [ -d "${here}/.git" ]; then
-      printf ":\n\n"
-      echo "  cd ${here} && git pull && cd -"
-    else
-      printf ".\n"
-    fi
-  } >&2
-fi
+      echo "See all available versions with \`pyenv install --list'."
+      echo
+      echo -n "If the version you need is missing, try upgrading pyenv"
+      if [ "$here" != "${here#$(brew --prefix 2>/dev/null)}" ]; then
+        printf ":\n\n"
+        echo "  brew update && brew upgrade pyenv"
+      elif [ -d "${here}/.git" ]; then
+        printf ":\n\n"
+        echo "  cd ${here} && git pull && cd -"
+      else
+        printf ".\n"
+      fi
+    } >&2
+  fi
 
-# Execute `after_install` hooks.
-for hook in "${after_hooks[@]}"; do eval "$hook"; done
+  # Execute `after_install` hooks.
+  for hook in "${after_hooks[@]}"; do eval "$hook"; done
 
-# Run `pyenv-rehash` after a successful installation.
-if [ "$STATUS" == "0" ]; then
-  pyenv-rehash
-else
-  cleanup
-fi
+  # Run `pyenv-rehash` after a successful installation.
+  if [ "$STATUS" == "0" ]; then
+    pyenv-rehash
+  else
+    break
+    cleanup
+  fi
 
-exit "$STATUS"
+done
+
+exit "${STATUS:-0}"

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -10,7 +10,7 @@ setup() {
 
 stub_python_build() {
   stub python-build "--lib : $BATS_TEST_DIRNAME/../bin/python-build --lib" "$@"
-  stub pyenv-latest " : false"
+  stub pyenv-latest ": false"
 }
 
 @test "install proper" {
@@ -20,6 +20,26 @@ stub_python_build() {
   assert_success "python-build 3.4.2 ${PYENV_ROOT}/versions/3.4.2"
 
   unstub python-build
+  unstub pyenv-hooks
+  unstub pyenv-rehash
+}
+
+@test "install proper multi versions" {
+  #stub python-build "--lib : $BATS_TEST_DIRNAME/../bin/python-build --lib" 'echo python-build "$@"' 'echo python-build "$@"'
+  #stub pyenv-latest ": false" ": false"
+  stub_python_build 'echo python-build "$@"' 'echo python-build "$@"'
+  stub pyenv-latest ": false"
+  stub pyenv-rehash 'true'
+
+  run pyenv-install 3.4.1 3.4.2
+  assert_success
+  assert_output <<OUT
+python-build 3.4.1 ${TMP}/pyenv/versions/3.4.1
+python-build 3.4.2 ${TMP}/pyenv/versions/3.4.2
+OUT
+
+  unstub python-build
+  unstub pyenv-latest
   unstub pyenv-hooks
   unstub pyenv-rehash
 }
@@ -37,12 +57,45 @@ stub_python_build() {
   unstub pyenv-rehash
 }
 
+@test "install resolves a prefix with multi versions" {
+  stub_python_build 'echo python-build "$@"' 'echo python-build "$@"'
+  stub pyenv-latest '-q -k 3.4 : echo 3.4.2' '-q -k 3.5 : echo 3.5.2'
+  stub pyenv-rehash 'true'
+  pyenv-latest || true  # pass through the stub entry added by stub_python_build
+
+  run pyenv-install 3.4 3.5
+  assert_success <<OUT
+python-build 3.4.2 ${PYENV_ROOT}/versions/3.4.2
+python-build 3.5.2 ${PYENV_ROOT}/versions/3.5.2
+OUT
+
+
+  unstub python-build
+  unstub pyenv-hooks
+  unstub pyenv-rehash
+}
+
 @test "install pyenv local version by default" {
   stub_python_build 'echo python-build "$1"'
   stub pyenv-local 'echo 3.4.2'
 
   run pyenv-install
   assert_success "python-build 3.4.2"
+
+  unstub python-build
+  unstub pyenv-local
+}
+
+@test "install pyenv local multi versions by default" {
+  stub_python_build 'echo python-build "$1"' 'echo python-build "$1"'
+  stub pyenv-local 'printf "%s\n%s\n" 3.4.2 3.4.1'
+  stub pyenv-latest ": false"
+
+  run pyenv-install
+  assert_success <<OUT
+python-build 3.4.2"
+python-build 3.4.1"
+OUT
 
   unstub python-build
   unstub pyenv-local
@@ -169,22 +222,23 @@ ${PYENV_ROOT}/plugins/foo/share/python-build
 OUT
 }
 
-@test "not enough arguments for pyenv-install" {
+@test "not enough arguments for pyenv-install if no local version" {
   stub_python_build
   stub pyenv-help 'install : true'
 
   run pyenv-install
   assert_failure
   unstub pyenv-help
+  assert_output ""
 }
 
-@test "too many arguments for pyenv-install" {
+@test "multi arguments for pyenv-install" {
   stub_python_build
   stub pyenv-help 'install : true'
 
   run pyenv-install 3.4.1 3.4.2
-  assert_failure
-  unstub pyenv-help
+  assert_success
+  assert_output ""
 }
 
 @test "show help for pyenv-install" {


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [X] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [X] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [X] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/919

### Description
As stated in #919, many of the users (as me) expect to have pyenv to install all versions specified in `.python-version` and have `pyenv install` works the same way as `pyenv local` works

### Tests
- [X] My PR adds the following unit tests (if any)
  - `install proper multi versions`
  - `install resolves a prefix with multi versions`
  - `install pyenv local multi versions by default`
  - `multi arguments for pyenv-install`
- [X] My PR remove the following unit tests (if any)
  - `too many arguments for pyenv-install`
    - replaced by  `multi arguments for pyenv-install` since user could specify multi versions now