### PR TITLE
Add CPython 3.11.3

### DIFF
--- a/plugins/python-build/share/python-build/3.11.3
+++ b/plugins/python-build/share/python-build/3.11.3
@@ -1,0 +1,10 @@
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
+install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+    install_package "Python-3.11.3" "https://www.python.org/ftp/python/3.11.3/Python-3.11.3.tar.xz#8a5db99c961a7ecf27c75956189c9602c968751f11dbeae2b900dbff1c085b5e" standard verify_py311 copy_python_gdb ensurepip
+else
+    install_package "Python-3.11.3" "https://www.python.org/ftp/python/3.11.3/Python-3.11.3.tar.xz#8a5db99c961a7ecf27c75956189c9602c968751f11dbeae2b900dbff1c085b5e" standard verify_py311 copy_python_gdb ensurepip
+fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
NA

### Description
- Add CPython 3.11.3 released earlier today: https://www.python.org/downloads/release/python-3113/

### Tests
NA
