### PR TITLE
Backport bpo-42351 to 3.5.10

### DIFF
--- a/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0008-bpo-36231-Support-building-on-macOS-without-usr-incl.patch
+++ b/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0008-bpo-36231-Support-building-on-macOS-without-usr-incl.patch
@@ -1,6 +1,6 @@
-From c7302116573d853d3181133477d9d0e4d4d3abfd Mon Sep 17 00:00:00 2001
-From: Ned Deily <nad@python.org>
-Date: Tue, 18 Jun 2019 16:28:13 -0400
+From 2ad0bb719f5ce416d3bfa366814ebcf3b654f081 Mon Sep 17 00:00:00 2001
+From: Ivan Pozdeev <vano@mail.mipt.ru>
+Date: Sat, 10 Jun 2023 20:17:25 +0300
 Subject: [PATCH] bpo-36231:  Support building on macOS without /usr/include
  (GH-13773) (GH-14208)
 
@@ -20,12 +20,12 @@ index 0000000000..c82e54c12c
 +10.14, system header files are only available within an SDK provided by
 +either the Command Line Tools or the Xcode app.
 diff --git a/setup.py b/setup.py
-index bcc4bfa89d..5e0cd02430 100644
+index ab8065866f..28dc801845 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -90,18 +90,57 @@ def sysroot_paths(make_vars, subdirs):
-                 break
-     return dirs
+@@ -60,18 +60,57 @@ def add_dir_to_list(dirlist, dir):
+             return
+     dirlist.insert(0, dir)
  
 +MACOS_SDK_ROOT = None
 +
@@ -86,8 +86,8 @@ index bcc4bfa89d..5e0cd02430 100644
 +
 +    return MACOS_SDK_ROOT
  
- def is_macosx_sdk_path(path):
-     """
+ def is_macosx_at_least(vers):
+     if host_platform == 'darwin':
 -- 
-2.30.1 (Apple Git-130)
+2.36.1.windows.1
 

--- a/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0009-bpo-42351-Avoid-error-when-opening-header-with-non-U.patch
+++ b/plugins/python-build/share/python-build/patches/3.5.10/Python-3.5.10/0009-bpo-42351-Avoid-error-when-opening-header-with-non-U.patch
@@ -1,0 +1,28 @@
+From 3cc28dc409d0db3752278379e7a8d4c23e0f2e29 Mon Sep 17 00:00:00 2001
+From: Ronald Oussoren <ronaldoussoren@mac.com>
+Date: Sat, 14 Nov 2020 16:07:47 +0100
+Subject: [PATCH] bpo-42351: Avoid error when opening header with non-UTF8
+ encoding (GH-23279)
+
+grep_headers_for() would error out when a header contained
+text that cannot be interpreted as UTF-8.
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 28dc801845..dd50485213 100644
+--- a/setup.py
++++ b/setup.py
+@@ -129,7 +129,7 @@ def is_macosx_sdk_path(path):
+ 
+ def grep_headers_for(function, headers):
+     for header in headers:
+-        with open(header, 'r') as f:
++        with open(header, 'r', errors='surrogateescape') as f:
+             if function in f.read():
+                 return True
+     return False
+-- 
+2.36.1.windows.1
+


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2716

### Description
- [x] Here are some details about my PR

Backport the fix, https://bugs.python.org/issue42351

### Tests
- [x] My PR adds the following unit tests (if any)
N/A