### PR TITLE
Add CPython 3.12.0b1

### DIFF
--- a/plugins/python-build/share/python-build/3.12.0b1
+++ b/plugins/python-build/share/python-build/3.12.0b1
@@ -3,7 +3,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.12.0a7" "https://www.python.org/ftp/python/3.12.0/Python-3.12.0a7.tar.xz#a19ae4dc5afebdff5e1312346f160062a11e0dbd5f9e68a6a981ea37b21608e1" standard verify_py312 copy_python_gdb ensurepip
+    install_package "Python-3.12.0b1" "https://www.python.org/ftp/python/3.12.0/Python-3.12.0b1.tar.xz#8ba76ca64acd745babdfb8467820964df98858ee6a9577bf1d93447257be581e" standard verify_py312 copy_python_gdb ensurepip
 else
-    install_package "Python-3.12.0a7" "https://www.python.org/ftp/python/3.12.0/Python-3.12.0a7.tgz#86d288766153193706e545cc98f73ea8ef1a9cb057608cfdecbd89190b796cf6" standard verify_py312 copy_python_gdb ensurepip
+    install_package "Python-3.12.0b1" "https://www.python.org/ftp/python/3.12.0/Python-3.12.0b1.tgz#7684fa5e43fd68513b268c4569ba2cd323335c19c1d66c18ee1b90db9c57ca39" standard verify_py312 copy_python_gdb ensurepip
 fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)

https://www.python.org/downloads/release/python-3120b1/