### PR TITLE
Add miniconda 22.11.1-1

### DIFF
--- a/plugins/python-build/scripts/add_miniconda.py
+++ b/plugins/python-build/scripts/add_miniconda.py
@@ -121,7 +121,7 @@ class PyVersion(StrEnum):
 @total_ordering
 class VersionStr(str):
     def info(self):
-        return tuple(int(n) for n in self.split("."))
+        return tuple(int(n) for n in self.replace("-", ".").split("."))
 
     def __eq__(self, other):
         return str(self) == str(other)
@@ -214,7 +214,10 @@ class CondaSpec(NamedTuple):
 
     @classmethod
     def from_filestem(cls, stem, md5, repo, py_version=None):
-        miniconda_n, ver, os, arch = stem.split("-")
+        # The `*vers` captures the new trailing `-1` in some file names (a build number?)
+        # so they can be processed properly.
+        miniconda_n, *vers, os, arch = stem.split("-")
+        ver = "-".join(vers)
         suffix = miniconda_n[-1]
         if suffix in string.digits:
             tflavor = miniconda_n[:-1]
@@ -372,7 +375,7 @@ if __name__ == "__main__":
             reason = "already exists"
         elif key.version_str.info() <= (4, 3, 30):
             reason = "too old"
-        elif len(key.version_str.info()) >= 4:
+        elif len(key.version_str.info()) >= 4 and "-" not in key.version_str:
             reason = "ignoring hotfix releases"
         
         if reason:

--- a/plugins/python-build/scripts/add_miniconda.py
+++ b/plugins/python-build/scripts/add_miniconda.py
@@ -108,6 +108,7 @@ class PyVersion(StrEnum):
     PY37 = "py37"
     PY38 = "py38"
     PY39 = "py39"
+    PY310 = "py310"
 
     def version(self):
         first, *others = self.value[2:]

--- a/plugins/python-build/share/python-build/miniconda3-3.10-22.11.1-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.10-22.11.1-1
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py310_22.11.1-1-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_22.11.1-1-Linux-aarch64.sh#48a96df9ff56f7421b6dd7f9f71d548023847ba918c3826059918c08326c2017" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py310_22.11.1-1-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py310_22.11.1-1-Linux-ppc64le.sh#4c86c3383bb27b44f7059336c3a46c34922df42824577b93eadecefbf7423836" "miniconda" verify_py310
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py310_22.11.1-1-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py310_22.11.1-1-Linux-s390x.sh#a150511e7fd19d07b770f278fb5dd2df4bc24a8f55f06d6274774f209a36c766" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py310_22.11.1-1-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_22.11.1-1-Linux-x86_64.sh#00938c3534750a0e4069499baf8f4e6dc1c2e471c86a59caa0dd03f4a9269db6" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py310_22.11.1-1-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_22.11.1-1-MacOSX-arm64.sh#22eec9b7d3add25ac3f9b60621d8f3d8df3e63d4aa0ae5eb846b558d7ba68333" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py310_22.11.1-1-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_22.11.1-1-MacOSX-x86_64.sh#7406579393427eaf9bc0e094dcd3c66d1e1b93ee9db4e7686d0a72ea5d7c0ce5" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.7-22.11.1-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.7-22.11.1-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py37_22.11.1-1-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_22.11.1-1-Linux-aarch64.sh#ebba2f7e33ce5594c50e6422477106e6bb327310838fbac3db89d2eaebcde943" "miniconda" verify_py37
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py37_22.11.1-1-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py37_22.11.1-1-Linux-ppc64le.sh#dda16ae14992697e3c90b56fe9de819f5f3b1dcb3ac7a31d24ab5736ccd5f129" "miniconda" verify_py37
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py37_22.11.1-1-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py37_22.11.1-1-Linux-s390x.sh#3c71628865164c3f8b461f8e4b2a353ff1367eed61c83b9c3e14fc201608b1a7" "miniconda" verify_py37
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py37_22.11.1-1-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_22.11.1-1-Linux-x86_64.sh#22b14d52265b4e609c6ce78e2f2884b277d976b83b5f9c8a83423e3eba2ccfbe" "miniconda" verify_py37
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py37_22.11.1-1-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py37_22.11.1-1-MacOSX-x86_64.sh#e51d459aae45bb6b86c2716738b778b788785e6e1ea4b2ed244a0fdd754feb19" "miniconda" verify_py37
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.8-22.11.1-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.8-22.11.1-1
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py38_22.11.1-1-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_22.11.1-1-Linux-aarch64.sh#ff65684bce7a7ad7abb698ff649195816ee0f47a4f17cb9632a44abf69357ea5" "miniconda" verify_py38
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py38_22.11.1-1-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py38_22.11.1-1-Linux-ppc64le.sh#59fd0901f9fa1ba6b07e734adff4d6c5215e9d7f13ad37f0044af22e9b72194a" "miniconda" verify_py38
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py38_22.11.1-1-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py38_22.11.1-1-Linux-s390x.sh#5bdc6ead307c098b32ba8473b7cbbe87eb80f8eca9adba03f47848bcb34a9b38" "miniconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py38_22.11.1-1-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_22.11.1-1-Linux-x86_64.sh#473e5ecc8e078e9ef89355fbca21f8eefa5f9081544befca99867c7beac3150d" "miniconda" verify_py38
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py38_22.11.1-1-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_22.11.1-1-MacOSX-arm64.sh#bf75dbf193db6895c62b2bb963cab2534a8bbdf0ac956f270da8d7a19f4d1b54" "miniconda" verify_py38
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py38_22.11.1-1-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_22.11.1-1-MacOSX-x86_64.sh#6c4cea3c355326f503d15ae97e5126437529a595499e3ce304cd0f247e935da8" "miniconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.9-22.11.1-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-22.11.1-1
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py39_22.11.1-1-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-Linux-aarch64.sh#031b6c52060bb75e930846c0a66baa91db8196f0d97fd32f3822c54db6b7c76a" "miniconda" verify_py39
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py39_22.11.1-1-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-Linux-ppc64le.sh#16cc2d74644cf838d2761723c01172e0b704674317630480902ef429af29bd0b" "miniconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py39_22.11.1-1-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-Linux-s390x.sh#ed6176aa6b52e22d939ea5c0c38f9f3cf52d2519a5d0dcb414936287893a31f9" "miniconda" verify_py39
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py39_22.11.1-1-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-Linux-x86_64.sh#e685005710679914a909bfb9c52183b3ccc56ad7bb84acc861d596fcbe5d28bb" "miniconda" verify_py39
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py39_22.11.1-1-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-MacOSX-arm64.sh#eca5e241faea19d4b352aba819f99f42e2336fdbeecb04f5bc89c9ca786ea798" "miniconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py39_22.11.1-1-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-MacOSX-x86_64.sh#9a537f3a1b472098754c59a30b94822f1e9458405af831172aaa8f8124e9df88" "miniconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
I used `add_miniconda.py` to generate installation files for miniconda `22.11.1-1`. I needed to change the conda version processing logic to handle this.

In addition, I realized that `add_miniconda.py` was missing support for Python 3.10, so I added it as an acceptable Python version.

---

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)
