### PR TITLE
Nicer git upgrade command

### DIFF
--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -271,7 +271,7 @@ for DEFINITION in "${DEFINITIONS[@]}"; do
         echo "  brew update && brew upgrade pyenv"
       elif [ -d "${here}/.git" ]; then
         printf ":\n\n"
-        echo "  cd ${here} && git pull && cd -"
+        echo "  git -C \"$(realpath "${here}")\" pull"
       else
         printf ".\n"
       fi


### PR DESCRIPTION
### Description
Use `git -C` instead of changing the user's working directory and switching it back at the end