### PR TITLE
Add "Building for maximum performance" instructions for Apple silicon

### DIFF
--- a/plugins/python-build/README.md
+++ b/plugins/python-build/README.md
@@ -175,6 +175,15 @@ common for performance improvement from this to be in the ballpark of 30%.
 env PYTHON_CONFIGURE_OPTS='--enable-optimizations --with-lto' PYTHON_CFLAGS='-march=native -mtune=native' pyenv install 3.6.0
 ```
 
+If you are using a Mac computer with Apple silicon (e.g. M1), you must install
+`clang` 15+ before running the command above, and choose a recent minor version
+of Python. If you use Homebrew to update `clang` (`brew install llvm`), you must
+make sure the correct version is used:
+
+```sh
+env PATH="/opt/homebrew/opt/llvm/bin:$PATH" PYTHON_CONFIGURE_OPTS='--enable-optimizations --with-lto' PYTHON_CFLAGS='-march=native -mtune=native' pyenv install 3.10
+```
+
 You can also customize the task used for profile guided optimization by setting
 the `PROFILE_TASK` environment variable, for instance, `PROFILE_TASK='-m
 test.regrtest --pgo -j0'` will run much faster than the default task.


### PR DESCRIPTION
This is a documentation-only PR, targeted at Apple silicon users trying to follow "Building for maximum performance".

The `-march=native` flag does not work under the default `clang` version at the time of writing (clang 14):

https://stackoverflow.com/questions/65966969/why-does-march-native-not-work-on-apple-m1

Additionally, `--enable-optimizations --with-lto` is only supported by recent Python minor versions on macOS:

https://github.com/python/cpython/issues/86401

In the issue above, they mention 3.10+, with the intent to backport. I haven't checked if it's been backported to specific prior micro versions.

Finally, the installation does not use a Homebrew-updated `clang` by default.
