### PR TITLE
Backfill missing {mini,mamba}forge versions

### DIFF
--- a/plugins/python-build/share/python-build/mambaforge-22.9.0-0
+++ b/plugins/python-build/share/python-build/mambaforge-22.9.0-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-22.9.0-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-0/Mambaforge-22.9.0-0-Linux-aarch64.sh#6076cfb0c2f88efa3e5e125dc54f3c0f8219cfe1ae9d9258a5abe42dbcf21a13" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-22.9.0-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-0/Mambaforge-22.9.0-0-Linux-ppc64le.sh#a17530e0e981991db5f6875e949dc22554f2ed0dd2b1bbb40ce677c910a2dc51" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-22.9.0-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-0/Mambaforge-22.9.0-0-Linux-x86_64.sh#7049f5ebdd6e2aee7611874599ab14445cd63070cdb63db2e00ae0b90d7c6132" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-22.9.0-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-0/Mambaforge-22.9.0-0-MacOSX-arm64.sh#d116ea977a2117068d290a961212f10fdaf1cc6ad156ea14b3979e2e4c0499d9" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-22.9.0-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-0/Mambaforge-22.9.0-0-MacOSX-x86_64.sh#03b0af9a3d343da8107edaf75713cea3b79c71aacbbeb8f06507d0dbd26c5218" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-22.9.0-1
+++ b/plugins/python-build/share/python-build/mambaforge-22.9.0-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-22.9.0-1-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-1/Mambaforge-22.9.0-1-Linux-aarch64.sh#2f60c1faadcf0660ac9a97e00c64edf8fd241664387a156685de4b72f36c657c" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-22.9.0-1-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-1/Mambaforge-22.9.0-1-Linux-ppc64le.sh#525cf02648ad50a221c1f1ca5ecc4c05be6cbe829e7d994c17507b439d923e55" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-22.9.0-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-1/Mambaforge-22.9.0-1-Linux-x86_64.sh#cba9a744454039944480871ed30d89e4e51a944a579b461dd9af60ea96560886" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-22.9.0-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-1/Mambaforge-22.9.0-1-MacOSX-arm64.sh#90c9c6eccdef8d938c4f31d44f2553c706b89955a4750adbd09d7eeefbedc603" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-22.9.0-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-1/Mambaforge-22.9.0-1-MacOSX-x86_64.sh#0afa53d38735762ee2a43174ee4ce726f076a1526f24122bd2faf7d0e005b61b" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-22.9.0-3
+++ b/plugins/python-build/share/python-build/mambaforge-22.9.0-3
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-22.9.0-3-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-3/Mambaforge-22.9.0-3-Linux-aarch64.sh#bd9694b1558f4ee6c4eef081cefc57dbb32ceb6406e497018f0c7d2dab5b61dd" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-22.9.0-3-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-3/Mambaforge-22.9.0-3-Linux-ppc64le.sh#f19dc098452ddbd73caa83792aaacd63674be20898ac63b38ad687e5148199f8" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-22.9.0-3-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-3/Mambaforge-22.9.0-3-Linux-x86_64.sh#29f6374464307732c2c9d6711cdbca4d685c632f31e8bf1a5565276c65e0069b" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-22.9.0-3-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-3/Mambaforge-22.9.0-3-MacOSX-arm64.sh#eebe06970fec4cb1445bba106e65f57084b753d39766bf213edf4e02b14e27c1" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-22.9.0-3-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-3/Mambaforge-22.9.0-3-MacOSX-x86_64.sh#a3ccaf7b93b6f99bc2018f2a6f3cd95489940731f11fb9bf6adf1a44a7ba4e17" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.10.2-0
+++ b/plugins/python-build/share/python-build/mambaforge-4.10.2-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.10.2-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.2-0/Mambaforge-4.10.2-0-Linux-aarch64.sh#cbc5329fa22f4d7ff10f66e59024b186d37653b9da31d841d23092a701f46b1f" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.10.2-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.2-0/Mambaforge-4.10.2-0-Linux-ppc64le.sh#c682e2e1f07e2da07cbe6252559af363bb0b67aa315527887fe2dd5123ca8760" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.10.2-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.2-0/Mambaforge-4.10.2-0-Linux-x86_64.sh#1e89ee86afa06e23b2478579be16a33fff6cff346314f6a6382fd20b1f83e669" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.10.2-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.2-0/Mambaforge-4.10.2-0-MacOSX-arm64.sh#87768fed0097edf58a129981129142db2651ab5d1591e19c5840ade186b443c5" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.10.2-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.2-0/Mambaforge-4.10.2-0-MacOSX-x86_64.sh#5a396db66672b5e6557e692bcb3cb527bcbe7c24b9c4a1c67b4449f8ef67cd47" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.10.3-0
+++ b/plugins/python-build/share/python-build/mambaforge-4.10.3-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.10.3-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-0/Mambaforge-4.10.3-0-Linux-aarch64.sh#d6d4fdf1d722c4afe9fdf5e372369321d5de9b491fdada22255665b122453fc7" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.10.3-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-0/Mambaforge-4.10.3-0-Linux-ppc64le.sh#cdda287122007bdc6b96ed62fb17c7c8213e38b3598ad6db03d8301c81d7d594" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.10.3-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-0/Mambaforge-4.10.3-0-Linux-x86_64.sh#5c3914235c0db8a8925d294a17d196fca7e6eab9175406fc78ed90fde34297db" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.10.3-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-0/Mambaforge-4.10.3-0-MacOSX-arm64.sh#17a38bf23ef3f2864eb3c1ebf1c07389635ad9ff65f0692f438c1f6286feef63" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.10.3-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-0/Mambaforge-4.10.3-0-MacOSX-x86_64.sh#43986b8c2a6b3535c2fa920c8001187c89695c0aaaa96c25696adb7746e0eb54" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.10.3-1
+++ b/plugins/python-build/share/python-build/mambaforge-4.10.3-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.10.3-1-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-1/Mambaforge-4.10.3-1-Linux-aarch64.sh#e830d626bcf8fccde1e64567fa9974d87fa45026c3baa73c889bab9a7fa60647" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.10.3-1-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-1/Mambaforge-4.10.3-1-Linux-ppc64le.sh#ade3331e4946dc149c97346941c635ddef1b99d63ec0781027a0ae0d156f62d7" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.10.3-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-1/Mambaforge-4.10.3-1-Linux-x86_64.sh#72c623cc9ce300c5ad54e0b383e428b13e5c640e74529295ab61fbbfa1a8acaa" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.10.3-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-1/Mambaforge-4.10.3-1-MacOSX-arm64.sh#5d1e6ae4eb424290271fe25e7f8c3e8165ba5730a4817f92a157566f44c7e363" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.10.3-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-1/Mambaforge-4.10.3-1-MacOSX-x86_64.sh#a8b0e666c893eb21769c00ab4ba603d28590f4c92d1fafe6ca2eb959cecf76ce" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.10.3-2
+++ b/plugins/python-build/share/python-build/mambaforge-4.10.3-2
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.10.3-2-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-2/Mambaforge-4.10.3-2-Linux-aarch64.sh#63294acfe2859c4a7b86151836da3253fd0370e9e0cd821be6ffb18a029c3a7a" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.10.3-2-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-2/Mambaforge-4.10.3-2-Linux-ppc64le.sh#8162d50d3111a4c0746c7a4e51094eea3011966816768c4d3638fe40050d6e59" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.10.3-2-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-2/Mambaforge-4.10.3-2-Linux-x86_64.sh#e4228930af7102de20019efdf45e4e9c056b6ae354cb2e344249e53a11f71175" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.10.3-2-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-2/Mambaforge-4.10.3-2-MacOSX-arm64.sh#49132e1e2593b4ab3762ff238e76dfc5f5bd670fe23c622c5051607709f93a0b" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.10.3-2-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-2/Mambaforge-4.10.3-2-MacOSX-x86_64.sh#cbd143702ed1d1176fa3b480eca1ec6eb0e32a2c9eab7134877ff32dabae91e0" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.10.3-3
+++ b/plugins/python-build/share/python-build/mambaforge-4.10.3-3
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.10.3-3-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-3/Mambaforge-4.10.3-3-Linux-aarch64.sh#c53eda563935e7ed5d07816477758374f4c541d912ee5732f2f9ace37d9fab75" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.10.3-3-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-3/Mambaforge-4.10.3-3-Linux-ppc64le.sh#3b762a3cf77fffebc56d3ecdefe590bf065139b36f556bb57f7f83a0ebe8561b" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.10.3-3-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-3/Mambaforge-4.10.3-3-Linux-x86_64.sh#a012c24e1cc3bcbe74a1e5693e510830e7c2956e85877b08d1e28707a0bd8d75" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.10.3-3-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-3/Mambaforge-4.10.3-3-MacOSX-arm64.sh#6cbae54d7a2d99cdcf747d74412a0c6490c8240cbb2d870655f61a9600bc2f06" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.10.3-3-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-3/Mambaforge-4.10.3-3-MacOSX-x86_64.sh#69f626a18eb1a6fda52d9f005114604acff1fd2d7c10d46e56543dca7d78f30d" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.10.3-4
+++ b/plugins/python-build/share/python-build/mambaforge-4.10.3-4
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.10.3-4-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-4/Mambaforge-4.10.3-4-Linux-aarch64.sh#f37435d5e2bc3eb14ec7f5bc64f9c45997f8e0a6d2fef3a7bb1ffa19f118817b" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.10.3-4-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-4/Mambaforge-4.10.3-4-Linux-ppc64le.sh#68319a11298b8c13a15960cd9d2a5777fd34420b73587a7f2e8e4757752f3252" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.10.3-4-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-4/Mambaforge-4.10.3-4-Linux-x86_64.sh#5017562c434185b4d9d311274c14717077f6c09a238a4d34a1caf7618d26ddd4" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.10.3-4-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-4/Mambaforge-4.10.3-4-MacOSX-arm64.sh#901f2c2b4be08cadf6968f408d4a1ee632ddb011a07ce4b480b83d8da142255f" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.10.3-4-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-4/Mambaforge-4.10.3-4-MacOSX-x86_64.sh#b5fd40995aebd7631f761324eb425ee813fb4604ce8d8fde3c03cb60cac1716e" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.10.3-5
+++ b/plugins/python-build/share/python-build/mambaforge-4.10.3-5
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.10.3-5-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-5/Mambaforge-4.10.3-5-Linux-aarch64.sh#5e471d796d7b1749949c0c0d79841e00f1b477833ce82b4b05b7b9886a1735eb" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.10.3-5-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-5/Mambaforge-4.10.3-5-Linux-ppc64le.sh#892ccb32b847978062c8045e96827a403d59fe64f318e0b92303be6a08e4d3f7" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.10.3-5-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-5/Mambaforge-4.10.3-5-Linux-x86_64.sh#2692f9ae27327412cbf018ec0218d21a99b013d0597ccaefc988540c8a9ced65" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.10.3-5-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-5/Mambaforge-4.10.3-5-MacOSX-arm64.sh#1c7517e204814f7227ef0d2e0fbf95b43f6afae978e882cd017779e31f8b26cb" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.10.3-5-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-5/Mambaforge-4.10.3-5-MacOSX-x86_64.sh#547823784a2b79641f29d06f70f74ae25775eec1680c6cca14888c4907441f5c" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.10.3-6
+++ b/plugins/python-build/share/python-build/mambaforge-4.10.3-6
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.10.3-6-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-6/Mambaforge-4.10.3-6-Linux-aarch64.sh#b6d3c0af4ba6202dc9994e70933d2de47ef8c4e6891afce768889a7d44e1db28" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.10.3-6-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-6/Mambaforge-4.10.3-6-Linux-ppc64le.sh#9d50677aeff37b56b0d6067339aad8c964942e28fc74a24a7602416a3dcc35b2" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.10.3-6-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-6/Mambaforge-4.10.3-6-Linux-x86_64.sh#c63907ba0971d2ca9a8775bd7ea48b635b2bdce4838b2f2d3a8e751876849595" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.10.3-6-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-6/Mambaforge-4.10.3-6-MacOSX-arm64.sh#c753e99380e3f777d690e7131fc79c6f9cb8fb79af23fb53c7b8a0ade3361fec" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.10.3-6-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-6/Mambaforge-4.10.3-6-MacOSX-x86_64.sh#955a6255871d9b53975e1c1581910844bcf33cbca613c7dba2842f6269917da6" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.10.3-7
+++ b/plugins/python-build/share/python-build/mambaforge-4.10.3-7
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.10.3-7-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-7/Mambaforge-4.10.3-7-Linux-aarch64.sh#ac95f137b287b3408e4f67f07a284357b1119ee157373b788b34e770ef2392b2" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.10.3-7-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-7/Mambaforge-4.10.3-7-Linux-ppc64le.sh#21c0190d2462eea68c78a600ce28828238d6a450858a289d7d4c03d9a2551ee8" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.10.3-7-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-7/Mambaforge-4.10.3-7-Linux-x86_64.sh#fc872522ec427fcab10167a93e802efaf251024b58cc27b084b915a9a73c4474" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.10.3-7-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-7/Mambaforge-4.10.3-7-MacOSX-arm64.sh#49c7ba06fe663c634929d5d85b4c06840f4ab9844744be691aab90848c52444e" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.10.3-7-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-7/Mambaforge-4.10.3-7-MacOSX-x86_64.sh#94ed8b8a647f48a815590958217aabebd4a3e3e10edaf2c5772d50a75727773a" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.10.3-8
+++ b/plugins/python-build/share/python-build/mambaforge-4.10.3-8
@@ -1,0 +1,16 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.10.3-8-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-8/Mambaforge-4.10.3-8-MacOSX-arm64.sh#f40271609a59bad71e7b1c6fa61a36065ea35222a9497614bc970572594e1f5a" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.10.3-8-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-8/Mambaforge-4.10.3-8-MacOSX-x86_64.sh#4f3dfd9475ed226f6a4478fe5c0585117528700557fe06fb9db054a354f07951" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.10.3-9
+++ b/plugins/python-build/share/python-build/mambaforge-4.10.3-9
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.10.3-9-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-9/Mambaforge-4.10.3-9-Linux-aarch64.sh#91fcdf2dfca49d68daaa9927d38f77a82718b5b72333180f9855e5b2cfa07c3b" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.10.3-9-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-9/Mambaforge-4.10.3-9-Linux-ppc64le.sh#4873079e88bcda0225af7c6acf59b48b272bb147ab9506e1b80cdab035a53b02" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.10.3-9-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-9/Mambaforge-4.10.3-9-Linux-x86_64.sh#f53ab6584385a4648608993de2a66bb84b9255c87e1f4315bb39cbfc05b19e87" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.10.3-9-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-9/Mambaforge-4.10.3-9-MacOSX-arm64.sh#968fe531ee2d9900409853085e6b458077144c1674061a5501938e3581b5adf4" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.10.3-9-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-9/Mambaforge-4.10.3-9-MacOSX-x86_64.sh#d669b345a7612552a9a218e3499b7a3a7c8deec2925d203155bd0922250b2823" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.11.0-0
+++ b/plugins/python-build/share/python-build/mambaforge-4.11.0-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.11.0-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-0/Mambaforge-4.11.0-0-Linux-aarch64.sh#9ad5db1775ed7f6a390774a7b7a2aeac3992499ee4b01e801f53528857112dc0" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.11.0-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-0/Mambaforge-4.11.0-0-Linux-ppc64le.sh#6fe80e207d409eb6c0922e068aa23aff5032083d9a5c2aacecc446a1d20f357b" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.11.0-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-0/Mambaforge-4.11.0-0-Linux-x86_64.sh#49268ee30d4418be4de852dda3aa4387f8c95b55a76f43fb1af68dcbf8b205c3" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.11.0-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-0/Mambaforge-4.11.0-0-MacOSX-arm64.sh#7703e27a2ceadb747a69f2c6a88b3cb859cb4bb4268fc85b03739e22d0eb160b" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.11.0-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-0/Mambaforge-4.11.0-0-MacOSX-x86_64.sh#2039f744e272d47878f0bc2ae372f03c7f07881f39a93d693d5445744f36f19d" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.11.0-1
+++ b/plugins/python-build/share/python-build/mambaforge-4.11.0-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.11.0-1-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-1/Mambaforge-4.11.0-1-Linux-aarch64.sh#8b2cd64b89c7e92a444dd2df993a4c0aeda20b1d090aeef8956bbb3fa5c526fe" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.11.0-1-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-1/Mambaforge-4.11.0-1-Linux-ppc64le.sh#c7fb2000b4447a410fd18d334a9b658f8682b19962fe0e22d1d003078dc89dfe" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.11.0-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-1/Mambaforge-4.11.0-1-Linux-x86_64.sh#32eb24c99062d5c97d1b8ab55cae19e37cca08464a3249e5eac65339927697e9" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.11.0-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-1/Mambaforge-4.11.0-1-MacOSX-arm64.sh#ce002867552011148b77e1df022465c584d25d0aec02fc15fdc96b68a0da1545" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.11.0-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-1/Mambaforge-4.11.0-1-MacOSX-x86_64.sh#11b0e24649ca1931cfcc92ff2b3a67d43e7f2485a1f57b7f512b5b7cd6f3f27c" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.11.0-2
+++ b/plugins/python-build/share/python-build/mambaforge-4.11.0-2
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.11.0-2-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-2/Mambaforge-4.11.0-2-Linux-aarch64.sh#dc24d61b3c57fde5bb05367a9514bcdf7acd820f97ef913e94781c78dff55f8d" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.11.0-2-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-2/Mambaforge-4.11.0-2-Linux-ppc64le.sh#8936568238c0ab4ae6444390cbe22853f8852080b5bc85912e1d41c8d3bbaea7" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.11.0-2-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-2/Mambaforge-4.11.0-2-Linux-x86_64.sh#5708db10e2e84035f9ed5700731435bf4027c73b0d5d41562cb5cf5dd9048925" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.11.0-2-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-2/Mambaforge-4.11.0-2-MacOSX-arm64.sh#8265d0902b6c3914a64afa7899c6398b1db7005603ad5d190dc0f0c87e8a8446" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.11.0-2-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-2/Mambaforge-4.11.0-2-MacOSX-x86_64.sh#e6312bcd55bac1036ce0d3c52a36bf57d3f65d3ec4f36f6267617dbb7edfe16d" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.11.0-3
+++ b/plugins/python-build/share/python-build/mambaforge-4.11.0-3
@@ -1,0 +1,16 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.11.0-3-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-3/Mambaforge-4.11.0-3-MacOSX-arm64.sh#7f16bf19722987cba7b077a010276262d8c3b521cb5c759f0b981e0fb0877d50" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.11.0-3-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-3/Mambaforge-4.11.0-3-MacOSX-x86_64.sh#e0e60c1542d087b514c3a81a1d4df9f0cc1d127b5245f1685bf77b2562ad6314" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.11.0-4
+++ b/plugins/python-build/share/python-build/mambaforge-4.11.0-4
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.11.0-4-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-4/Mambaforge-4.11.0-4-Linux-aarch64.sh#e2105e962f19a764c33d986f6e6850a3ce9aef9efc9571c7293b5274c335231d" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.11.0-4-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-4/Mambaforge-4.11.0-4-Linux-ppc64le.sh#d50a94a0fd367242db4bf5121ba4fd9356e171c79444d2226081275baa31e63a" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.11.0-4-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-4/Mambaforge-4.11.0-4-Linux-x86_64.sh#3f3a9177c3ce022a5f7f8798aab360af004c6c1e4963d0e91fc005e54bc1e271" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.11.0-4-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-4/Mambaforge-4.11.0-4-MacOSX-arm64.sh#d0a86d865d3881f26bc0e677a83b7fdff700536e654cd8490c8fdc1731f93f6c" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.11.0-4-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-4/Mambaforge-4.11.0-4-MacOSX-x86_64.sh#9b385902da43fba025ba8a02e628057217fe75cace15af26add5748ab443abbb" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.12.0-0
+++ b/plugins/python-build/share/python-build/mambaforge-4.12.0-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.12.0-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-0/Mambaforge-4.12.0-0-Linux-aarch64.sh#44e0a9f7c32e855e82a24af4df9a65ecf35a12b6eede8822b24dcf2308289d40" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.12.0-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-0/Mambaforge-4.12.0-0-Linux-ppc64le.sh#44de866d661a441f5e32605ce4708b3323f80348ccb5e0568e52a25a3de0d81e" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.12.0-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-0/Mambaforge-4.12.0-0-Linux-x86_64.sh#6c6fd04d688ceb7e6b540bba059dd3a541d60602e9adece3abaf754d15c83484" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.12.0-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-0/Mambaforge-4.12.0-0-MacOSX-arm64.sh#59d847b17148ebd27a4b31775d0047302cf9f8f8dae7db1e75bf037f0a823d48" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.12.0-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-0/Mambaforge-4.12.0-0-MacOSX-x86_64.sh#2301f866fb239ce6cda3e741e00be22ff7aa5ff76ba5683509ebae58df917546" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.12.0-1
+++ b/plugins/python-build/share/python-build/mambaforge-4.12.0-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.12.0-1-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-1/Mambaforge-4.12.0-1-Linux-aarch64.sh#c6ee5819f700926485197c864ed1190e8ca9d436cf15b100ed8a35540f1c46ea" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.12.0-1-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-1/Mambaforge-4.12.0-1-Linux-ppc64le.sh#87dc485c6c82592102b8704e0e59cf9ce2fef762c369011a3e132fa72549d730" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.12.0-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-1/Mambaforge-4.12.0-1-Linux-x86_64.sh#10f7194e7356e46e41ddf6add800a2f175a801211ed62869ad8c0c301d493c34" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.12.0-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-1/Mambaforge-4.12.0-1-MacOSX-arm64.sh#234504f4db1d04966218f0c1ad73418a15e7e9bdf714d166bc5e86b917291cc2" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.12.0-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-1/Mambaforge-4.12.0-1-MacOSX-x86_64.sh#e68c3b8f94db17aae3b33f2bacb950c613c06b170507002d72231ff320b9ad7c" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.12.0-2
+++ b/plugins/python-build/share/python-build/mambaforge-4.12.0-2
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.12.0-2-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-2/Mambaforge-4.12.0-2-Linux-aarch64.sh#6b67bdd1552dfd6a2257c4c3da0ead19a4d34f68c16fb3e5b4bbc728b60cd200" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.12.0-2-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-2/Mambaforge-4.12.0-2-Linux-ppc64le.sh#f8700febc99cbda9cbe9ff52364477ed6a04efdf15a0aa499d8ea8be4a58998c" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.12.0-2-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-2/Mambaforge-4.12.0-2-Linux-x86_64.sh#8cb16ef82fe18d466850abb873c7966090b0fbdcf1e80842038e0b4e6d8f0b66" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.12.0-2-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-2/Mambaforge-4.12.0-2-MacOSX-arm64.sh#2e2be9d976da31b62ab314881d3c6ed3f65c76e3ea69cc4b59fb344780109026" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.12.0-2-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-2/Mambaforge-4.12.0-2-MacOSX-x86_64.sh#562c2bcbabff10387f130acea72b960454fa3d90b593126e4e4febcf6da763d3" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.12.0-3
+++ b/plugins/python-build/share/python-build/mambaforge-4.12.0-3
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.12.0-3-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-3/Mambaforge-4.12.0-3-Linux-aarch64.sh#379796ce7d0f6515093bdde06f45df1bd7261c4104f13f53a5cd30f9acba44d9" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.12.0-3-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-3/Mambaforge-4.12.0-3-Linux-ppc64le.sh#ae6fb19467c147c77cf31b044aaae155109bc0e952965d98990fa8d2b2e7bfdd" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.12.0-3-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-3/Mambaforge-4.12.0-3-Linux-x86_64.sh#93d481e4f12dce9f2ffe46904dc8cf88485c7b27fc4d18dd8e900e2c3ab83f80" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.12.0-3-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-3/Mambaforge-4.12.0-3-MacOSX-arm64.sh#6c3b82eb0edce21b58d0bcafc9afbbc498e140a8229b70275afcdf9e17db47d1" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.12.0-3-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-3/Mambaforge-4.12.0-3-MacOSX-x86_64.sh#17ecce907a048240970cc9a546369aed07bcd21f30116ad43249360dce69edcd" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.13.0-1
+++ b/plugins/python-build/share/python-build/mambaforge-4.13.0-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.13.0-1-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.13.0-1/Mambaforge-4.13.0-1-Linux-aarch64.sh#69e3c90092f61916da7add745474e15317ed0dc6d48bfe4e4c90f359ba141d23" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.13.0-1-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.13.0-1/Mambaforge-4.13.0-1-Linux-ppc64le.sh#ff41608c73da7deb01f741682e9b6c92435f4b2aff2aecde353093d3125126cf" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.13.0-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.13.0-1/Mambaforge-4.13.0-1-Linux-x86_64.sh#412b79330e90e49cf7e39a7b6f4752970fcdb8eb54b1a45cc91afe6777e8518c" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.13.0-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.13.0-1/Mambaforge-4.13.0-1-MacOSX-arm64.sh#6263560d2b0902942841667721dad3621c05f704f6b080d968ad355aeca51486" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.13.0-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.13.0-1/Mambaforge-4.13.0-1-MacOSX-x86_64.sh#bc42d606b67ace370847deb849e7d1ea2879b0be78bb1be51b020c3cb4e5bef2" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.14.0-0
+++ b/plugins/python-build/share/python-build/mambaforge-4.14.0-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.14.0-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-0/Mambaforge-4.14.0-0-Linux-aarch64.sh#37221b8d818951fab125c0bfb6cc6e83dac059f66892d2544a83192828d8e2c4" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.14.0-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-0/Mambaforge-4.14.0-0-Linux-ppc64le.sh#607bbd38aa21af4c79a663f2a183a06cca054efdd8d617c17370522504c7be1e" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.14.0-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-0/Mambaforge-4.14.0-0-Linux-x86_64.sh#d47b78b593e3cf5513bafbfa6a51eafcd9f0e164c41c79c790061bb583c82859" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.14.0-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-0/Mambaforge-4.14.0-0-MacOSX-arm64.sh#35d05a65e19b8e5d596964936ddd6023ae66d664a25ba291a52fec18f06a73b6" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.14.0-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-0/Mambaforge-4.14.0-0-MacOSX-x86_64.sh#949f046b4404cc8e081807b048050e6642d8db5520c20d5158a7ef721fbf76c5" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.14.0-1
+++ b/plugins/python-build/share/python-build/mambaforge-4.14.0-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.14.0-1-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-1/Mambaforge-4.14.0-1-Linux-aarch64.sh#f721dc44d5aba7a24c6f76408979d125e7ed7f1ba56397ff073a9cfd1611f71c" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.14.0-1-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-1/Mambaforge-4.14.0-1-Linux-ppc64le.sh#da6cbf1abe89fae4e1246aa64e86e8e155e7938c462f968265266af61fda64cc" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.14.0-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-1/Mambaforge-4.14.0-1-Linux-x86_64.sh#d9c8337bda234cf53d2743f32efaab41cbc9d942b8fb52b8588996ef0300c82f" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.14.0-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-1/Mambaforge-4.14.0-1-MacOSX-arm64.sh#48aca11999c866058c8201cbd01361cd1bf35044e36655874238cd57c06b389d" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.14.0-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-1/Mambaforge-4.14.0-1-MacOSX-x86_64.sh#e0f2c280e5cd4b4211151a9d8e40c3f86b1b53fdb4b4fbb907603409581e696f" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/mambaforge-4.14.0-2
+++ b/plugins/python-build/share/python-build/mambaforge-4.14.0-2
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Mambaforge-4.14.0-2-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-2/Mambaforge-4.14.0-2-Linux-aarch64.sh#af6b683bb6bf3170a29b1fe37c1356d4b7fd94f9c38019d33d3d1933a5a5f41a" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Mambaforge-4.14.0-2-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-2/Mambaforge-4.14.0-2-Linux-ppc64le.sh#ab2cfff59870fbd946d26ed55fc47def32de25879b994eac6c464d079ed39c68" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Mambaforge-4.14.0-2-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-2/Mambaforge-4.14.0-2-Linux-x86_64.sh#ac3cabd483712a216f1dddeb92a7f8e198a771390c6627aa94791ab6abc7fae8" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Mambaforge-4.14.0-2-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-2/Mambaforge-4.14.0-2-MacOSX-arm64.sh#28b45f0949cb734347656e27acb6feb6da6ff12f93cb8c7546d7195e1ae1beba" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Mambaforge-4.14.0-2-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-2/Mambaforge-4.14.0-2-MacOSX-x86_64.sh#efd4ea95da961c8005a28ecb8bde719d0fd408ccac92dafaaa37eab133ff7a52" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Mambaforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-22.9.0-0
+++ b/plugins/python-build/share/python-build/miniforge3-22.9.0-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-22.9.0-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-0/Miniforge3-22.9.0-0-Linux-aarch64.sh#e3d8d8a2ca641a70f3aee492fff22f67ced642bded34a260827a1fa82437a999" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-22.9.0-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-0/Miniforge3-22.9.0-0-Linux-ppc64le.sh#7db5858e7de6d730b92c3a6d1138f21ada88396876fa9fec65115d15e2f922e2" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-22.9.0-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-0/Miniforge3-22.9.0-0-Linux-x86_64.sh#24b704203a4cdabd99362f52a9836c55219579814eb904188675e077b488be38" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-22.9.0-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-0/Miniforge3-22.9.0-0-MacOSX-arm64.sh#e9eb55f8409e5f227c5ecc5f5d0024e4d81148454a763b95b612447a1585cc2c" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-22.9.0-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-0/Miniforge3-22.9.0-0-MacOSX-x86_64.sh#c6e4fc3e9dca2375e91a3bc2f27c01634bb1841ab4d284a3a83b4181ae79b16d" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-22.9.0-1
+++ b/plugins/python-build/share/python-build/miniforge3-22.9.0-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-22.9.0-1-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-1/Miniforge3-22.9.0-1-Linux-aarch64.sh#786777d47b27f490701ecb42c61b245bd945c34bc9ce8d7e90f4b87f430297a1" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-22.9.0-1-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-1/Miniforge3-22.9.0-1-Linux-ppc64le.sh#f51ea2fe47b2481a42e67747573690e13cac796c6f18ba1af1d198850c35c23a" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-22.9.0-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-1/Miniforge3-22.9.0-1-Linux-x86_64.sh#47f4b8ef9c5e2ba28eb3c17d27c4d0709f59ea3ab78d7d87c2d34e0c7ad439d5" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-22.9.0-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-1/Miniforge3-22.9.0-1-MacOSX-arm64.sh#8631692804809f14ac9da0c2d277bcede715854da6b1a3fa81822ba961dc546b" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-22.9.0-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-1/Miniforge3-22.9.0-1-MacOSX-x86_64.sh#0b56334b4ed62076fbf6973fd3ced9d41190b73ab27432c8db224ca42e614207" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-22.9.0-3
+++ b/plugins/python-build/share/python-build/miniforge3-22.9.0-3
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-22.9.0-3-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-3/Miniforge3-22.9.0-3-Linux-aarch64.sh#3862fd31ed24d9254cecd8b080dc741b556a6e371b4615880173a782c7cf3b27" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-22.9.0-3-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-3/Miniforge3-22.9.0-3-Linux-ppc64le.sh#914e0ae86d5ce473379841041e52c7891aa65e46be7892c2258cb439a83dd301" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-22.9.0-3-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-3/Miniforge3-22.9.0-3-Linux-x86_64.sh#0df76d7a8e66c4f96478ff71b90b7a8df04c19474f3d36dd77ace53e75aa47e4" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-22.9.0-3-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-3/Miniforge3-22.9.0-3-MacOSX-arm64.sh#c3065cbfaef72966599fc658a2724f5109b0315f7b9ffc6078fd061b084942f4" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-22.9.0-3-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/22.9.0-3/Miniforge3-22.9.0-3-MacOSX-x86_64.sh#45a1314dad30baececc43b4ecef839a17e43860a6a9c77e87ab1d4297796fa9d" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.10.2-0
+++ b/plugins/python-build/share/python-build/miniforge3-4.10.2-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.10.2-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.2-0/Miniforge3-4.10.2-0-Linux-aarch64.sh#eb0a303e716d795b64a4ab056e3c03dae7760c3a3275312419051d272f5d0307" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.10.2-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.2-0/Miniforge3-4.10.2-0-Linux-ppc64le.sh#1a55c5f9ee8c49ce0368b77acb4964a8b060ca57d951f68adb98b28c3ed5c145" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.10.2-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.2-0/Miniforge3-4.10.2-0-Linux-x86_64.sh#d2d66f09811c0d846ffb2f04c1827854aa4333624a0dc841389230291d944c30" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.10.2-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.2-0/Miniforge3-4.10.2-0-MacOSX-arm64.sh#36d4a12254c90bdacd3c2a757c8c257dffe3c67754c44372d446c2a54e03cebc" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.10.2-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.2-0/Miniforge3-4.10.2-0-MacOSX-x86_64.sh#60aaecd1681633e84bad0520479e938a0a0c671fa7d78d2aa607d4807c670975" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.10.3-0
+++ b/plugins/python-build/share/python-build/miniforge3-4.10.3-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.10.3-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-0/Miniforge3-4.10.3-0-Linux-aarch64.sh#4aff1bfe62b2974a418937bd4687316acef46e461908332159b2f68cb95f6d67" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.10.3-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-0/Miniforge3-4.10.3-0-Linux-ppc64le.sh#b854e26db0635846ad4065c54de9d8cef7a97050d7e1303923c5ba18ea9b4dd1" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.10.3-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-0/Miniforge3-4.10.3-0-Linux-x86_64.sh#c22bd3f494ac12f3ef2f146d7625ab140272670f7b4d606af8ff50aac3a0dae2" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.10.3-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-0/Miniforge3-4.10.3-0-MacOSX-arm64.sh#14e0ce6a16c7de8372d0d59cdf279b53601f62b14a073d0824c5ee7384005a2f" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.10.3-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-0/Miniforge3-4.10.3-0-MacOSX-x86_64.sh#e405b2a2be60b6b408569e4b7f6e39c87c3b579235e92dd58615fe708f18d036" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.10.3-1
+++ b/plugins/python-build/share/python-build/miniforge3-4.10.3-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.10.3-1-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-1/Miniforge3-4.10.3-1-Linux-aarch64.sh#ebb7b2548f3908ccc1b3c39bc41e2a3dbe19b4d266e844bc929147c39c8a14d3" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.10.3-1-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-1/Miniforge3-4.10.3-1-Linux-ppc64le.sh#cf20609570a5a716e7370a836ee895cbc4e7ca2683a598d32cc0573fddd65e66" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.10.3-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-1/Miniforge3-4.10.3-1-Linux-x86_64.sh#303d65289f600fa4c85fe2b0fef9bb0848ec544a75a9c3079607d847918f7023" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.10.3-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-1/Miniforge3-4.10.3-1-MacOSX-arm64.sh#823f61563947fd9ff92970f4e2323f2f0b61fe5f3cfb75cc7579a1c6169f8853" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.10.3-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-1/Miniforge3-4.10.3-1-MacOSX-x86_64.sh#8ed6871bbd0b24f66b2d87fd88cbcd0854142e5cf1447de5f5f246884ef9c846" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.10.3-2
+++ b/plugins/python-build/share/python-build/miniforge3-4.10.3-2
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.10.3-2-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-2/Miniforge3-4.10.3-2-Linux-aarch64.sh#11705546b6e6f7052a83992b7505f74e7cb51b5a519ddccbd9eabfad9451bfee" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.10.3-2-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-2/Miniforge3-4.10.3-2-Linux-ppc64le.sh#da8c5a43f941155aa937bb00068e4ecc5651fe3a9ea0eddd9c40e339eb5fa6d7" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.10.3-2-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-2/Miniforge3-4.10.3-2-Linux-x86_64.sh#8af640a77047b493d37b4e21302387abb6a62e0b3f942416c525e60dde019c7e" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.10.3-2-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-2/Miniforge3-4.10.3-2-MacOSX-arm64.sh#74fdfc71022af33ef671c9fe08f917f0e5d4ff5e69b1ef1a02b72f12df146d45" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.10.3-2-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-2/Miniforge3-4.10.3-2-MacOSX-x86_64.sh#ac68224f726bc2dc38502d6aaf605af976d29cc3fbaaca3c948b1fd5271e8235" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.10.3-3
+++ b/plugins/python-build/share/python-build/miniforge3-4.10.3-3
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.10.3-3-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-3/Miniforge3-4.10.3-3-Linux-aarch64.sh#ca6aa614c217c923bbb6fb48246f356b013697629bcf7d4d3b71c8813910ff94" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.10.3-3-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-3/Miniforge3-4.10.3-3-Linux-ppc64le.sh#84572443a08a640a0308f3f80a3a98431241eed646c26398144b2c8042524006" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.10.3-3-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-3/Miniforge3-4.10.3-3-Linux-x86_64.sh#12c83e744bf52564445cae0281bc7870b24c77257ac9c72986cbb1443e9b6d0a" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.10.3-3-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-3/Miniforge3-4.10.3-3-MacOSX-arm64.sh#5f5906dec9ba56fe4cbf1a50b9a573629f4af8f3f166785d114a8af65b9c78a3" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.10.3-3-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-3/Miniforge3-4.10.3-3-MacOSX-x86_64.sh#3242d65bae12edf2d7cd29ed466fc72cb66f3f031f621ac360ab8968e4d29974" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.10.3-4
+++ b/plugins/python-build/share/python-build/miniforge3-4.10.3-4
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.10.3-4-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-4/Miniforge3-4.10.3-4-Linux-aarch64.sh#1237209ed8145efc05dcc4e97e367811d569154609fffcc22ebcb08b0e0392d2" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.10.3-4-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-4/Miniforge3-4.10.3-4-Linux-ppc64le.sh#591825a5b5f690bb74759c0f93c347f0ae1f9b30057609d8205a11b2b7c21902" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.10.3-4-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-4/Miniforge3-4.10.3-4-Linux-x86_64.sh#13626e6d43546d0b8c47be37b34d2c2ba5e0a518066b0659addb4afcc30a70be" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.10.3-4-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-4/Miniforge3-4.10.3-4-MacOSX-arm64.sh#0079a2172ff9cc92d6a0f30d4269d7e27ef77f5074525c31fb46db57f9ccaefe" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.10.3-4-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-4/Miniforge3-4.10.3-4-MacOSX-x86_64.sh#21be593ec3a3d917862bf452a78bf4c9dddb9b360346562b3c19c21efd892d77" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.10.3-5
+++ b/plugins/python-build/share/python-build/miniforge3-4.10.3-5
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.10.3-5-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-5/Miniforge3-4.10.3-5-Linux-aarch64.sh#acd5f31fd2bdd9ebd996a6d5b36fcc6a8ab5d0b3820cbc47d660afa2cf0bd3ba" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.10.3-5-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-5/Miniforge3-4.10.3-5-Linux-ppc64le.sh#e018e8a7c41e1871b456bc27efbc0e3a4093d3e6ba84cb5ea94f6d0601b3e27a" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.10.3-5-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-5/Miniforge3-4.10.3-5-Linux-x86_64.sh#5f143112b6c9533c550b447cc01f7313a86b6b88b92632791bcb4320e57f9af6" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.10.3-5-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-5/Miniforge3-4.10.3-5-MacOSX-arm64.sh#77989d3186c21ec8de9ff22ef076e815c465c026cef087601b2bec5d02cfd889" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.10.3-5-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-5/Miniforge3-4.10.3-5-MacOSX-x86_64.sh#6f324566af60279518c2d03ffd69f605b335f87f72e6e7e4c2f383808e41e212" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.10.3-6
+++ b/plugins/python-build/share/python-build/miniforge3-4.10.3-6
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.10.3-6-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-6/Miniforge3-4.10.3-6-Linux-aarch64.sh#a79cd78324bb42cde5150d2194744205b9ebae1ebab06c50c3205e4846efb9e0" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.10.3-6-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-6/Miniforge3-4.10.3-6-Linux-ppc64le.sh#d3624b1d7a715a6089c309b9a593a5c241a1d959d00b037c074d3080be587b27" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.10.3-6-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-6/Miniforge3-4.10.3-6-Linux-x86_64.sh#8e76a21311e4fcc9ee8497b72717b276bb960e0151c5b27816502f14bac6303f" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.10.3-6-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-6/Miniforge3-4.10.3-6-MacOSX-arm64.sh#4ba889103eb119e9d12e45b5fba3bcdef45877d9a886657f14f1ebe71a9b5a63" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.10.3-6-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-6/Miniforge3-4.10.3-6-MacOSX-x86_64.sh#eabb50e2594d55eeb2a74fa05a919be876ec364e8064e1623ab096f39d6b6dd1" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.10.3-7
+++ b/plugins/python-build/share/python-build/miniforge3-4.10.3-7
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.10.3-7-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-7/Miniforge3-4.10.3-7-Linux-aarch64.sh#d597961defe8c7889f3e924d0dc7624fab2c8845abccdd8ffa8da8018ff3dc6e" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.10.3-7-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-7/Miniforge3-4.10.3-7-Linux-ppc64le.sh#8825827240c0d06413876055bf3a04d8704f0e5ac773692a352502862dce7aa5" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.10.3-7-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-7/Miniforge3-4.10.3-7-Linux-x86_64.sh#4de9b7dcc9b2761136f4a7a42a8b2ea06ae2ebc61d865c9fca0db3d6c90b569d" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.10.3-7-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-7/Miniforge3-4.10.3-7-MacOSX-arm64.sh#3cd1f11743f936ba522709eb7a173930c299ac681671a909b664222329a56290" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.10.3-7-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-7/Miniforge3-4.10.3-7-MacOSX-x86_64.sh#a25c1b381b20873ed856ce675a7a2ccf48f1d6782a5cdce9f06496e6ffa7883f" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.10.3-8
+++ b/plugins/python-build/share/python-build/miniforge3-4.10.3-8
@@ -1,0 +1,16 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.10.3-8-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-8/Miniforge3-4.10.3-8-MacOSX-arm64.sh#ed1f245d8effb463c9bd5d1cde034e7e291684e0668885a87deb34303dafced5" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.10.3-8-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-8/Miniforge3-4.10.3-8-MacOSX-x86_64.sh#9c123f45da81878b3b3f221dcb7595f6420cac0310235316a7deba93cf12bbe3" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.10.3-9
+++ b/plugins/python-build/share/python-build/miniforge3-4.10.3-9
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.10.3-9-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-9/Miniforge3-4.10.3-9-Linux-aarch64.sh#33850a3806c61c2f0c27a4619a49a2ab7c27691b65b64ea764b57b3cc572efa1" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.10.3-9-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-9/Miniforge3-4.10.3-9-Linux-ppc64le.sh#7192460dcf7d309ebe0c2e53f0034c86b097de4f1ebf669f677d57886b9b48de" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.10.3-9-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-9/Miniforge3-4.10.3-9-Linux-x86_64.sh#387ed0e31a0e16def1f4b602c8a3633f707c53fff7cbf2ff56175953d0c6f7e7" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.10.3-9-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-9/Miniforge3-4.10.3-9-MacOSX-arm64.sh#68196959ddc966046935ab80fb0fda73675914e55e96764e0358f7eb4a4e7714" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.10.3-9-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.10.3-9/Miniforge3-4.10.3-9-MacOSX-x86_64.sh#86ba79bba787ea943d11810b8f7b393a3ce5d421cd31528436c3ffa17eb062ed" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.11.0-0
+++ b/plugins/python-build/share/python-build/miniforge3-4.11.0-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.11.0-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-0/Miniforge3-4.11.0-0-Linux-aarch64.sh#3c4728ece94f005a0edfcb45f930bf2fd4acdaafdee2692006b0322ca6c44ca7" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.11.0-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-0/Miniforge3-4.11.0-0-Linux-ppc64le.sh#cfaedc8ff54703b91ef0a1f27232ac4f85dad2725d65a19624e63674aca19bd0" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.11.0-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-0/Miniforge3-4.11.0-0-Linux-x86_64.sh#4c24b38969ac413efa3a984290296f72578340d06004f2c7ba5efcbf828ec86b" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.11.0-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-0/Miniforge3-4.11.0-0-MacOSX-arm64.sh#d37c13f42f6d8e1b5786da5c73735eb4584a100c8b3572e5413dffe943a6a38b" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.11.0-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-0/Miniforge3-4.11.0-0-MacOSX-x86_64.sh#037da3c64fd8f8179ce99909784cfdaa2326b7ea832e747de8ea9e396c1583e7" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.11.0-1
+++ b/plugins/python-build/share/python-build/miniforge3-4.11.0-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.11.0-1-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-1/Miniforge3-4.11.0-1-Linux-aarch64.sh#5032a44b9a6c11a2ef46c02707c9c21adc276e2acd40305d615a6b923b7acd26" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.11.0-1-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-1/Miniforge3-4.11.0-1-Linux-ppc64le.sh#38ea90c2aa8c380a50f8fadf329981b0ad8c05064a928212a234e9101d23a81f" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.11.0-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-1/Miniforge3-4.11.0-1-Linux-x86_64.sh#83ed76dcc907c9d9fc553a8a33278f06e80a27ac47c0db78e73f2b14f0bfbad1" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.11.0-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-1/Miniforge3-4.11.0-1-MacOSX-arm64.sh#67f6c7bec83f04d8fe3a8083c6a13084b9dd0bb33e5bb8975a9a6531f7360875" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.11.0-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-1/Miniforge3-4.11.0-1-MacOSX-x86_64.sh#9795921a6836f0d1e0abc10e4a724dcddaba8fbcf9740b2764c6d64f1378b835" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.11.0-2
+++ b/plugins/python-build/share/python-build/miniforge3-4.11.0-2
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.11.0-2-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-2/Miniforge3-4.11.0-2-Linux-aarch64.sh#6497f1e696c4f2931acecdc341242f3b2d1acfdb1360c6dd86dbd5a4000a970d" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.11.0-2-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-2/Miniforge3-4.11.0-2-Linux-ppc64le.sh#7661deb911b2210d619a60c4f63275680c003ec83898fd80af4025d30e722a44" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.11.0-2-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-2/Miniforge3-4.11.0-2-Linux-x86_64.sh#f671f3a225ce5517021f0eb430ffa9110eebad8e0a0549d36c778e7769cb4970" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.11.0-2-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-2/Miniforge3-4.11.0-2-MacOSX-arm64.sh#eba035fb0f2f0d7a095713e93fd3848c847e18e8dbbef7173653f57a0518abe8" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.11.0-2-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-2/Miniforge3-4.11.0-2-MacOSX-x86_64.sh#379323b33054730c7d06004f9a0cc7eb8283e45ae6d44814bb0b283d5eda2f03" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.11.0-3
+++ b/plugins/python-build/share/python-build/miniforge3-4.11.0-3
@@ -1,0 +1,16 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.11.0-3-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-3/Miniforge3-4.11.0-3-MacOSX-arm64.sh#e74e4acfcc2bdf662746172b684855790d018f3b9c1d2630e65b2c4e316f3eb5" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.11.0-3-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-3/Miniforge3-4.11.0-3-MacOSX-x86_64.sh#f7a5e379135a7f2454a6cfe7d81fa7f6a082793c60d6c88648b4035ca1c83d24" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.11.0-4
+++ b/plugins/python-build/share/python-build/miniforge3-4.11.0-4
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.11.0-4-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-4/Miniforge3-4.11.0-4-Linux-aarch64.sh#7b88645381840589aeaa8a2a9a3a077a0909541ecfd6752b44eef53af83786b5" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.11.0-4-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-4/Miniforge3-4.11.0-4-Linux-ppc64le.sh#adfe136cef5dd92bf54ec8e71656714ec485a140b18cfb3319837828d4a5ede0" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.11.0-4-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-4/Miniforge3-4.11.0-4-Linux-x86_64.sh#b8560aaab6edce86e690cdf096427dde0fa2c4f1bb083b20b642e6b2b4543ed1" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.11.0-4-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-4/Miniforge3-4.11.0-4-MacOSX-arm64.sh#7b3e3c29f8cc4a6a13e53f20e155f7bd30216e071c6028f699582b23bff06e60" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.11.0-4-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.11.0-4/Miniforge3-4.11.0-4-MacOSX-x86_64.sh#5f0019f6f671f3a41352b53ee7001dfbc6d7806a62d3691159c60d493ed82ea2" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.12.0-0
+++ b/plugins/python-build/share/python-build/miniforge3-4.12.0-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.12.0-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-0/Miniforge3-4.12.0-0-Linux-aarch64.sh#09b0ec8cefd3d94327ce12185af8164c8890bff00351b3f64bf280e22e947d21" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.12.0-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-0/Miniforge3-4.12.0-0-Linux-ppc64le.sh#29e3969b82538c78a13e684f53c0a0cd2eba7b500e7e187e4d6bddacc3eb66e1" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.12.0-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-0/Miniforge3-4.12.0-0-Linux-x86_64.sh#ccb6c87f42355e2e0b652dd35a980b7c60ca5e53643237f6a070748ef0dd23ff" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.12.0-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-0/Miniforge3-4.12.0-0-MacOSX-arm64.sh#e52cb92d620c5a408afef9ac8b5d2e964e2c72211c69cc41a2bb4d6af0a26001" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.12.0-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-0/Miniforge3-4.12.0-0-MacOSX-x86_64.sh#3bfcd52dd1acafc712b6fb042d4b019c6f09ea3ba62710f722f4e9ebcde7f67c" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.12.0-1
+++ b/plugins/python-build/share/python-build/miniforge3-4.12.0-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.12.0-1-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-1/Miniforge3-4.12.0-1-Linux-aarch64.sh#b1fb77baffdc187f1ccf34db781aa849f8c057b31fdb7394788fe6c8ffb99916" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.12.0-1-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-1/Miniforge3-4.12.0-1-Linux-ppc64le.sh#3b4bd33274e02ef7a19ffacd0e7eafe9275f08fc188a77f3a75ddf877772bf35" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.12.0-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-1/Miniforge3-4.12.0-1-Linux-x86_64.sh#fe0c49f6af64668006b87174a7dcddd3ea59fe2d0f05c7db3de057e2fbc8a6e9" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.12.0-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-1/Miniforge3-4.12.0-1-MacOSX-arm64.sh#622fc4220a90a80ff7f6ae40883d2d37eb09e9168aa74b9516de81c302490527" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.12.0-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-1/Miniforge3-4.12.0-1-MacOSX-x86_64.sh#4456a11cc99ac9a671b83f3ecf1d670e93dc88c1e5ecd3f038e041e658104b05" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.12.0-2
+++ b/plugins/python-build/share/python-build/miniforge3-4.12.0-2
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.12.0-2-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-2/Miniforge3-4.12.0-2-Linux-aarch64.sh#507c9763942821d7541b5a1b1130545e4c19416cc0473054faa10fee435aa9fa" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.12.0-2-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-2/Miniforge3-4.12.0-2-Linux-ppc64le.sh#447d1729353189ba732e951b598d5b9ea4ab46296db4523ac34a775150a60199" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.12.0-2-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-2/Miniforge3-4.12.0-2-Linux-x86_64.sh#e8bd60572d1bdcd9fc16114f423653c95e02f0be1393383f77fba17cf8acb10e" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.12.0-2-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-2/Miniforge3-4.12.0-2-MacOSX-arm64.sh#24181b1a42c6bb9704e28ac4ecb234f3c86d882a7db408948692bc5792a2f713" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.12.0-2-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-2/Miniforge3-4.12.0-2-MacOSX-x86_64.sh#37007407ab504fb8bd3af68ff821c0819ad2f016087b9c45f1e95a910c92531e" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.12.0-3
+++ b/plugins/python-build/share/python-build/miniforge3-4.12.0-3
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.12.0-3-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-3/Miniforge3-4.12.0-3-Linux-aarch64.sh#8ddc79ffaa40dfc7e3d93c8c02e268c6d3958c4ef662bc2194c36aa7d50820a3" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.12.0-3-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-3/Miniforge3-4.12.0-3-Linux-ppc64le.sh#2892b96723bb8aec33275ce033c209cd0ee53a9208afce7138c79438bd533fbb" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.12.0-3-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-3/Miniforge3-4.12.0-3-Linux-x86_64.sh#680f8549374474bad903ebb2985a2c264f592fecae1544700bcc4e0d41e1ba17" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.12.0-3-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-3/Miniforge3-4.12.0-3-MacOSX-arm64.sh#9088b27744512960b4834d318204f2bdbaeb44c13dd21b4740de357cea270d44" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.12.0-3-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.12.0-3/Miniforge3-4.12.0-3-MacOSX-x86_64.sh#76b6cf644e74c2c2df9ff7a315259a1cf82170bcb9fea0038069616fe25d1d14" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.13.0-0
+++ b/plugins/python-build/share/python-build/miniforge3-4.13.0-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.13.0-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.13.0-0/Miniforge3-4.13.0-0-Linux-aarch64.sh#930ea585fa30047ada7bc892aa96bb4b521f082469b0594e3fbbbb6ac17dcda5" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.13.0-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.13.0-0/Miniforge3-4.13.0-0-Linux-ppc64le.sh#ce3c506f2dc939b368e91521355a68653aa40541371ffe12aa0cbe43e264f26c" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.13.0-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.13.0-0/Miniforge3-4.13.0-0-Linux-x86_64.sh#e810f2e2a36bec232ed8f00e68be1b75590b51b4e3f3de39aab3212e596bf7a8" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.13.0-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.13.0-0/Miniforge3-4.13.0-0-MacOSX-arm64.sh#b00587bfd44d259d28d376497d0fc68bd150eb74b4a96771220917699bd26340" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.13.0-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.13.0-0/Miniforge3-4.13.0-0-MacOSX-x86_64.sh#f29457257d01f06569f342723d58d4c6b526c9404dbb579ab72548d933b5b547" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.13.0-1
+++ b/plugins/python-build/share/python-build/miniforge3-4.13.0-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.13.0-1-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.13.0-1/Miniforge3-4.13.0-1-Linux-aarch64.sh#e0d671d18ef578700dce1796f1a8796a74c8e5e4e5d6ee9f33cf6a1159f570c8" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.13.0-1-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.13.0-1/Miniforge3-4.13.0-1-Linux-ppc64le.sh#2981ba22334a73f3bd8c0bcb9ad2510c411ab454280f460ca461977e5c0c43a6" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.13.0-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.13.0-1/Miniforge3-4.13.0-1-Linux-x86_64.sh#6e0a33060c525909fa0e8ae74cb511480e8191cef88e3c297619f31574804184" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.13.0-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.13.0-1/Miniforge3-4.13.0-1-MacOSX-arm64.sh#57bef67a4c80bfef04223eb76ee1b49b1bdfd5eeb46ebcf49e65d6c308c84a98" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.13.0-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.13.0-1/Miniforge3-4.13.0-1-MacOSX-x86_64.sh#9996677f0ca0bfa6399e9a5688556bfaff544389ea123e2ac6e6252d3a1d0658" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.14.0-0
+++ b/plugins/python-build/share/python-build/miniforge3-4.14.0-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.14.0-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-0/Miniforge3-4.14.0-0-Linux-aarch64.sh#8e2de8657e0ff7315daf22df1874d5a57ff8295bc9489d43d61f2d9fac49e42b" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.14.0-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-0/Miniforge3-4.14.0-0-Linux-ppc64le.sh#a1614873842aec1703ea4509554998663d5a774976c30bf89c76410a5f82aaa0" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.14.0-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-0/Miniforge3-4.14.0-0-Linux-x86_64.sh#643dd45d9a9dd362508e8edd8cd535a87b002bd7716b12fb956247c8c7494908" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.14.0-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-0/Miniforge3-4.14.0-0-MacOSX-arm64.sh#91b7cadb5986af1c38555cfb4214dcb353212492a89d5e7f4c32204829ed1829" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.14.0-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-0/Miniforge3-4.14.0-0-MacOSX-x86_64.sh#80ee5ce53a1f4edb21677dd6794a043ad7d1db6e3d5ffe7a994937923a50a2c9" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.14.0-1
+++ b/plugins/python-build/share/python-build/miniforge3-4.14.0-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.14.0-1-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-1/Miniforge3-4.14.0-1-Linux-aarch64.sh#79bb1694aee2cd4bc7ee412f267f6b06ccd011cd7be6686970599bff9ab5ae0b" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.14.0-1-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-1/Miniforge3-4.14.0-1-Linux-ppc64le.sh#d82789f644759b21cbfcfb3de96b6a9879c38d6c3aa90394ee8b0916e0c5c45b" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.14.0-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-1/Miniforge3-4.14.0-1-Linux-x86_64.sh#8a83e4a7440157d57631b9cb4958591b41547263a30f02046767271695a242ad" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.14.0-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-1/Miniforge3-4.14.0-1-MacOSX-arm64.sh#d2dc25e5c73e420ae22a30abfebd24b51cb1d66d369594085ee42ba0e3e3d4d9" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.14.0-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-1/Miniforge3-4.14.0-1-MacOSX-x86_64.sh#4b956674c1c5f312bfc04f8f4d1a47bfe5cc7b9ca6a011cdd044c7152a8309d7" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-4.14.0-2
+++ b/plugins/python-build/share/python-build/miniforge3-4.14.0-2
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-4.14.0-2-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-2/Miniforge3-4.14.0-2-Linux-aarch64.sh#52e44682aecbfb1c41e9f07b0f2f08ab22369e236893768be3c85ad6c039090f" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-4.14.0-2-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-2/Miniforge3-4.14.0-2-Linux-ppc64le.sh#60d37536a07fbf9278308a8601fa125b5d643fb36e6b8e12faad45455aae3119" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-4.14.0-2-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-2/Miniforge3-4.14.0-2-Linux-x86_64.sh#ff0b9f78a51a4d9851e8fd3cdb6ff0b233f4f49d82c0690a12560e57075690bd" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-4.14.0-2-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-2/Miniforge3-4.14.0-2-MacOSX-arm64.sh#5089a254923acb6221cf7c3c5138cf68664684e18d4223e53482948c21975d7e" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-4.14.0-2-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/4.14.0-2/Miniforge3-4.14.0-2-MacOSX-x86_64.sh#ac3c2a283f6ebf24d6072d39f9bf9297c64a752315353f666260f72b02daf6d1" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Make sure you have checked all steps below.

This is the result of running the script in https://github.com/pyenv/pyenv/pull/2560.

Test script (with untracked files):

```bash
#!/usr/bin/bash

set -eu

for f in $(git ls-files --others --exclude-standard -- plugins/python-build/share); do
    bin/pyenv install $(basename $f) &> /dev/null
    bin/pyenv local $(basename $f)
    echo "Testing $(basename $f)"
    bin/pyenv exec python3 -V
    echo
    bin/pyenv uninstall -f $(basename $f) &> /dev/null
done
```

Output:

```
Testing mambaforge-22.9.0-0
Python 3.10.6

Testing mambaforge-22.9.0-1
Python 3.10.6

Testing mambaforge-22.9.0-3
Python 3.10.8

Testing mambaforge-4.10.2-0
Python 3.9.5

Testing mambaforge-4.10.3-0
Python 3.9.5

Testing mambaforge-4.10.3-1
Python 3.9.5

Testing mambaforge-4.10.3-2
Python 3.9.6

Testing mambaforge-4.10.3-3
Python 3.9.6

Testing mambaforge-4.10.3-4
Python 3.9.6

Testing mambaforge-4.10.3-5
Python 3.9.6

Testing mambaforge-4.10.3-6
Python 3.9.7

Testing mambaforge-4.10.3-7
Python 3.9.7
```

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
