### PR TITLE
Add CPython 3.12.0a5

### DIFF
--- a/plugins/python-build/share/python-build/3.12.0a5
+++ b/plugins/python-build/share/python-build/3.12.0a5
@@ -3,7 +3,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.12.0a4" "https://www.python.org/ftp/python/3.12.0/Python-3.12.0a4.tar.xz#b9176c46b1cd21dbdcb31bbbab6169faa92da9acc5f35bd4a009879ac74cf6af" standard verify_py312 copy_python_gdb ensurepip
+    install_package "Python-3.12.0a5" "https://www.python.org/ftp/python/3.12.0/Python-3.12.0a5.tar.xz#d66ef7a342fe3a356f9cee3bb97adc1e5fb4840f6b6cff7de0ff7dd495f8323b" standard verify_py312 copy_python_gdb ensurepip
 else
-    install_package "Python-3.12.0a4" "https://www.python.org/ftp/python/3.12.0/Python-3.12.0a4.tgz#d9d9cbebc745ecaf5cae6b4004a84692154183b729954d3a421fba3d2a541d59" standard verify_py312 copy_python_gdb ensurepip
+    install_package "Python-3.12.0a5" "https://www.python.org/ftp/python/3.12.0/Python-3.12.0a5.tgz#53bea5094887bba2fc4f429fa8abb4976b5c7cfe70d41923cf6aff0b4854c666" standard verify_py312 copy_python_gdb ensurepip
 fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [X] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [X] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [X] My PR does not address any issues

### Description
- [X] This PR adds the recently released Python 3.12.0a5 to pyenv.

### Tests
- [X] My PR does not add any unit tests
