### PR TITLE
Update 3.12-dev and add 3.13-dev

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1958,6 +1958,11 @@ build_package_verify_py312() {
   build_package_verify_py311 "$1" "${2:-3.12}"
 }
 
+# Post-install check for Python 3.13.x
+build_package_verify_py313() {
+  build_package_verify_py312 "$1" "${2:-3.13}"
+}
+
 # Post-install check for Python 3.x rolling release scripts
 # XXX: Will need splitting into project-specific ones if there emerge
 # multiple rolling-release scripts with different checks needed

--- a/plugins/python-build/share/python-build/3.13-dev
+++ b/plugins/python-build/share/python-build/3.13-dev
@@ -4,4 +4,4 @@ export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
 export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
 install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_git "Python-3.12-dev" "https://github.com/python/cpython" 3.12 standard verify_py312 copy_python_gdb ensurepip
+install_git "Python-3.13-dev" "https://github.com/python/cpython" main standard verify_py313 copy_python_gdb ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
Now that 3.12 has its own branch, switch to it with 3.12-dev and point 3.13-dev to main branch...

### Tests
none
