### PR TITLE
Show symlink contents in non-bare `pyenv versions'

### DIFF
--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -128,7 +128,7 @@ if [ -n "$include_system" ] && \
     (PYENV_VERSION=system pyenv-which python >/dev/null 2>&1 || \
      PYENV_VERSION=system pyenv-which python3 >/dev/null 2>&1 || \
      PYENV_VERSION=system pyenv-which python2 >/dev/null 2>&1) ; then
-  print_version system
+  print_version system "/"
 fi
 
 shopt -s dotglob nullglob

--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -104,10 +104,19 @@ exists() {
 }
 
 print_version() {
+  local version="${1:?}"
+  local path="${2:?}"
+  if [[ -z "$bare" && -L "$path" ]]; then
+    # Only resolve the link itself for printing, do not resolve further.
+    # Doing otherwise would misinform the user of what the link contains.
+    version_repr="$version --> $(resolve_link "$version")"
+  else
+    version_repr="$version"
+  fi
   if [[ ${BASH_VERSINFO[0]} -ge 4 && ${current_versions["$1"]} ]]; then
-    echo "${hit_prefix}$1 (set by $(pyenv-version-origin))"
+    echo "${hit_prefix}${version_repr} (set by $(pyenv-version-origin))"
   elif (( ${BASH_VERSINFO[0]} <= 3 )) && exists "$1" "${current_versions[@]}"; then
-    echo "${hit_prefix}$1 (set by $(pyenv-version-origin))"
+    echo "${hit_prefix}${version_repr} (set by $(pyenv-version-origin))"
   else
     echo "${miss_prefix}$1"
   fi
@@ -139,14 +148,14 @@ for path in "${versions_dir_entries[@]}"; do
   if [ -d "$path" ]; then
     if [ -n "$skip_aliases" ] && [ -L "$path" ]; then
       target="$(realpath "$path")"
-      [ "${target%/*}" != "$versions_dir" ] || continue
-      [ "${target%/*/envs/*}" != "$versions_dir" ] || continue
+      [ "${target%/*}" == "$versions_dir" ] && continue
+      [ "${target%/*/envs/*}" == "$versions_dir" ] && continue
     fi
-    print_version "${path##*/}"
+    print_version "${path##*/}" "$path"
     # virtual environments created by anaconda/miniconda
     for env_path in "${path}/envs/"*; do
       if [ -d "${env_path}" ]; then
-        print_version "${env_path#${PYENV_ROOT}/versions/}"
+        print_version "${env_path#${PYENV_ROOT}/versions/}" "${env_path}"
       fi
     done
   fi

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -216,21 +216,24 @@ SH
 OUT
 }
 
-@test "prints resolves links" {
+@test "non-bare output resolves links" {
   create_version "1.9.0"
-  create_version "1.53.0"
-  create_version "1.218.0"
-  create_executable sort <<SH
-#!$BASH
-exit 1
-SH
+  create_alias "link" "foo/bar"
 
-  run pyenv-versions --bare
-  assert_success
-  assert_output <<OUT
-1.218.0
-1.53.0
-1.9.0
+  run pyenv-versions
+    assert_success <<OUT
+  1.9.0
+  link --> foo/bar
 OUT
 }
 
+@test "bare output doesn't resolve links" {
+  create_version "1.9.0"
+  create_alias "link" "foo/bar"
+
+  run pyenv-versions
+    assert_success <<OUT
+1.9.0
+link
+OUT
+}

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -143,7 +143,7 @@ OUT
 
 @test "lists symlinks under versions" {
   create_version "2.7.8"
-  ln -s "2.7.8" "${PYENV_ROOT}/versions/2.7"
+  create_alias "2.7" "2.7.8"
 
   run pyenv-versions --bare
   assert_success
@@ -155,9 +155,9 @@ OUT
 
 @test "doesn't list symlink aliases when --skip-aliases" {
   create_version "1.8.7"
-  ln -s "1.8.7" "${PYENV_ROOT}/versions/1.8"
+  create_alias "1.8" "1.8.7"
   mkdir moo
-  ln -s "${PWD}/moo" "${PYENV_ROOT}/versions/1.9"
+  create_alias "1.9" "${PWD}/moo"
 
   run pyenv-versions --bare --skip-aliases
   assert_success

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -226,14 +226,3 @@ OUT
   link --> foo/bar
 OUT
 }
-
-@test "bare output doesn't resolve links" {
-  create_version "1.9.0"
-  create_alias "link" "foo/bar"
-
-  run pyenv-versions
-    assert_success <<OUT
-1.9.0
-link
-OUT
-}

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -6,6 +6,11 @@ create_version() {
   mkdir -p "${PYENV_ROOT}/versions/$1"
 }
 
+create_alias() {
+  mkdir -p "${PYENV_ROOT}/versions"
+  ln -s "$2" "${PYENV_ROOT}/versions/$1"
+}
+
 setup() {
   mkdir -p "$PYENV_TEST_DIR"
   cd "$PYENV_TEST_DIR"
@@ -210,3 +215,22 @@ SH
 1.9.0
 OUT
 }
+
+@test "prints resolves links" {
+  create_version "1.9.0"
+  create_version "1.53.0"
+  create_version "1.218.0"
+  create_executable sort <<SH
+#!$BASH
+exit 1
+SH
+
+  run pyenv-versions --bare
+  assert_success
+  assert_output <<OUT
+1.218.0
+1.53.0
+1.9.0
+OUT
+}
+


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/1563

### Description
- [x] Here are some details about my PR

In non-bare display, if a `versions/` entry is a symlink, show its _direct_ contents (do no resolve further so as not to misinform the user of its contents).

### Tests
- [x] My PR adds the following unit tests (if any)
Test the added function