### PR TITLE
Fix not showing symlink contents for unselected versions in `pyenv versions`

### DIFF
--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -121,7 +121,7 @@ print_version() {
   elif (( ${BASH_VERSINFO[0]} <= 3 )) && exists "$1" "${current_versions[@]}"; then
     echo "${hit_prefix}${version_repr} (set by $(pyenv-version-origin))"
   else
-    echo "${miss_prefix}$1"
+    echo "${miss_prefix}${version_repr}"
   fi
   num_versions=$((num_versions + 1))
 }

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -240,8 +240,11 @@ OUT
   create_version "1.9.0"
   create_alias "link" "foo/bar"
 
+  export PYENV_DEBUG=1 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
   run pyenv-versions
-    assert_success <<OUT
+  assert_success
+  assert_output <<OUT
+* system (set by ${PYENV_ROOT}/version)
   1.9.0
   link --> foo/bar
 OUT

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -238,14 +238,13 @@ OUT
 
 @test "non-bare output shows symlink contents" {
   create_version "1.9.0"
-  create_alias "link" "foo/bar"
+  create_alias "link" "1.9.0"
 
-  export PYENV_DEBUG=1 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
   run pyenv-versions
   assert_success
   assert_output <<OUT
 * system (set by ${PYENV_ROOT}/version)
   1.9.0
-  link --> foo/bar
+  link --> 1.9.0
 OUT
 }


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

#2609 doesn't actually show link contents for non-selected versions. The test passed because the test/ version of assert_success doesn't support checkling the output at the same time.

### Tests
- [x] My PR adds the following unit tests (if any)
Fixes the test false positive