### PR TITLE
README: clarify behavior of `pyenv latest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ please visit the wiki page about
 
 All Pyenv subcommands except `uninstall` automatically resolve full prefixes to the latest version in the corresponding version line.
 
-`pyenv install` picks the latest known version while other subcommands -- the latest installed version.
+`pyenv install` picks the latest known version, while other subcommands pick the latest installed version.
 
 E.g. to install and then switch to the latest 3.10 release:
 
@@ -425,8 +425,7 @@ pyenv install 3.10
 pyenv global 3.10
 ```
 
-You can run [`pyenv latest <prefix>`](COMMANDS.md#pyenv-latest) to see
-what a specific prefix would be resolved to.
+You can run [`pyenv latest -k <prefix>`](COMMANDS.md#pyenv-latest) to see how `pyenv install` would resolve a specific prefix, or [`pyenv latest <prefix>`](COMMANDS.md#pyenv-latest) to see how other subcommands would resolve it.
 
 See the [`pyenv latest` documentation](COMMANDS.md#pyenv-latest) for details.
 


### PR DESCRIPTION


### Description

The README mentions `pyenv latest` in the [Prefix auto-resolution to the latest version](https://github.com/pyenv/pyenv/tree/3bfc97a#prefix-auto-resolution-to-the-latest-version) section, which is a subsection of [Install additional Python versions](https://github.com/pyenv/pyenv/tree/3bfc97a#install-additional-python-versions).

As such, it seems to me the first command provided should be `pyenv latest -k <prefix>`, as this shows how `pyenv install` would resolve the prefix.

This PR does that, plus some minor changes for readability.

### Prerequisite, Tests
_n/a_
