### PR TITLE
Add CPython 3.12.0a4

### DIFF
--- a/plugins/python-build/share/python-build/3.12.0a4
+++ b/plugins/python-build/share/python-build/3.12.0a4
@@ -3,7 +3,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.12.0a3" "https://www.python.org/ftp/python/3.12.0/Python-3.12.0a3.tar.xz#1b64b3075e0a9241974e580e09b09c9117a1c4e2be698039201ef1d8a73453d1" standard verify_py312 copy_python_gdb ensurepip
+    install_package "Python-3.12.0a4" "https://www.python.org/ftp/python/3.12.0/Python-3.12.0a4.tar.xz#b9176c46b1cd21dbdcb31bbbab6169faa92da9acc5f35bd4a009879ac74cf6af" standard verify_py312 copy_python_gdb ensurepip
 else
-    install_package "Python-3.12.0a3" "https://www.python.org/ftp/python/3.12.0/Python-3.12.0a3.tgz#fd414e6b6520171f5cefc5cba1067265187a322417f7bdec8d024db7fc8fbe96" standard verify_py312 copy_python_gdb ensurepip
+    install_package "Python-3.12.0a4" "https://www.python.org/ftp/python/3.12.0/Python-3.12.0a4.tgz#d9d9cbebc745ecaf5cae6b4004a84692154183b729954d3a421fba3d2a541d59" standard verify_py312 copy_python_gdb ensurepip
 fi


### PR DESCRIPTION
This PR adds the recently released Python 3.12.0a4 to `pyenv`.