### PR TITLE
Correct link in has_tar_xz_support else branch of 3.10.11 and 3.11.3

### DIFF
--- a/plugins/python-build/share/python-build/3.10.11
+++ b/plugins/python-build/share/python-build/3.10.11
@@ -5,5 +5,5 @@ install_package "readline-8.1" "https://ftpmirror.gnu.org/readline/readline-8.1.
 if has_tar_xz_support; then
     install_package "Python-3.10.11" "https://www.python.org/ftp/python/3.10.11/Python-3.10.11.tar.xz#3c3bc3048303721c904a03eb8326b631e921f11cc3be2988456a42f115daf04c" standard verify_py310 copy_python_gdb ensurepip
 else
-    install_package "Python-3.10.11" "https://www.python.org/ftp/python/3.10.11/Python-3.10.11.tar.xz#3c3bc3048303721c904a03eb8326b631e921f11cc3be2988456a42f115daf04c" standard verify_py310 copy_python_gdb ensurepip
+    install_package "Python-3.10.11" "https://www.python.org/ftp/python/3.10.11/Python-3.10.11.tgz#f3db31b668efa983508bd67b5712898aa4247899a346f2eb745734699ccd3859" standard verify_py310 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.11.3
+++ b/plugins/python-build/share/python-build/3.11.3
@@ -6,5 +6,5 @@ install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.
 if has_tar_xz_support; then
     install_package "Python-3.11.3" "https://www.python.org/ftp/python/3.11.3/Python-3.11.3.tar.xz#8a5db99c961a7ecf27c75956189c9602c968751f11dbeae2b900dbff1c085b5e" standard verify_py311 copy_python_gdb ensurepip
 else
-    install_package "Python-3.11.3" "https://www.python.org/ftp/python/3.11.3/Python-3.11.3.tar.xz#8a5db99c961a7ecf27c75956189c9602c968751f11dbeae2b900dbff1c085b5e" standard verify_py311 copy_python_gdb ensurepip
+    install_package "Python-3.11.3" "https://www.python.org/ftp/python/3.11.3/Python-3.11.3.tgz#1a79f3df32265d9e6625f1a0b31c28eb1594df911403d11f3320ee1da1b3e048" standard verify_py311 copy_python_gdb ensurepip
 fi


### PR DESCRIPTION
Fix a mistake reported in https://github.com/pyenv/pyenv/pull/2670#issuecomment-1502655762 - `has_tar_xz_support` else branch should use different URL (download tgz instead of tar.xz) and specify different checksum.

This affects both 3.10.11 (#2670) and 3.11.3 (#2671).

Sorry about that.