### PR TITLE
Fix `pyenv which` to support auto-resolved prefixes

### DIFF
--- a/libexec/pyenv-which
+++ b/libexec/pyenv-which
@@ -55,7 +55,7 @@ for version in "${versions[@]}" "$system"; do
     PYENV_COMMAND_PATH="$(command -v "$PYENV_COMMAND" || true)"
   else
     # $version may be a prefix to be resolved by pyenv-latest
-    version_path="$(pyenv-prefix "${version} 2>/dev/null")" || \
+    version_path="$(pyenv-prefix "${version}" 2>/dev/null)" || \
         { nonexistent_versions+=("$version"); continue; }
     PYENV_COMMAND_PATH="$version_path/bin/${PYENV_COMMAND}"
     unset version_path
@@ -76,7 +76,7 @@ if [ -x "$PYENV_COMMAND_PATH" ]; then
   echo "$PYENV_COMMAND_PATH"
 else
   if (( ${#nonexistent_versions[@]} )); then
-    for version in "${#nonexistent_versions[@]}"; do
+    for version in "${nonexistent_versions[@]}"; do
       echo "pyenv: version \`$version' is not installed (set by $(pyenv-version-origin))" >&2
     done
     exit 1

--- a/libexec/pyenv-which
+++ b/libexec/pyenv-which
@@ -47,12 +47,18 @@ OLDIFS="$IFS"
 IFS=: versions=(${PYENV_VERSION:-$(pyenv-version-name)})
 IFS="$OLDIFS"
 
+declare -a nonexistent_versions
+
 for version in "${versions[@]}" "$system"; do
   if [ "$version" = "system" ]; then
     PATH="$(remove_from_path "${PYENV_ROOT}/shims")"
     PYENV_COMMAND_PATH="$(command -v "$PYENV_COMMAND" || true)"
   else
-    PYENV_COMMAND_PATH="${PYENV_ROOT}/versions/${version}/bin/${PYENV_COMMAND}"
+    # $version may be a prefix to be resolved by pyenv-latest
+    version_path="$(pyenv-prefix "${version} 2>/dev/null")" || \
+        { nonexistent_versions+=("$version"); continue; }
+    PYENV_COMMAND_PATH="$version_path/bin/${PYENV_COMMAND}"
+    unset version_path
   fi
   if [ -x "$PYENV_COMMAND_PATH" ]; then
     break
@@ -69,17 +75,10 @@ done
 if [ -x "$PYENV_COMMAND_PATH" ]; then
   echo "$PYENV_COMMAND_PATH"
 else
-  any_not_installed=0
-  for version in "${versions[@]}"; do
-    if [ "$version" = "system" ]; then
-      continue
-    fi
-    if ! [ -d "${PYENV_ROOT}/versions/${version}" ]; then
+  if (( ${#nonexistent_versions[@]} )); then
+    for version in "${#nonexistent_versions[@]}"; do
       echo "pyenv: version \`$version' is not installed (set by $(pyenv-version-origin))" >&2
-      any_not_installed=1
-    fi
-  done
-  if [ "$any_not_installed" = 1 ]; then
+    done
     exit 1
   fi
 

--- a/libexec/pyenv-which
+++ b/libexec/pyenv-which
@@ -57,6 +57,8 @@ for version in "${versions[@]}" "$system"; do
     # $version may be a prefix to be resolved by pyenv-latest
     version_path="$(pyenv-prefix "${version}" 2>/dev/null)" || \
         { nonexistent_versions+=("$version"); continue; }
+    # resolve $version for hooks
+    version="$(basenane "$version_path")"
     PYENV_COMMAND_PATH="$version_path/bin/${PYENV_COMMAND}"
     unset version_path
   fi

--- a/libexec/pyenv-which
+++ b/libexec/pyenv-which
@@ -58,7 +58,7 @@ for version in "${versions[@]}" "$system"; do
     version_path="$(pyenv-prefix "${version}" 2>/dev/null)" || \
         { nonexistent_versions+=("$version"); continue; }
     # resolve $version for hooks
-    version="$(basenane "$version_path")"
+    version="$(basename "$version_path")"
     PYENV_COMMAND_PATH="$version_path/bin/${PYENV_COMMAND}"
     unset version_path
   fi

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -113,4 +113,3 @@ OUT
   PYENV_VERSION=system:custom run pyenv-exec python3 -c 'import os; print(os.getenv("PATH"))'
   assert_success "$PATH"
 }
-

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -113,3 +113,4 @@ OUT
   PYENV_VERSION=system:custom run pyenv-exec python3 -c 'import os; print(os.getenv("PATH"))'
   assert_success "$PATH"
 }
+

--- a/test/which.bats
+++ b/test/which.bats
@@ -136,3 +136,10 @@ SH
   PYENV_VERSION= run pyenv-which python
   assert_success "${PYENV_ROOT}/versions/3.4/bin/python"
 }
+
+@test "resolves pyenv-latest prefixes" {
+  create_executable "3.4.2" "python"
+  
+  PYENV_VERSION=3.4 run pyenv-which python
+  assert_success "${PYENV_ROOT}/versions/3.4.2/bin/python"
+}

--- a/test/which.bats
+++ b/test/which.bats
@@ -144,3 +144,14 @@ SH
   assert_success "${PYENV_ROOT}/versions/3.4.2/bin/python"
 }
 
+@test "hooks get resolved version name" {
+  create_hook which echo.bash <<!
+echo version=\$version
+exit
+!
+
+  create_executable "3.4.2" "python"
+
+  PYENV_VERSION=3.4 run pyenv-which python
+  assert_success "version=3.4.2"
+}

--- a/test/which.bats
+++ b/test/which.bats
@@ -143,3 +143,4 @@ SH
   PYENV_VERSION=3.4 run pyenv-which python
   assert_success "${PYENV_ROOT}/versions/3.4.2/bin/python"
 }
+


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - None. A prerequisite to fix https://github.com/pyenv/pyenv-virtualenv/issues/441

### Description
- [x] Here are some details about my PR

A missed bit when implementing autoresolution. The code was using `-d versions/${version}` instead of delegating to `pyenv-prefix`.
Also did a cleanup to avoid iterating twice.

### Tests
- [x] My PR adds the following unit tests (if any)
* test for resolving a prefix
* test for resolving version name for hooks