### PR TITLE
Fix `:latest` after #2568

### DIFF
--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -120,8 +120,8 @@ unset VERSION_NAME
 # version is specified by pyenv. Show usage instructions if a local
 # version is not specified.
 DEFINITIONS=("${ARGUMENTS[@]}")
-[[ "${#DEFINITIONS[*]}" -eq 0 ] && DEFINITIONS=($(pyenv-local 2>/dev/null || true))
-[[ "${#DEFINITIONS[*]}" -eq 0 ] && usage 1 >&2
+[[ "${#DEFINITIONS[*]}" -eq 0 ]] && DEFINITIONS=($(pyenv-local 2>/dev/null || true))
+[[ "${#DEFINITIONS[*]}" -eq 0 ]] && usage 1 >&2
 
 # Define `before_install` and `after_install` functions that allow
 # plugin hooks to register a string of code for execution before or
@@ -176,7 +176,7 @@ for DEFINITION in "${DEFINITIONS[@]}"; do
 
       case "$REPLY" in
       y | Y | yes | YES ) ;;
-      * ) { STATUS=1; [[ $STATUS -gt $COMBINED_STATUS ]] && COMBINED_STATUS=STATUS; }; continue ;;
+      * ) { STATUS=1; [[ $STATUS -gt $COMBINED_STATUS ]] && COMBINED_STATUS=$STATUS; }; continue ;;
       esac
     elif [ -n "$SKIP_EXISTING" ]; then
       # Since we know the python version is already installed, and are opting to
@@ -251,7 +251,7 @@ for DEFINITION in "${DEFINITIONS[@]}"; do
 
   # Invoke `python-build` and record the exit status in $STATUS.
   python-build $KEEP $VERBOSE $HAS_PATCH $DEBUG "$DEFINITION" "$PREFIX" || \
-      { STATUS="$?"; [[ $STATUS -gt $COMBINED_STATUS ]] && COMBINED_STATUS=STATUS; }
+      { STATUS=$?; [[ $STATUS -gt $COMBINED_STATUS ]] && COMBINED_STATUS=$STATUS; }
 
   # Display a more helpful message if the definition wasn't found.
   if [ "$STATUS" == "2" ]; then
@@ -282,7 +282,7 @@ for DEFINITION in "${DEFINITIONS[@]}"; do
   for hook in "${after_hooks[@]}"; do eval "$hook"; done
 
   # Run `pyenv-rehash` after a successful installation.
-  if [ "$STATUS" == "0" ]; then
+  if [[ $STATUS -eq 0 ]]; then
     pyenv-rehash
   else
     cleanup

--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -120,8 +120,8 @@ unset VERSION_NAME
 # version is specified by pyenv. Show usage instructions if a local
 # version is not specified.
 DEFINITIONS=("${ARGUMENTS[@]}")
-[ -n "${DEFINITIONS[*]}" ] || DEFINITIONS=($(pyenv-local 2>/dev/null || true))
-[ -n "${DEFINITIONS[*]}" ] || usage 1 >&2
+[[ "${#DEFINITIONS[*]}" -eq 0 ] && DEFINITIONS=($(pyenv-local 2>/dev/null || true))
+[[ "${#DEFINITIONS[*]}" -eq 0 ] && usage 1 >&2
 
 # Define `before_install` and `after_install` functions that allow
 # plugin hooks to register a string of code for execution before or
@@ -151,7 +151,10 @@ IFS=$'\n' scripts=(`pyenv-hooks install`)
 IFS="$OLDIFS"
 for script in "${scripts[@]}"; do source "$script"; done
 
-for DEFINITION in "${DEFINITIONS[@]}";do
+COMBINED_STATUS=0
+for DEFINITION in "${DEFINITIONS[@]}"; do
+  STATUS=0
+
   # Try to resolve a prefix if user indeed gave a prefix.
   # We install the version under the resolved name
   # and hooks also see the resolved name
@@ -173,7 +176,7 @@ for DEFINITION in "${DEFINITIONS[@]}";do
 
       case "$REPLY" in
       y | Y | yes | YES ) ;;
-      * ) exit 1 ;;
+      * ) { STATUS=1; [[ $STATUS -gt $COMBINED_STATUS ]] && COMBINED_STATUS=STATUS; }; continue ;;
       esac
     elif [ -n "$SKIP_EXISTING" ]; then
       # Since we know the python version is already installed, and are opting to
@@ -247,8 +250,8 @@ for DEFINITION in "${DEFINITIONS[@]}";do
   for hook in "${before_hooks[@]}"; do eval "$hook"; done
 
   # Invoke `python-build` and record the exit status in $STATUS.
-  STATUS=0
-  python-build $KEEP $VERBOSE $HAS_PATCH $DEBUG "$DEFINITION" "$PREFIX" || STATUS="$?"
+  python-build $KEEP $VERBOSE $HAS_PATCH $DEBUG "$DEFINITION" "$PREFIX" || \
+      { STATUS="$?"; [[ $STATUS -gt $COMBINED_STATUS ]] && COMBINED_STATUS=STATUS; }
 
   # Display a more helpful message if the definition wasn't found.
   if [ "$STATUS" == "2" ]; then
@@ -282,10 +285,11 @@ for DEFINITION in "${DEFINITIONS[@]}";do
   if [ "$STATUS" == "0" ]; then
     pyenv-rehash
   else
-    break
     cleanup
+    break
   fi
 
 done
 
-exit "${STATUS:-0}"
+
+exit "${COMBINED_STATUS}"

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -5,31 +5,36 @@ export PYENV_ROOT="${TMP}/pyenv"
 
 setup() {
   stub pyenv-hooks 'install : true'
-  stub pyenv-rehash 'true'
+  stub pyenv-rehash true
 }
 
-stub_python_build() {
+stub_python_build_lib() {
   stub python-build "--lib : $BATS_TEST_DIRNAME/../bin/python-build --lib" "$@"
-  stub pyenv-latest ": false"
 }
 
-@test "install proper" {
-  stub_python_build 'echo python-build "$@"'
+stub_python_build_no_latest() {
+  stub python_build "${@:-'echo python-build "$@"'}"
+}
+  
+stub_python_build() {
+  stub_python_build_no_latest "$@"
+  stub pyenv-latest false
+}
+
+@test "install a single version" {
+  stub_python_build_lib
+  stub_python_build
 
   run pyenv-install 3.4.2
   assert_success "python-build 3.4.2 ${PYENV_ROOT}/versions/3.4.2"
 
   unstub python-build
-  unstub pyenv-hooks
-  unstub pyenv-rehash
 }
 
-@test "install proper multi versions" {
-  #stub python-build "--lib : $BATS_TEST_DIRNAME/../bin/python-build --lib" 'echo python-build "$@"' 'echo python-build "$@"'
-  #stub pyenv-latest ": false" ": false"
-  stub_python_build 'echo python-build "$@"' 'echo python-build "$@"'
-  stub pyenv-latest ": false"
-  stub pyenv-rehash 'true'
+@test "install multiple versions" {
+  stub_python_build_lib
+  stub_python_build
+  stub_python_build
 
   run pyenv-install 3.4.1 3.4.2
   assert_success
@@ -40,61 +45,66 @@ OUT
 
   unstub python-build
   unstub pyenv-latest
-  unstub pyenv-hooks
-  unstub pyenv-rehash
 }
 
-@test "install resolves a prefix" {
-  stub_python_build 'echo python-build "$@"'
-  stub pyenv-latest '-q -k 3.4 : echo 3.4.2'
-  pyenv-latest || true  # pass through the stub entry added by stub_python_build
+@test "install multiple versions, some fail" {
+  stub_python_build_lib
+  stub_python_build 'echo "fail: python-build" "$@"; false'
+  stub_python_build
+  stub pyenv-latest false false
 
-  run pyenv-install 3.4
-  assert_success "python-build 3.4.2 ${PYENV_ROOT}/versions/3.4.2"
+  run pyenv-install 3.4.1 3.4.2
+  assert_failure
+  assert_output <<OUT
+fail: python-build 3.4.1 ${TMP}/pyenv/versions/3.4.1
+python-build 3.4.2 ${TMP}/pyenv/versions/3.4.2
+OUT
 
   unstub python-build
-  unstub pyenv-hooks
-  unstub pyenv-rehash
 }
 
-@test "install resolves a prefix with multi versions" {
-  stub_python_build 'echo python-build "$@"' 'echo python-build "$@"'
-  stub pyenv-latest '-q -k 3.4 : echo 3.4.2' '-q -k 3.5 : echo 3.5.2'
-  stub pyenv-rehash 'true'
-  pyenv-latest || true  # pass through the stub entry added by stub_python_build
 
-  run pyenv-install 3.4 3.5
+@test "install resolves a prefix" {
+  stub_python_build_lib
+  for i in {1..3}; do stub_python_build_no_latest; done
+  stub pyenv-latest \
+      '-q -k 3.4 : echo 3.4.2' \
+      '-q -k 3.5.1 : false' \
+      '-q -k 3.5 : echo 3.5.2'
+
+  run pyenv-install 3.4 3.5.1 3.5
   assert_success <<OUT
 python-build 3.4.2 ${PYENV_ROOT}/versions/3.4.2
+python-build 3.5.1 ${PYENV_ROOT}/versions/3.5.1
 python-build 3.5.2 ${PYENV_ROOT}/versions/3.5.2
 OUT
 
 
   unstub python-build
-  unstub pyenv-hooks
-  unstub pyenv-rehash
 }
 
-@test "install pyenv local version by default" {
-  stub_python_build 'echo python-build "$1"'
-  stub pyenv-local 'echo 3.4.2'
 
-  run pyenv-install
-  assert_success "python-build 3.4.2"
+@test "install resolves :latest" {
+  stub_python_build_lib
+  stub_python_build
+  stub pyenv-latest false
+
+  run pyenv-install 3.4
+  assert_success "python-build 3.4.2 ${PYENV_ROOT}/versions/3.4.2"
 
   unstub python-build
-  unstub pyenv-local
 }
 
-@test "install pyenv local multi versions by default" {
-  stub_python_build 'echo python-build "$1"' 'echo python-build "$1"'
-  stub pyenv-local 'printf "%s\n%s\n" 3.4.2 3.4.1'
-  stub pyenv-latest ": false"
+@test "install installs local versions by default" {
+  stub_python_build_lib
+  stub_python_build
+  stub_python_build
+  stub pyenv-local 'echo 3.4.2; echo 3.4.1'
 
   run pyenv-install
   assert_success <<OUT
-python-build 3.4.2"
-python-build 3.4.1"
+python-build 3.4.2
+python-build 3.4.1
 OUT
 
   unstub python-build
@@ -102,8 +112,8 @@ OUT
 }
 
 @test "list available versions" {
-  stub_python_build \
-    "--definitions : echo 2.6.9 2.7.9-rc1 2.7.9-rc2 3.4.2 | tr ' ' $'\\n'"
+  stub_python_build_lib
+  stub_python_build "--definitions : echo 2.6.9 2.7.9-rc1 2.7.9-rc2 3.4.2 | tr ' ' $'\\n'"
 
   run pyenv-install --list
   assert_success
@@ -118,10 +128,11 @@ OUT
   unstub python-build
 }
 
-@test "nonexistent version" {
+@test "upgrade instructions given for a nonexistent version" {
   stub brew false
-  stub_python_build 'echo ERROR >&2 && exit 2' \
-    "--definitions : echo 2.6.9 2.7.9-rc1 2.7.9-rc2 3.4.2 | tr ' ' $'\\n'"
+  stub_python_build_lib
+  stub_python_build 'echo ERROR >&2 && exit 2'
+  stub_python_build "--definitions : echo 2.6.9 2.7.9-rc1 2.7.9-rc2 3.4.2 | tr ' ' $'\\n'"
 
   run pyenv-install 2.7.9
   assert_failure
@@ -142,9 +153,9 @@ OUT
   unstub python-build
 }
 
-@test "Homebrew upgrade instructions" {
+@test "homebrew upgrade instructions given when pyenv is homebrew-installed" {
   stub brew "--prefix : echo '${BATS_TEST_DIRNAME%/*}'"
-  stub_python_build 'echo ERROR >&2 && exit 2' \
+  stub_python_build_lib 'echo ERROR >&2 && exit 2' \
     "--definitions : true"
 
   run pyenv-install 1.9.3
@@ -165,15 +176,19 @@ OUT
 
 @test "no build definitions from plugins" {
   assert [ ! -e "${PYENV_ROOT}/plugins" ]
+  stub_python_build_lib
   stub_python_build 'echo $PYTHON_BUILD_DEFINITIONS'
 
   run pyenv-install 3.4.2
   assert_success ""
+  
+  unstub python-build
 }
 
 @test "some build definitions from plugins" {
   mkdir -p "${PYENV_ROOT}/plugins/foo/share/python-build"
   mkdir -p "${PYENV_ROOT}/plugins/bar/share/python-build"
+  stub_python_build_lib
   stub_python_build "echo \$PYTHON_BUILD_DEFINITIONS | tr ':' $'\\n'"
 
   run pyenv-install 3.4.2
@@ -183,12 +198,15 @@ OUT
 ${PYENV_ROOT}/plugins/bar/share/python-build
 ${PYENV_ROOT}/plugins/foo/share/python-build
 OUT
+
+  unstub python-build
 }
 
 @test "list build definitions from plugins" {
   mkdir -p "${PYENV_ROOT}/plugins/foo/share/python-build"
   mkdir -p "${PYENV_ROOT}/plugins/bar/share/python-build"
-  stub_python_build "--definitions : echo \$PYTHON_BUILD_DEFINITIONS | tr ':' $'\\n'"
+  stub_python_build_lib
+  stub python_build "--definitions : echo \$PYTHON_BUILD_DEFINITIONS | tr ':' $'\\n'"
 
   run pyenv-install --list
   assert_success
@@ -198,11 +216,14 @@ Available versions:
   ${PYENV_ROOT}/plugins/bar/share/python-build
   ${PYENV_ROOT}/plugins/foo/share/python-build
 OUT
+
+  unstub python-build
 }
 
 @test "completion results include build definitions from plugins" {
   mkdir -p "${PYENV_ROOT}/plugins/foo/share/python-build"
   mkdir -p "${PYENV_ROOT}/plugins/bar/share/python-build"
+  stub_python_build_lib
   stub python-build "--definitions : echo \$PYTHON_BUILD_DEFINITIONS | tr ':' $'\\n'"
 
   run pyenv-install --complete
@@ -223,7 +244,7 @@ OUT
 }
 
 @test "not enough arguments for pyenv-install if no local version" {
-  stub_python_build
+  stub_python_build_lib
   stub pyenv-help 'install : true'
 
   run pyenv-install
@@ -233,7 +254,7 @@ OUT
 }
 
 @test "multi arguments for pyenv-install" {
-  stub_python_build
+  stub_python_build_lib
   stub pyenv-help 'install : true'
 
   run pyenv-install 3.4.1 3.4.2
@@ -242,7 +263,6 @@ OUT
 }
 
 @test "show help for pyenv-install" {
-  stub_python_build
   stub pyenv-help 'install : true'
 
   run pyenv-install -h
@@ -263,7 +283,7 @@ OUT
   unstub pyenv-help
 }
 
-@test "more than one argument for pyenv-uninstall" {
+@test "multiple arguments for pyenv-uninstall" {
   mkdir -p "${PYENV_ROOT}/versions/3.4.1"
   mkdir -p "${PYENV_ROOT}/versions/3.4.2"
   run pyenv-uninstall -f 3.4.1 3.4.2

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -13,7 +13,7 @@ stub_python_build_lib() {
 }
 
 stub_python_build_no_latest() {
-  stub python_build "${@:-'echo python-build "$@"'}"
+  stub python-build "${@:-echo python-build \"\$@\"}"
 }
   
 stub_python_build() {
@@ -50,14 +50,11 @@ OUT
 @test "install multiple versions, some fail" {
   stub_python_build_lib
   stub_python_build 'echo "fail: python-build" "$@"; false'
-  stub_python_build
-  stub pyenv-latest false false
 
   run pyenv-install 3.4.1 3.4.2
   assert_failure
   assert_output <<OUT
 fail: python-build 3.4.1 ${TMP}/pyenv/versions/3.4.1
-python-build 3.4.2 ${TMP}/pyenv/versions/3.4.2
 OUT
 
   unstub python-build
@@ -86,10 +83,12 @@ OUT
 
 @test "install resolves :latest" {
   stub_python_build_lib
+  stub_python_build '--definitions : echo 3.4.2 3.5.1'
   stub_python_build
   stub pyenv-latest false
 
   run pyenv-install 3.4
+  unstub python-build
   assert_success "python-build 3.4.2 ${PYENV_ROOT}/versions/3.4.2"
 
   unstub python-build

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -86,9 +86,14 @@ OUT
   stub_python_build '--definitions : echo 3.4.2 3.5.1'
   stub_python_build
   stub pyenv-latest false
+  
+  pyenv-hooks install; unstub pyenv-hooks
+  PYENV_INSTALL_ROOT="$BATS_TEST_DIRNAME/../../.."
+  export PYENV_HOOK_PATH="$PYENV_INSTALL_ROOT/pyenv.d"
+  [[ -d "$PYENV_INSTALL_ROOT/libexec" ]] || skip "python-build is installed separately from pyenv"
+  export PATH="$PATH:$PYENV_INSTALL_ROOT/libexec"
 
-  run pyenv-install 3.4
-  unstub python-build
+  run pyenv-install 3.4:latest
   assert_success "python-build 3.4.2 ${PYENV_ROOT}/versions/3.4.2"
 
   unstub python-build

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -83,11 +83,8 @@ OUT
 
 @test "install resolves :latest" {
   stub_python_build_lib
-  for i in {1..3}; do
-    stub_python_build '--definitions : echo 3.4.2 3.5.1 3.5.2'
-    stub_python_build
-  done
-  stub pyenv-latest false
+  for i in {1..2}; do stub_python_build '--definitions : echo -e 3.4.2\\n3.5.1\\n3.5.2'; done
+  for i in {1..2}; do stub_python_build; done
   
   pyenv-hooks install; unstub pyenv-hooks
   PYENV_INSTALL_ROOT="$BATS_TEST_DIRNAME/../../.."
@@ -95,10 +92,11 @@ OUT
   [[ -d "$PYENV_INSTALL_ROOT/libexec" ]] || skip "python-build is installed separately from pyenv"
   export PATH="$PATH:$PYENV_INSTALL_ROOT/libexec"
 
-  run pyenv-install 3.4:latest 3.5.1:latest 3:latest
-  assert_success "python-build 3.4.2 ${PYENV_ROOT}/versions/3.4.2"
-  assert_success "python-build 3.5.1 ${PYENV_ROOT}/versions/3.5.1"
-  assert_success "python-build 3.5.2 ${PYENV_ROOT}/versions/3.5.2"
+  run pyenv-install 3.4:latest 3:latest
+  assert_success <<!
+python-build 3.4.2 ${PYENV_ROOT}/versions/3.4.2
+python-build 3.5.2 ${PYENV_ROOT}/versions/3.5.2
+!
 
   unstub python-build
 }

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -161,7 +161,8 @@ OUT
 
 @test "homebrew upgrade instructions given when pyenv is homebrew-installed" {
   stub brew "--prefix : echo '${BATS_TEST_DIRNAME%/*}'"
-  stub_python_build_lib 'echo ERROR >&2 && exit 2' \
+  stub_python_build_lib
+  stub_python_build 'echo ERROR >&2 && exit 2' \
     "--definitions : true"
 
   run pyenv-install 1.9.3
@@ -212,7 +213,7 @@ OUT
   mkdir -p "${PYENV_ROOT}/plugins/foo/share/python-build"
   mkdir -p "${PYENV_ROOT}/plugins/bar/share/python-build"
   stub_python_build_lib
-  stub python_build "--definitions : echo \$PYTHON_BUILD_DEFINITIONS | tr ':' $'\\n'"
+  stub_python_build "--definitions : echo \$PYTHON_BUILD_DEFINITIONS | tr ':' $'\\n'"
 
   run pyenv-install --list
   assert_success
@@ -229,8 +230,7 @@ OUT
 @test "completion results include build definitions from plugins" {
   mkdir -p "${PYENV_ROOT}/plugins/foo/share/python-build"
   mkdir -p "${PYENV_ROOT}/plugins/bar/share/python-build"
-  stub_python_build_lib
-  stub python-build "--definitions : echo \$PYTHON_BUILD_DEFINITIONS | tr ':' $'\\n'"
+  stub_python_build "--definitions : echo \$PYTHON_BUILD_DEFINITIONS | tr ':' $'\\n'"
 
   run pyenv-install --complete
   assert_success
@@ -247,6 +247,8 @@ OUT
 ${PYENV_ROOT}/plugins/bar/share/python-build
 ${PYENV_ROOT}/plugins/foo/share/python-build
 OUT
+
+  unstub python-build
 }
 
 @test "not enough arguments for pyenv-install if no local version" {
@@ -256,15 +258,6 @@ OUT
   run pyenv-install
   assert_failure
   unstub pyenv-help
-  assert_output ""
-}
-
-@test "multi arguments for pyenv-install" {
-  stub_python_build_lib
-  stub pyenv-help 'install : true'
-
-  run pyenv-install 3.4.1 3.4.2
-  assert_success
   assert_output ""
 }
 

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -83,8 +83,10 @@ OUT
 
 @test "install resolves :latest" {
   stub_python_build_lib
-  stub_python_build '--definitions : echo 3.4.2 3.5.1'
-  stub_python_build
+  for i in {1..3}; do
+    stub_python_build '--definitions : echo 3.4.2 3.5.1 3.5.2'
+    stub_python_build
+  done
   stub pyenv-latest false
   
   pyenv-hooks install; unstub pyenv-hooks
@@ -93,8 +95,10 @@ OUT
   [[ -d "$PYENV_INSTALL_ROOT/libexec" ]] || skip "python-build is installed separately from pyenv"
   export PATH="$PATH:$PYENV_INSTALL_ROOT/libexec"
 
-  run pyenv-install 3.4:latest
+  run pyenv-install 3.4:latest 3.5.1:latest 3:latest
   assert_success "python-build 3.4.2 ${PYENV_ROOT}/versions/3.4.2"
+  assert_success "python-build 3.5.1 ${PYENV_ROOT}/versions/3.5.1"
+  assert_success "python-build 3.5.2 ${PYENV_ROOT}/versions/3.5.2"
 
   unstub python-build
 }

--- a/pyenv.d/install/latest.bash
+++ b/pyenv.d/install/latest.bash
@@ -1,13 +1,22 @@
-DEFINITION_PREFIX="${DEFINITION%%:*}"
-DEFINITION_TYPE="${DEFINITION_PREFIX%%-*}" # TODO: support non-CPython versions
-if [[ "${DEFINITION}" != "${DEFINITION_PREFIX}" ]]; then
-  DEFINITION_CANDIDATES=(\
-    $(python-build --definitions | \
-      grep -F "${DEFINITION_PREFIX}" | \
-      grep "^${DEFINITION_TYPE}" | \
-      sed -E -e '/-dev$/d' -e '/-src$/d' -e '/(b|rc)[0-9]+$/d' | \
-      sort -t. -k1,1r -k 2,2nr -k 3,3nr \
-    || true))
-  DEFINITION="${DEFINITION_CANDIDATES}"
-  VERSION_NAME="${DEFINITION##*/}"
-fi
+pyenv_install_resolve_latest() {
+  local DEFINITION_PREFIX, DEFINITION_TYPE, DEFINITION_CANDIDATES
+  local DEFINITION="$1"
+  
+  DEFINITION_PREFIX="${DEFINITION%%:*}"
+  DEFINITION_TYPE="${DEFINITION_PREFIX%%-*}" # TODO: support non-CPython versions
+  if [[ "${DEFINITION}" != "${DEFINITION_PREFIX}" ]]; then
+    DEFINITION_CANDIDATES=(\
+      $(python-build --definitions | \
+        grep -F "${DEFINITION_PREFIX}" | \
+        grep "^${DEFINITION_TYPE}" | \
+        sed -E -e '/-dev$/d' -e '/-src$/d' -e '/(b|rc)[0-9]+$/d' | \
+        sort -t. -k1,1r -k 2,2nr -k 3,3nr \
+      || true))
+    DEFINITION="${DEFINITION_CANDIDATES}"
+  fi
+}
+
+for i in $(seq ${#DEFINITIONS}); do
+  DEFINITIONS[i]="$(pyenv_install_resolve_latest "${DEFINITIONS[i]}")"
+
+unset pyenv_install_resolve_latest

--- a/pyenv.d/install/latest.bash
+++ b/pyenv.d/install/latest.bash
@@ -1,5 +1,6 @@
 pyenv_install_resolve_latest() {
-  local DEFINITION_PREFIX, DEFINITION_TYPE, DEFINITION_CANDIDATES
+  local DEFINITION_PREFIX DEFINITION_TYPE
+  local -a DEFINITION_CANDIDATES
   local DEFINITION="$1"
   
   DEFINITION_PREFIX="${DEFINITION%%:*}"
@@ -14,9 +15,11 @@ pyenv_install_resolve_latest() {
       || true))
     DEFINITION="${DEFINITION_CANDIDATES}"
   fi
+  echo "$DEFINITION"
 }
 
-for i in $(seq ${#DEFINITIONS}); do
-  DEFINITIONS[i]="$(pyenv_install_resolve_latest "${DEFINITIONS[i]}")"
+for i in ${!DEFINITIONS[*]}; do
+  DEFINITIONS[$i]="$(pyenv_install_resolve_latest "${DEFINITIONS[$i]}")"
+done
 
 unset pyenv_install_resolve_latest


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2569

### Description
- [x] Here are some details about my PR

#2568 inadvertently broke `:latest` due to changed logic.
Tests passed because there was no test for `:latest`.

### Tests
- [x] My PR adds the following unit tests (if any)

Test for `:latest`.
Note that other tests disable hooks. We enable only Pyenv built-in ones for this particular test.