### PR TITLE
Add CPython 3.10.11

### DIFF
--- a/plugins/python-build/share/python-build/3.10.11
+++ b/plugins/python-build/share/python-build/3.10.11
@@ -1,0 +1,9 @@
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1o" "https://www.openssl.org/source/openssl-1.1.1o.tar.gz#9384a2b0570dd80358841464677115df785edb941c71211f75076d72fe6b438f" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.1" "https://ftpmirror.gnu.org/readline/readline-8.1.tar.gz#f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+    install_package "Python-3.10.11" "https://www.python.org/ftp/python/3.10.11/Python-3.10.11.tar.xz#3c3bc3048303721c904a03eb8326b631e921f11cc3be2988456a42f115daf04c" standard verify_py310 copy_python_gdb ensurepip
+else
+    install_package "Python-3.10.11" "https://www.python.org/ftp/python/3.10.11/Python-3.10.11.tar.xz#3c3bc3048303721c904a03eb8326b631e921f11cc3be2988456a42f115daf04c" standard verify_py310 copy_python_gdb ensurepip
+fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
NA

### Description
- Add CPython 3.10.11 released earlier today: https://www.python.org/downloads/release/python-31011/

### Tests
NA
