### PR TITLE
bpo-27987 for v3.5.10 and v3.6.15: align by 16bytes on 64bit platforms

### DIFF
--- a/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0001-bpo-27987-pymalloc-align-by-16bytes-on-64bit-platfor.patch
+++ b/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0001-bpo-27987-pymalloc-align-by-16bytes-on-64bit-platfor.patch
@@ -1,0 +1,43 @@
+From 112cceb514e79b4c9805f9e5ea037a205be428da Mon Sep 17 00:00:00 2001
+From: Inada Naoki <songofacandy@gmail.com>
+Date: Tue, 14 May 2019 18:51:15 +0900
+Subject: [PATCH 1/2] bpo-27987: pymalloc: align by 16bytes on 64bit platform
+ (GH-12850)
+
+---
+ .../2019-04-16-11-52-21.bpo-27987.n2_DcQ.rst                | 3 +++
+ Objects/obmalloc.c                                          | 6 ++++++
+ 2 files changed, 9 insertions(+)
+ create mode 100644 Misc/NEWS.d/next/Core and Builtins/2019-04-16-11-52-21.bpo-27987.n2_DcQ.rst
+
+diff --git a/Misc/NEWS.d/next/Core and Builtins/2019-04-16-11-52-21.bpo-27987.n2_DcQ.rst b/Misc/NEWS.d/next/Core and Builtins/2019-04-16-11-52-21.bpo-27987.n2_DcQ.rst
+new file mode 100644
+index 0000000000..b0f32a5c6c
+--- /dev/null
++++ b/Misc/NEWS.d/next/Core and Builtins/2019-04-16-11-52-21.bpo-27987.n2_DcQ.rst	
+@@ -0,0 +1,3 @@
++pymalloc returns memory blocks aligned by 16 bytes, instead of 8 bytes, on
++64-bit platforms to conform x86-64 ABI. Recent compilers assume this alignment
++more often. Patch by Inada Naoki.
+diff --git a/Objects/obmalloc.c b/Objects/obmalloc.c
+index 9dd8421a33..da9029c4a6 100644
+--- a/Objects/obmalloc.c
++++ b/Objects/obmalloc.c
+@@ -540,8 +540,14 @@ static int running_on_valgrind = -1;
+  *
+  * You shouldn't change this unless you know what you are doing.
+  */
++
++#if SIZEOF_VOID_P > 4
++#define ALIGNMENT              16               /* must be 2^N */
++#define ALIGNMENT_SHIFT         4
++#else
+ #define ALIGNMENT               8               /* must be 2^N */
+ #define ALIGNMENT_SHIFT         3
++#endif
+ 
+ /* Return the number of bytes in size class I, as a uint. */
+ #define INDEX2SIZE(I) (((uint)(I) + 1) << ALIGNMENT_SHIFT)
+-- 
+2.38.4
+

--- a/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0002-bpo-27987-align-PyGC_Head-to-alignof-long-double-GH-.patch
+++ b/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0002-bpo-27987-align-PyGC_Head-to-alignof-long-double-GH-.patch
@@ -1,0 +1,40 @@
+From 618ef35426ecc57da1bee50f8dc5896f5fb178a9 Mon Sep 17 00:00:00 2001
+From: Inada Naoki <songofacandy@gmail.com>
+Date: Sat, 25 May 2019 21:13:33 +0900
+Subject: [PATCH 2/2] bpo-27987: align PyGC_Head to alignof(long double)
+ (GH-13335)
+
+---
+ Include/objimpl.h                                           | 6 +++++-
+ .../2019-05-15-18-28-43.bpo-27987.FaxuLy.rst                | 2 ++
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+ create mode 100644 Misc/NEWS.d/next/Core and Builtins/2019-05-15-18-28-43.bpo-27987.FaxuLy.rst
+
+diff --git a/Include/objimpl.h b/Include/objimpl.h
+index 65b6d91c36..eaf57975c8 100644
+--- a/Include/objimpl.h
++++ b/Include/objimpl.h
+@@ -250,7 +250,11 @@ typedef union _gc_head {
+         union _gc_head *gc_prev;
+         Py_ssize_t gc_refs;
+     } gc;
+-    double dummy;  /* force worst-case alignment */
++    long double dummy;  /* force worst-case alignment */
++    // malloc returns memory block aligned for any built-in types and
++    // long double is the largest standard C type.
++    // On amd64 linux, long double requires 16 byte alignment.
++    // See bpo-27987 for more discussion.
+ } PyGC_Head;
+ 
+ extern PyGC_Head *_PyGC_generation0;
+diff --git a/Misc/NEWS.d/next/Core and Builtins/2019-05-15-18-28-43.bpo-27987.FaxuLy.rst b/Misc/NEWS.d/next/Core and Builtins/2019-05-15-18-28-43.bpo-27987.FaxuLy.rst
+new file mode 100644
+index 0000000000..97ca37b262
+--- /dev/null
++++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-15-18-28-43.bpo-27987.FaxuLy.rst	
+@@ -0,0 +1,2 @@
++``PyGC_Head`` structure is aligned to ``long double``.  This is needed to
++GC-ed objects are aligned properly.  Patch by Inada Naoki.
+-- 
+2.38.4
+

--- a/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0003-bpo-45405-Prevent-internal-configure-error-when-runn.patch
+++ b/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0003-bpo-45405-Prevent-internal-configure-error-when-runn.patch
@@ -1,0 +1,86 @@
+From 655f26bb742d6bd32c388e9fea14b64eb25fd4de Mon Sep 17 00:00:00 2001
+From: Ned Deily <nad@python.org>
+Date: Tue, 15 Mar 2022 03:18:39 -0400
+Subject: [PATCH] bpo-45405: Prevent internal configure error when running
+ configure with recent versions of clang. (GH-28845) (GH-31890)
+
+Change the configure logic to function properly on macOS when the compiler
+outputs a platform triplet for option --print-multiarch.
+The Apple Clang included with Xcode 13.3 now supports --print-multiarch
+causing configure to fail without this change.
+
+Co-authored-by: Ned Deily <nad@python.org>
+(cherry picked from commit 9c4766772cda67648184f8ddba546a5fc0167f91)
+
+Co-authored-by: David Bohman <debohman@gmail.com>
+(cherry picked from commit 720bb456dc711b0776bae837d1f9a0b10c28ddf2)
+---
+ .../next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst   | 2 ++
+ configure                                                 | 8 +++++---
+ configure.ac                                              | 8 +++++---
+ 3 files changed, 12 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+new file mode 100644
+index 0000000000..13c93d1b8a
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2021-10-11-16-27-38.bpo-45405.iSfdW5.rst
+@@ -0,0 +1,2 @@
++Prevent ``internal configure error`` when running ``configure``
++with recent versions of clang.  Patch by David Bohman.
+diff --git a/configure b/configure
+index fb0a499145..67e6e69b5f 100755
+--- a/configure
++++ b/configure
+@@ -5203,9 +5203,6 @@ $as_echo "$as_me:
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }
+ cat >> conftest.c <<EOF
+@@ -5334,6 +5331,11 @@ $as_echo "none" >&6; }
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     as_fn_error $? "internal configure error for the platform triplet, please file a bug report" "$LINENO" 5
+diff --git a/configure.ac b/configure.ac
+index d86dad9a7c..468ad6070f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -747,9 +747,6 @@ then
+ fi
+ 
+ 
+-MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+-AC_SUBST(MULTIARCH)
+-
+ AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
+ cat >> conftest.c <<EOF
+ #undef bfin
+@@ -875,6 +872,11 @@ else
+ fi
+ rm -f conftest.c conftest.out
+ 
++if test x$PLATFORM_TRIPLET != xdarwin; then
++  MULTIARCH=$($CC --print-multiarch 2>/dev/null)
++fi
++AC_SUBST(MULTIARCH)
++
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then
+   if test x$PLATFORM_TRIPLET != x$MULTIARCH; then
+     AC_MSG_ERROR([internal configure error for the platform triplet, please file a bug report])
+-- 
+2.32.0 (Apple Git-132)
+

--- a/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0004-Detect-arm64-in-configure.patch
+++ b/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0004-Detect-arm64-in-configure.patch
@@ -1,0 +1,41 @@
+From 002501946bad91a308f37a09204393c172f03c3e Mon Sep 17 00:00:00 2001
+From: Takumi Sueda <puhitaku@gmail.com>
+Date: Sat, 11 Sep 2021 16:50:14 +0900
+Subject: [PATCH 2/6] Detect arm64 in configure
+
+---
+ configure    | 3 +++
+ configure.ac | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/configure b/configure
+index e39c16eee2..8dc1fc7595 100755
+--- a/configure
++++ b/configure
+@@ -9230,6 +9230,9 @@ fi
+     	ppc)
+     		MACOSX_DEFAULT_ARCH="ppc64"
+     		;;
++    	arm64)
++    		MACOSX_DEFAULT_ARCH="arm64"
++    		;;
+     	*)
+     		as_fn_error $? "Unexpected output of 'arch' on OSX" "$LINENO" 5
+     		;;
+diff --git a/configure.ac b/configure.ac
+index cf280506bd..34846a7df3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2435,6 +2435,9 @@ case $ac_sys_system/$ac_sys_release in
+     	ppc)
+     		MACOSX_DEFAULT_ARCH="ppc64"
+     		;;
++    	arm64) 
++    		MACOSX_DEFAULT_ARCH="arm64" 
++    		;;
+     	*)
+     		AC_MSG_ERROR([Unexpected output of 'arch' on OSX])
+     		;;
+-- 
+2.30.1 (Apple Git-130)
+

--- a/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0005-BPO-41100-Support-macOS-11-when-building-GH-21113.patch
+++ b/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0005-BPO-41100-Support-macOS-11-when-building-GH-21113.patch
@@ -1,0 +1,48 @@
+From 8ea6353f60625c96ce96588c70ff24a77f8c71f9 Mon Sep 17 00:00:00 2001
+From: Ronald Oussoren <ronaldoussoren@mac.com>
+Date: Thu, 25 Jun 2020 16:55:48 +0200
+Subject: [PATCH] BPO-41100: Support macOS 11 when building (GH-21113)
+
+---
+ Misc/NEWS.d/next/macOS/2020-06-24-13-51-57.bpo-41100.mcHdc5.rst | 1 +
+ configure                                                       | 2 +-
+ configure.ac                                                    | 2 +-
+ 3 files changed, 3 insertions(+), 2 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/macOS/2020-06-24-13-51-57.bpo-41100.mcHdc5.rst
+
+diff --git a/Misc/NEWS.d/next/macOS/2020-06-24-13-51-57.bpo-41100.mcHdc5.rst b/Misc/NEWS.d/next/macOS/2020-06-24-13-51-57.bpo-41100.mcHdc5.rst
+new file mode 100644
+index 0000000000..ded66b567a
+--- /dev/null
++++ b/Misc/NEWS.d/next/macOS/2020-06-24-13-51-57.bpo-41100.mcHdc5.rst
+@@ -0,0 +1 @@
++Support macOS 11 when building.
+diff --git a/configure b/configure
+index c51f396824..5024860ca4 100755
+--- a/configure
++++ b/configure
+@@ -3375,7 +3375,7 @@ $as_echo "#define _BSD_SOURCE 1" >>confdefs.h
+   # has no effect, don't bother defining them
+   Darwin/[6789].*)
+     define_xopen_source=no;;
+-  Darwin/1[0-9].*)
++  Darwin/[12][0-9].*)
+     define_xopen_source=no;;
+   # On AIX 4 and 5.1, mbstate_t is defined only when _XOPEN_SOURCE == 500 but
+   # used in wcsnrtombs() and mbsnrtowcs() even if _XOPEN_SOURCE is not defined
+diff --git a/configure.ac b/configure.ac
+index 70deefb6b9..5a3e340aa3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -495,7 +495,7 @@ case $ac_sys_system/$ac_sys_release in
+   # has no effect, don't bother defining them
+   Darwin/@<:@6789@:>@.*)
+     define_xopen_source=no;;
+-  Darwin/1@<:@0-9@:>@.*)
++  Darwin/@<:@[12]@:>@@<:@0-9@:>@.*)
+     define_xopen_source=no;;
+   # On AIX 4 and 5.1, mbstate_t is defined only when _XOPEN_SOURCE == 500 but
+   # used in wcsnrtombs() and mbsnrtowcs() even if _XOPEN_SOURCE is not defined
+-- 
+2.30.1 (Apple Git-130)
+

--- a/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0006-bpo-41100-fix-_decimal-for-arm64-Mac-OS-GH-21228.patch
+++ b/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0006-bpo-41100-fix-_decimal-for-arm64-Mac-OS-GH-21228.patch
@@ -1,0 +1,37 @@
+From 604d95e235d86465b8c17f02095edcaf18464d4c Mon Sep 17 00:00:00 2001
+From: Lawrence D'Anna <64555057+lawrence-danna-apple@users.noreply.github.com>
+Date: Tue, 30 Jun 2020 02:15:46 -0700
+Subject: [PATCH] bpo-41100: fix _decimal for arm64 Mac OS (GH-21228)
+
+Patch by Lawrence Danna.
+---
+ .../Core and Builtins/2020-06-30-04-44-29.bpo-41100.PJwA6F.rst | 1 +
+ Modules/_decimal/libmpdec/mpdecimal.h                          | 3 +++
+ 2 files changed, 4 insertions(+)
+ create mode 100644 Misc/NEWS.d/next/Core and Builtins/2020-06-30-04-44-29.bpo-41100.PJwA6F.rst
+
+diff --git a/Misc/NEWS.d/next/Core and Builtins/2020-06-30-04-44-29.bpo-41100.PJwA6F.rst b/Misc/NEWS.d/next/Core and Builtins/2020-06-30-04-44-29.bpo-41100.PJwA6F.rst
+new file mode 100644
+index 0000000000..d6176d69f0
+--- /dev/null
++++ b/Misc/NEWS.d/next/Core and Builtins/2020-06-30-04-44-29.bpo-41100.PJwA6F.rst	
+@@ -0,0 +1 @@
++add arm64 to the allowable Mac OS arches in mpdecimal.h
+\ No newline at end of file
+diff --git a/Modules/_decimal/libmpdec/mpdecimal.h b/Modules/_decimal/libmpdec/mpdecimal.h
+index 108b76efa8..35ce429f60 100644
+--- a/Modules/_decimal/libmpdec/mpdecimal.h
++++ b/Modules/_decimal/libmpdec/mpdecimal.h
+@@ -135,6 +135,9 @@ const char *mpd_version(void);
+   #elif defined(__x86_64__)
+     #define CONFIG_64
+     #define ASM
++  #elif defined(__arm64__)
++    #define CONFIG_64
++    #define ANSI
+   #else
+     #error "unknown architecture for universal build."
+   #endif
+-- 
+2.30.1 (Apple Git-130)
+

--- a/plugins/python-build/share/python-build/patches/3.6.15/Python-3.6.15/0009-bpo-27987-pymalloc-align-by-16bytes-on-64bit-platfor.patch
+++ b/plugins/python-build/share/python-build/patches/3.6.15/Python-3.6.15/0009-bpo-27987-pymalloc-align-by-16bytes-on-64bit-platfor.patch
@@ -1,0 +1,43 @@
+From 54dc627769bf112b0181972a52c4b45e4a02da57 Mon Sep 17 00:00:00 2001
+From: Inada Naoki <songofacandy@gmail.com>
+Date: Tue, 14 May 2019 18:51:15 +0900
+Subject: [PATCH 09/10] bpo-27987: pymalloc: align by 16bytes on 64bit platform
+ (GH-12850)
+
+---
+ .../2019-04-16-11-52-21.bpo-27987.n2_DcQ.rst                | 3 +++
+ Objects/obmalloc.c                                          | 6 ++++++
+ 2 files changed, 9 insertions(+)
+ create mode 100644 Misc/NEWS.d/next/Core and Builtins/2019-04-16-11-52-21.bpo-27987.n2_DcQ.rst
+
+diff --git a/Misc/NEWS.d/next/Core and Builtins/2019-04-16-11-52-21.bpo-27987.n2_DcQ.rst b/Misc/NEWS.d/next/Core and Builtins/2019-04-16-11-52-21.bpo-27987.n2_DcQ.rst
+new file mode 100644
+index 0000000000..b0f32a5c6c
+--- /dev/null
++++ b/Misc/NEWS.d/next/Core and Builtins/2019-04-16-11-52-21.bpo-27987.n2_DcQ.rst	
+@@ -0,0 +1,3 @@
++pymalloc returns memory blocks aligned by 16 bytes, instead of 8 bytes, on
++64-bit platforms to conform x86-64 ABI. Recent compilers assume this alignment
++more often. Patch by Inada Naoki.
+diff --git a/Objects/obmalloc.c b/Objects/obmalloc.c
+index d46d149311..47283354f4 100644
+--- a/Objects/obmalloc.c
++++ b/Objects/obmalloc.c
+@@ -650,8 +650,14 @@ static int running_on_valgrind = -1;
+  *
+  * You shouldn't change this unless you know what you are doing.
+  */
++
++#if SIZEOF_VOID_P > 4
++#define ALIGNMENT              16               /* must be 2^N */
++#define ALIGNMENT_SHIFT         4
++#else
+ #define ALIGNMENT               8               /* must be 2^N */
+ #define ALIGNMENT_SHIFT         3
++#endif
+ 
+ /* Return the number of bytes in size class I, as a uint. */
+ #define INDEX2SIZE(I) (((uint)(I) + 1) << ALIGNMENT_SHIFT)
+-- 
+2.38.4
+

--- a/plugins/python-build/share/python-build/patches/3.6.15/Python-3.6.15/0010-bpo-27987-align-PyGC_Head-to-alignof-long-double-GH-.patch
+++ b/plugins/python-build/share/python-build/patches/3.6.15/Python-3.6.15/0010-bpo-27987-align-PyGC_Head-to-alignof-long-double-GH-.patch
@@ -1,0 +1,40 @@
+From e68ff170dc6764b22886e703f583fb53e90367ef Mon Sep 17 00:00:00 2001
+From: Inada Naoki <songofacandy@gmail.com>
+Date: Sat, 25 May 2019 21:13:33 +0900
+Subject: [PATCH 10/10] bpo-27987: align PyGC_Head to alignof(long double)
+ (GH-13335)
+
+---
+ Include/objimpl.h                                           | 6 +++++-
+ .../2019-05-15-18-28-43.bpo-27987.FaxuLy.rst                | 2 ++
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+ create mode 100644 Misc/NEWS.d/next/Core and Builtins/2019-05-15-18-28-43.bpo-27987.FaxuLy.rst
+
+diff --git a/Include/objimpl.h b/Include/objimpl.h
+index e7a3696d7a..90d71b87ea 100644
+--- a/Include/objimpl.h
++++ b/Include/objimpl.h
+@@ -255,7 +255,11 @@ typedef union _gc_head {
+         union _gc_head *gc_prev;
+         Py_ssize_t gc_refs;
+     } gc;
+-    double dummy;  /* force worst-case alignment */
++    long double dummy;  /* force worst-case alignment */
++    // malloc returns memory block aligned for any built-in types and
++    // long double is the largest standard C type.
++    // On amd64 linux, long double requires 16 byte alignment.
++    // See bpo-27987 for more discussion.
+ } PyGC_Head;
+ 
+ extern PyGC_Head *_PyGC_generation0;
+diff --git a/Misc/NEWS.d/next/Core and Builtins/2019-05-15-18-28-43.bpo-27987.FaxuLy.rst b/Misc/NEWS.d/next/Core and Builtins/2019-05-15-18-28-43.bpo-27987.FaxuLy.rst
+new file mode 100644
+index 0000000000..97ca37b262
+--- /dev/null
++++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-15-18-28-43.bpo-27987.FaxuLy.rst	
+@@ -0,0 +1,2 @@
++``PyGC_Head`` structure is aligned to ``long double``.  This is needed to
++GC-ed objects are aligned properly.  Patch by Inada Naoki.
+-- 
+2.38.4
+


### PR DESCRIPTION
### Description
This resolves an error encountered on x86_64 for python versions 3.5.10 and 3.6.15 where `./python -c 'import ctypes'` causes an immediate segfault. Also, when pyenv install runs `./python -E -m ensurepip --upgrade --root=/`, this imports ctypes and also causes a segfault. 

The segfault causes `pyenv install 3.5.10` and the same for 3.6.15 to fail and not install.

This bug was resolved in [bpo-27987](https://bugs.python.org/issue27987) for the v2.7 branch and v3.7 branch and later. (Note that in the conversation, although one of the patches was reverted, the revert was reverted at the end.) This PR backports those patches for 3.5.10 and 3.6.15, which were left unfixed. These patches would likely not be accepted upstream because 3.5 and 3.6 are EOL.

Despite these versions being EOL, I was interested for old times sake. Also, the test harness for chaimleib/intervaltree lists these versions, among others, as test targets. 

### Tests
```
set -e
for v in 3.5.10 3.6.15; do
  pyenv install $v
  pyenv global $v
  python --version
  python -c 'import ctypes'
done
```