### PR TITLE
Undefined name: do not forget self when accessing flavor

### DIFF
--- a/plugins/python-build/scripts/add_miniconda.py
+++ b/plugins/python-build/scripts/add_miniconda.py
@@ -200,7 +200,7 @@ class CondaVersion(NamedTuple):
                 return PyVersion.PY37
             return PyVersion.PY36
 
-        raise ValueError(flavor)
+        raise ValueError(self.flavor)
 
 
 class CondaSpec(NamedTuple):


### PR DESCRIPTION
`self.flavor` is accessed in this function on lines 185 and 191.

The current code will raise a `NameError` instead of the expected `ValueError`.

% `flake8 . --count --select=E9,F63,F7,F82,Y --show-source --statistics`
```
./plugins/python-build/scripts/add_miniconda.py:203:26: F821 undefined name 'flavor'
        raise ValueError(flavor)
                         ^
1     F821 undefined name 'flavor'
1
```

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
