### PR TITLE
Fix #2682: Correct pyenv_user_setup.bash file

### DIFF
--- a/man/man1/pyenv.1
+++ b/man/man1/pyenv.1
@@ -1,4 +1,4 @@
-.TH PYENV 1 "12 Dec 2020" "PYENV"
+.TH PYENV 1 "24 Apr 2023" "PYENV"
 .SH NAME
 pyenv \- Simple Python version management
 .SH SYNOPSIS
@@ -12,10 +12,12 @@ pyenv lets you easily switch between multiple versions of Python\. It's simple, 
 \fBAppend\fR the following to \fB$HOME/.bashrc\fR
 .P
 .RS 15
-source /usr/share/pyenv/pyenv_user_setup.bash
+.nf
+if command -v pyenv 1>/dev/null 2>&1; then\n
+   eval "$(pyenv init -)" \n
+fi
+.fi
 .RE
-.\"OR
-.\"\fBsh echo \-e \if command \-v pyenv 1>/dev/null 2>&1; then\en eval "$(pyenv init \-)"\enfi' >> ~/\.bashrc\fR
 .RS 3
 .P
 .nh


### PR DESCRIPTION

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2682

### Description
- [x] The manpage contains a reference to a file which does only exist on Debian (`/usr/share/pyenv/pyenv_user_setup.bash`).

It is replaced by its content to make it usable for other distributions.

### Tests
- [x] ~My PR adds the following unit tests (if any)~
