### PR TITLE
Fix link resolving in pyenv-versions

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -17,7 +17,7 @@ jobs:
           - "3.11"
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Normally, we would use the superbly maintained...
       # - uses: actions/setup-python@v2
       #   with:

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -6,7 +6,7 @@ jobs:
     outputs:
       versions: ${{steps.modified-versions.outputs.versions}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch origin "$GITHUB_BASE_REF"
       - shell: bash
         run: >
@@ -30,7 +30,7 @@ jobs:
         os: ["macos-11", "macos-12"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
           #envvars
           export PYENV_ROOT="$GITHUB_WORKSPACE"
@@ -90,7 +90,7 @@ jobs:
         os: ["ubuntu-20.04", "ubuntu-22.04"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
           #envvars
           export PYENV_ROOT="$GITHUB_WORKSPACE"

--- a/.github/workflows/pyenv_tests.yml
+++ b/.github/workflows/pyenv_tests.yml
@@ -42,3 +42,8 @@ jobs:
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
       - run: |
           make test
+      - env:
+          PYENV_NATIVE_EXT: 1
+        run: |
+          (cd src; ./configure; make)
+          bats/bin/bats test/{pyenv,hooks,versions}.bats

--- a/.github/workflows/pyenv_tests.yml
+++ b/.github/workflows/pyenv_tests.yml
@@ -16,7 +16,7 @@ jobs:
           - macos-11
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Normally, we would use the superbly maintained...
       # - uses: actions/setup-python@v2
       #   with:

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -17,7 +17,7 @@ jobs:
           - "3.11"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Normally, we would use the superbly maintained...
       # - uses: actions/setup-python@v2
       #   with:

--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -112,7 +112,7 @@ print_version() {
   if [[ -L "$path" ]]; then
     # Only resolve the link itself for printing, do not resolve further.
     # Doing otherwise would misinform the user of what the link contains.
-    version_repr="$version --> $(resolve_link "$path")"
+    version_repr="$version --> $(readlink "$path")"
   else
     version_repr="$version"
   fi
@@ -157,12 +157,12 @@ for path in "${versions_dir_entries[@]}"; do
     print_version "${path##*/}" "$path"
     # virtual environments created by anaconda/miniconda/pyenv-virtualenv
     if [[ -z $skip_envs ]]; then
-      for env_path in "${path}/envs/"*; do
-        if [ -d "${env_path}" ]; then
-          print_version "${env_path#${PYENV_ROOT}/versions/}" "${env_path}"
-        fi
-      done
-    fi
+    for env_path in "${path}/envs/"*; do
+      if [ -d "${env_path}" ]; then
+        print_version "${env_path#${PYENV_ROOT}/versions/}" "${env_path}"
+      fi
+    done
+  fi
   fi
 done
 shopt -u dotglob nullglob


### PR DESCRIPTION
Resolves a bug introduced in #2609, `resolve_link` is not defined when `pyenv-realpath.dylib` is built. Here, the public API should be `realpath` but not `resolve_link`.
