### PR TITLE
Fix pyenv-latest to ignore virtualenvs

### DIFF
--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -51,7 +51,7 @@ IFS=$'\n'
     #FIXME: <version>/envs/<virtualenv> should be excluded in Pyenv-Virtualenv via a hook
     DEFINITION_CANDIDATES=(\
         $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
-          sed -E -e '/-dev$/d' -e '/-src$/d' -e '/-latest$/d' -e '/(b|rc)[0-9]+$/d' -e '/\/envs\//d'));
+          sed -E -e '/-dev$/d' -e '/-src$/d' -e '/-latest$/d' -e '/(a|b|rc)[0-9]+$/d' -e '/\/envs\//d'));
 
     # Compose a sorting key, followed by | and original value
     DEFINITION_CANDIDATES=(\

--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -48,9 +48,10 @@ IFS=$'\n'
       $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
       grep -Ee "^$prefix_re[-.]" || true))
 
+    #FIXME: <version>/envs/<virtualenv> should be excluded in Pyenv-Virtualenv via a hook
     DEFINITION_CANDIDATES=(\
         $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
-          sed -E -e '/-dev$/d' -e '/-src$/d' -e '/-latest$/d' -e '/(b|rc)[0-9]+$/d'));
+          sed -E -e '/-dev$/d' -e '/-src$/d' -e '/-latest$/d' -e '/(b|rc)[0-9]+$/d' -e '/\/envs\//d'));
 
     # Compose a sorting key, followed by | and original value
     DEFINITION_CANDIDATES=(\

--- a/test/latest.bats
+++ b/test/latest.bats
@@ -93,3 +93,22 @@ echo 3.10.6
 3.10.8
 !
 }
+
+@test "ignores rolling releases, branch tips, alternative srcs, prereleases and virtualenvs" {
+  create_executable pyenv-versions <<!
+#!$BASH
+echo 3.8.5-dev
+echo 3.8.5-src
+echo 3.8.5-latest
+echo 3.8.5a2
+echo 3.8.5b3
+echo 3.8.5rc2
+echo 3.8.1
+echo 3.8.1/envs/foo
+!
+  run pyenv-latest 3.8
+  assert_success
+  assert_output <<!
+3.8.1
+!
+}


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Workaround for https://github.com/pyenv/pyenv/issues/2606

### Description
- [x] Here are some details about my PR

When there are virtualenvs, `pyenv-latest` erroneously searches them for prefix resolution, too:

```
$ echo $PYENV_VERSION
pypy2.7-7
$ pyenv versions
  system
  3.10.9
  3.10.9/envs/venv
  3.11-dev
  pypy2.7-7.3.11
* pypy2.7-7.3.11/envs/venvpypy (set by PYENV_VERSION environment variable)
  venv
  venvpypy
```

### Tests
- [x] My PR adds the following unit tests (if any)

Test for ignoring specific entry types