### PR TITLE
Fix using dependencies from Ports in BSD

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1416,20 +1416,20 @@ use_freebsd_pkg() {
   if [ "FreeBSD" = "$(uname -s)" ]; then
     # use openssl if installed from Ports Collection
     if [ -f /usr/local/include/openssl/ssl.h ]; then
-      package_option ruby configure --with-openssl-dir="/usr/local"
+      package_option python configure --with-openssl-dir="/usr/local"
     fi
 
     # check if 11-R or later
     release="$(uname -r)"
     if [ "${release%%.*}" -ge 11 ]; then
-      # prefers readline to compile most of ruby versions
+      # prefers readline to compile most of python versions
       if pkg info -e readline > /dev/null; then
         # use readline from Ports Collection
-        package_option ruby configure --with-readline-dir="/usr/local"
+        package_option python configure --with-readline-dir="/usr/local"
       elif pkg info -e libedit > /dev/null; then
         # use libedit from Ports Collection
-        package_option ruby configure --enable-libedit
-        package_option ruby configure --with-libedit-dir="/usr/local"
+        package_option python configure --enable-libedit
+        package_option python configure --with-libedit-dir="/usr/local"
       fi
     fi
   fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2585

### Description
- [x] Here are some details about my PR

It looks like this part of the code was never adapted from Rbenv...

### Tests
- [x] My PR adds the following unit tests (if any)
N/A