### PR TITLE
Support for "BusyBox version" of "head"

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -29,7 +29,7 @@ if enable -f "${BASH_SOURCE%/*}"/../libexec/pyenv-realpath.dylib realpath 2>/dev
 else
   [ -z "$PYENV_NATIVE_EXT" ] || abort "failed to load \`realpath' builtin"
 
-  READLINK=$(type -P greadlink readlink | head -1)
+  READLINK=$(type -P greadlink readlink | head -n1)
   [ -n "$READLINK" ] || abort "cannot find readlink - are you missing GNU coreutils?"
 
   resolve_link() {

--- a/libexec/pyenv-help
+++ b/libexec/pyenv-help
@@ -46,7 +46,7 @@ extract_initial_comment_block() {
 collect_documentation() {
   # `tail` prevents "broken pipe" errors due to `head` closing the pipe without reading everything
   # https://superuser.com/questions/554855/how-can-i-fix-a-broken-pipe-error/642932#642932
-  $(type -P gawk awk | tail -n +1 | head -1) '
+  $(type -P gawk awk | tail -n +1 | head -n1) '
     /^Summary:/ {
       summary = substr($0, 10)
       next

--- a/libexec/pyenv-hooks
+++ b/libexec/pyenv-hooks
@@ -26,7 +26,7 @@ if ! enable -f "${BASH_SOURCE%/*}"/pyenv-realpath.dylib realpath 2>/dev/null; th
     echo "pyenv: failed to load \`realpath' builtin" >&2
     exit 1
   fi
-READLINK=$(type -P greadlink readlink | head -1)
+READLINK=$(type -P greadlink readlink | head -n1)
 if [ -z "$READLINK" ]; then
   echo "pyenv: cannot find readlink - are you missing GNU coreutils?" >&2
   exit 1

--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -34,7 +34,7 @@ if ! enable -f "${BASH_SOURCE%/*}"/pyenv-realpath.dylib realpath 2>/dev/null; th
     exit 1
   fi
 
-  READLINK=$(type -P greadlink readlink | head -1)
+  READLINK=$(type -P greadlink readlink | head -n1)
   if [ -z "$READLINK" ]; then
     echo "pyenv: cannot find readlink - are you missing GNU coreutils?" >&2
     exit 1

--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -59,7 +59,7 @@ usage() {
 
 definitions() {
   local query="$1"
-  python-build --definitions | $(type -P ggrep grep | head -1) -F "$query" || true
+  python-build --definitions | $(type -P ggrep grep | head -n1) -F "$query" || true
 }
 
 indent() {

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -58,7 +58,7 @@ lib "$1"
 
 
 resolve_link() {
-  $(type -P greadlink readlink | head -1) "$1"
+  $(type -P greadlink readlink | head -n1) "$1"
 }
 
 abs_dirname() {
@@ -102,7 +102,7 @@ os_information() {
     source /etc/os-release
     echo "$NAME" $VERSION_ID
   else
-    local os="$(cat /etc/{centos,redhat,fedora,system}-release /etc/debian_version 2>/dev/null | head -1)"
+    local os="$(cat /etc/{centos,redhat,fedora,system}-release /etc/debian_version 2>/dev/null | head -n1)"
     echo "${os:-$(uname -sr)}"
   fi
 }
@@ -256,7 +256,7 @@ compute_sha2() {
     output="$(shasum -a 256 -b)" || return 1
     echo "${output% *}"
   elif type openssl &>/dev/null; then
-    local openssl="$(command -v "$(brew --prefix openssl 2>/dev/null || true)"/bin/openssl openssl | head -1)"
+    local openssl="$(command -v "$(brew --prefix openssl 2>/dev/null || true)"/bin/openssl openssl | head -n1)"
     output="$("$openssl" dgst -sha256 2>/dev/null)" || return 1
     echo "${output##* }"
   elif type sha256sum &>/dev/null; then
@@ -867,7 +867,7 @@ build_package_jython() {
 fix_jython_shebangs() {
   # Workaround for Jython 2.7+ (#458)
   for file in "${PREFIX_PATH}/bin"/*; do
-    case "$(head -1 "${file}")" in
+    case "$(head -n1 "${file}")" in
     "#!"*"/bin/jython" )
       sed -i.bak "1 s:.*:#\!${PREFIX_PATH}\/bin\/jython:" "${file}"
       ;;
@@ -1144,7 +1144,7 @@ fix_directory_permissions() {
 }
 
 require_java7() {
-  local version="$(java -version 2>&1 | grep '\(java\|openjdk\) version' | head -1)"
+  local version="$(java -version 2>&1 | grep '\(java\|openjdk\) version' | head -n1)"
   if [[ $version != *[789]* ]]; then
     colorize 1 "ERROR" >&3
     echo ": Java 7 required. Please install a 1.7-compatible JRE." >&3
@@ -1587,7 +1587,7 @@ build_package_verify_openssl() {
       RbConfig::CONFIG.fetch("configure_args").shellsplit.each { |arg| $stderr.puts "  #{arg}" }
       exit 1
     end
-  ' "$(basename "$(type -P yum apt-get | head -1)")" >&4 2>&1
+  ' "$(basename "$(type -P yum apt-get | head -n1)")" >&4 2>&1
 }
 
 use_homebrew_zlib() {

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -89,7 +89,7 @@ install_tmp_fixture() {
 }
 
 resolve_link() {
-  $(type -P greadlink readlink | head -1) "$1"
+  $(type -P greadlink readlink | head -n1) "$1"
 }
 
 run_inline_definition_with_name() {

--- a/plugins/python-build/test/test_helper.bash
+++ b/plugins/python-build/test/test_helper.bash
@@ -133,7 +133,7 @@ assert_output_contains() {
     echo "assert_output_contains needs an argument" >&2
     return 1
   fi
-  echo "$output" | $(type -P ggrep grep | head -1) -F "$expected" >/dev/null || {
+  echo "$output" | $(type -P ggrep grep | head -n1) -F "$expected" >/dev/null || {
     { echo "expected output to contain $expected"
       echo "actual: $output"
     } | flunk

--- a/plugins/python-build/test/version.bats
+++ b/plugins/python-build/test/version.bats
@@ -3,7 +3,7 @@
 load test_helper
 
 bats_bin="${BATS_TEST_DIRNAME}/../bin/python-build"
-static_version="$(grep VERSION "$bats_bin" | head -1 | cut -d'"' -f 2)"
+static_version="$(grep VERSION "$bats_bin" | head -n1 | cut -d'"' -f 2)"
 
 @test "python-build static version" {
   stub git 'echo "ASPLODE" >&2; exit 1'


### PR DESCRIPTION
I wanted to try some things within [Venus OS](https://github.com/victronenergy/venus) without killing the python installation there (seemingly a use case for pyenv :-) )

I used the pyenv source package `v2.3.13.tar.gz` and this failed with
```
# head -1
head: invalid option -- '1'
BusyBox v1.31.1 (2023-02-09 11:42:03 UTC) multi-call binary.

Usage: head [OPTIONS] [FILE]...
```

So I was tempted to patch pyenv to use `head -n1` instead of `head -1`
In the systems I know, both are valid.

If there are versions of `head` out there which *don't* support `head -n1` I could also implement some check first and use the appropriate version then, which would be an overkill if it's not necessary.

Any thoughts on this?