### PR TITLE
Fix priority for user-supplied configure and make flags

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2198,7 +2198,7 @@ if [ -n "$DEBUG" ]; then
   package_option python configure --with-pydebug
 fi
 
-if [[ "$CONFIGURE_OPTS $PYTHON_CONFIGURE_OPTS" != *"--enable-framework"* ]]; then
+if [[ "$CONFIGURE_OPTS $PYTHON_CONFIGURE_OPTS" != *"--enable-framework"* && "$CONFIGURE_OPTS $PYTHON_CONFIGURE_OPTS" != *"--disable-shared"* ]]; then
   package_option python configure --enable-shared
 fi
 

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -813,10 +813,10 @@ build_package_standard_build() {
       export CC=clang
     fi
     ${!PACKAGE_CONFIGURE:-./configure} --prefix="${!PACKAGE_PREFIX_PATH:-$PREFIX_PATH}" \
-      $CONFIGURE_OPTS ${!PACKAGE_CONFIGURE_OPTS} "${!PACKAGE_CONFIGURE_OPTS_ARRAY}" || return 1
+      "${!PACKAGE_CONFIGURE_OPTS_ARRAY}" $CONFIGURE_OPTS ${!PACKAGE_CONFIGURE_OPTS} || return 1
   ) >&4 2>&1
 
-  { "$MAKE" $MAKE_OPTS ${!PACKAGE_MAKE_OPTS} "${!PACKAGE_MAKE_OPTS_ARRAY}"
+  { "$MAKE" "${!PACKAGE_MAKE_OPTS_ARRAY}" $MAKE_OPTS ${!PACKAGE_MAKE_OPTS}
   } >&4 2>&1
 }
 

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -613,6 +613,30 @@ make install --custom-make-install
 OUT
 }
 
+@test "--enable-shared is not added if --disable-shared is passed" {
+  cached_tarball "Python-3.6.2"
+
+  for i in {1..8}; do stub uname '-s : echo Linux'; done
+
+  stub_make_install
+
+  export PYTHON_CONFIGURE_OPTS='--disable-shared'
+  run_inline_definition <<DEF
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub make
+
+  assert_build_log <<OUT
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include" LDFLAGS="-L${TMP}/install/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --disable-shared
+make -j 2
+make install
+OUT
+}
+
 @test "configuring with dSYM in MacOS" {
   cached_tarball "Python-3.6.2"
 

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -372,7 +372,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include" LDFLAGS="-L${TMP}/install/lib" PKG_CONFIG_PATH=""
-Python-3.6.2: --prefix=$INSTALL_ROOT CPPFLAGS=-I$readline_libdir/include LDFLAGS=-L$readline_libdir/lib --enable-shared --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib CPPFLAGS=-I$readline_libdir/include LDFLAGS=-L$readline_libdir/lib
 make -j 2
 make install
 OUT
@@ -582,6 +582,34 @@ Python-3.6.2: CPPFLAGS="-I${TMP}/install/include" LDFLAGS="-L${TMP}/install/lib 
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install DOGE="such wow"
+OUT
+}
+
+@test "(PYTHON_)CONFIGURE_OPTS and (PYTHON_)MAKE_OPTS take priority over automatically added options" {
+  cached_tarball "Python-3.6.2"
+
+  for i in {1..9}; do stub uname '-s : echo Linux'; done
+
+  stub_make_install
+
+  export CONFIGURE_OPTS="--custom-configure"
+  export PYTHON_CONFIGURE_OPTS='--custom-python-configure'
+  export MAKE_OPTS="${MAKE_OPTS:+$MAKE_OPTS }--custom-make"
+  export PYTHON_MAKE_OPTS="--custom-python-make"
+  export PYTHON_MAKE_INSTALL_OPTS="--custom-make-install"
+  run_inline_definition <<DEF
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub make
+
+  assert_build_log <<OUT
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath=${TMP}/install/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib --custom-configure --custom-python-configure
+make -j 2 --custom-make --custom-python-make
+make install --custom-make-install
 OUT
 }
 

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -325,7 +325,7 @@ EOS
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath=${TMP}/install/lib"
-Python-3.6.2: --prefix=$INSTALL_ROOT --enable-unicode=ucs2 --enable-shared --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs2
 make -j 2
 make install
 OUT


### PR DESCRIPTION
Only set --enable-shared if user hasn't supplied --disable-shared

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2580

### Description
- [x] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)
* Test for the priority of user-supplied configure/make options
* Test for user-supplied --disable-shared