### PR TITLE
Support ksh versions

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -109,7 +109,12 @@ function detect_profile() {
     profile='~/.zprofile'
     rc='~/.zshrc'
     ;;
-  ksh | ksh93 | ksh88 | pdksh | mksh )
+  ksh | ksh93 | mksh )
+    # There are two implementations of Korn shell: AT&T (ksh93) and Mir (mksh).
+    # Systems may have them installed under those names, or as ksh, so those
+    # are recognized here. The obsolete ksh88 (subsumed by ksh93) and pdksh
+    # (subsumed by mksh) are not included, since they are unlikely to still
+    # be in use as interactive shells anywhere.
     profile='~/.profile'
     rc='~/.profile'
     ;;
@@ -269,7 +274,7 @@ function pyenv
 end
 EOS
     ;;
-  ksh | ksh93 | ksh88 | pdksh | mksh )
+  ksh | ksh93 | mksh )
     cat <<EOS
 function pyenv {
   typeset command

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -109,7 +109,7 @@ function detect_profile() {
     profile='~/.zprofile'
     rc='~/.zshrc'
     ;;
-  ksh )
+  ksh | ksh93 | ksh88 | pdksh | mksh )
     profile='~/.profile'
     rc='~/.profile'
     ;;
@@ -269,7 +269,7 @@ function pyenv
 end
 EOS
     ;;
-  ksh )
+  ksh | ksh93 | ksh88 | pdksh | mksh )
     cat <<EOS
 function pyenv {
   typeset command


### PR DESCRIPTION
### Prerequisite

`libexec/pyenv-init` has diverged somewhat from `rbenv`'s version. [An equivalent PR has been proposed there](https://github.com/rbenv/rbenv/pull/1504), so that this will not introduce a new conflict in the next merge.

### Description

Korn shell had two major versions: ’88 and ’93. Some systems have ksh installed under the name `ksh93`. A few systems (maybe only Solaris now) also have a `ksh88`. A few others use the `pdksh` (roughly ’88) or `mksh` (roughly ’93) implementations, originated before ksh was open source.

As far as the (very minor) use in pyenv is concerned, these are all equivalent. This change accepts all of the above.

### Tests

Verified under `ksh93`, `pdksh`, and `mksh`.
