### PR TITLE
Ignore virtualenvs in `pyenv latest' in a clean way

### DIFF
--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -31,7 +31,7 @@ exitcode=0
 IFS=$'\n'
 
     if [[ -z $FROM_KNOWN ]]; then
-        DEFINITION_CANDIDATES=( $(pyenv-versions --bare) )
+        DEFINITION_CANDIDATES=( $(pyenv-versions --bare --skip-envs) )
     else
         DEFINITION_CANDIDATES=( $(python-build --definitions ) )
     fi
@@ -48,10 +48,9 @@ IFS=$'\n'
       $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
       grep -Ee "^$prefix_re[-.]" || true))
 
-    #FIXME: <version>/envs/<virtualenv> should be excluded in Pyenv-Virtualenv via a hook
     DEFINITION_CANDIDATES=(\
         $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
-          sed -E -e '/-dev$/d' -e '/-src$/d' -e '/-latest$/d' -e '/(a|b|rc)[0-9]+$/d' -e '/\/envs\//d'));
+          sed -E -e '/-dev$/d' -e '/-src$/d' -e '/-latest$/d' -e '/(a|b|rc)[0-9]+$/d'));
 
     # Compose a sorting key, followed by | and original value
     DEFINITION_CANDIDATES=(\

--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -71,8 +71,6 @@ else
   current_versions=()
 fi
 if [ -n "$bare" ]; then
-  hit_prefix=""
-  miss_prefix=""
   include_system=""
 else
   hit_prefix="* "
@@ -106,8 +104,12 @@ exists() {
 
 print_version() {
   local version="${1:?}"
+  if [[ -n $bare ]]; then
+    echo "$version"
+    return
+  fi
   local path="${2:?}"
-  if [[ -z "$bare" && -L "$path" ]]; then
+  if [[ -L "$path" ]]; then
     # Only resolve the link itself for printing, do not resolve further.
     # Doing otherwise would misinform the user of what the link contains.
     version_repr="$version --> $(resolve_link "$path")"

--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
 # Summary: List all Python versions available to pyenv
-# Usage: pyenv versions [--bare] [--skip-aliases]
+# Usage: pyenv versions [--bare] [--skip-aliases] [--skip-envs]
 #
 # Lists all Python versions found in `$PYENV_ROOT/versions/*'.
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
-unset bare
-unset skip_aliases
+unset bare skip_aliases skip_envs
 # Provide pyenv completions
 for arg; do
   case "$arg" in
   --complete )
     echo --bare
     echo --skip-aliases
+    echo --skip-envs
     exit ;;
   --bare ) bare=1 ;;
   --skip-aliases ) skip_aliases=1 ;;
+  --skip-envs ) skip_envs=1 ;;
   * )
     pyenv-help --usage versions >&2
     exit 1
@@ -109,7 +110,7 @@ print_version() {
   if [[ -z "$bare" && -L "$path" ]]; then
     # Only resolve the link itself for printing, do not resolve further.
     # Doing otherwise would misinform the user of what the link contains.
-    version_repr="$version --> $(resolve_link "$version")"
+    version_repr="$version --> $(resolve_link "$path")"
   else
     version_repr="$version"
   fi
@@ -152,12 +153,14 @@ for path in "${versions_dir_entries[@]}"; do
       [ "${target%/*/envs/*}" == "$versions_dir" ] && continue
     fi
     print_version "${path##*/}" "$path"
-    # virtual environments created by anaconda/miniconda
-    for env_path in "${path}/envs/"*; do
-      if [ -d "${env_path}" ]; then
-        print_version "${env_path#${PYENV_ROOT}/versions/}" "${env_path}"
-      fi
-    done
+    # virtual environments created by anaconda/miniconda/pyenv-virtualenv
+    if [[ -z $skip_envs ]]; then
+      for env_path in "${path}/envs/"*; do
+        if [ -d "${env_path}" ]; then
+          print_version "${env_path#${PYENV_ROOT}/versions/}" "${env_path}"
+        fi
+      done
+    fi
   fi
 done
 shopt -u dotglob nullglob

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -66,18 +66,38 @@ OUT
   assert_success "3.3"
 }
 
-@test "multiple versions" {
+@test "multiple versions and envs" {
   stub_system_python
   create_version "2.7.6"
-  create_version "3.3.3"
   create_version "3.4.0"
+  create_version "3.4.0/envs/foo"
+  create_version "3.4.0/envs/bar"
+  create_version "3.5.2"
   run pyenv-versions
   assert_success
   assert_output <<OUT
 * system (set by ${PYENV_ROOT}/version)
   2.7.6
+  3.4.0
+  3.4.0/envs/bar
+  3.4.0/envs/foo
+  3.5.2
+OUT
+}
+
+@test "skips envs with --skip-envs" {
+  create_version "3.3.3"
+  create_version "3.4.0"
+  create_version "3.4.0/envs/foo"
+  create_version "3.4.0/envs/bar"
+  create_version "3.5.0"
+
+  run pyenv-versions --skip-envs
+    assert_success <<OUT
+* system (set by ${PYENV_ROOT}/version)
   3.3.3
   3.4.0
+  3.5.0
 OUT
 }
 
@@ -216,7 +236,7 @@ SH
 OUT
 }
 
-@test "non-bare output resolves links" {
+@test "non-bare output shows symlink contents" {
   create_version "1.9.0"
   create_alias "link" "foo/bar"
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/pull/2608

### Description
- [x] Here are some details about my PR

The core reason why https://github.com/pyenv/pyenv/pull/2608 happened is because `pyenv-versions` prints `*/envs/*` in addition to the raw `versions/` contents. So the clean way to fix it is to make it not do so in the first place.

### Tests
- [x] My PR adds the following unit tests (if any)
Test for the added `pyenv-versions` option