### PR TITLE
Adding micropython 1.20

### DIFF
--- a/plugins/python-build/share/python-build/micropython-1.20
+++ b/plugins/python-build/share/python-build/micropython-1.20
@@ -1,0 +1,4 @@
+has_tar_xz_support \
+  && { install=install_package; src="https://micropython.org/resources/source/micropython-1.20.0.tar.xz#098ef8e40abdc62551b5460d0ffe9489074240c0cb5589ca3c3a425551beb9bf"; } \
+  || { install=install_zip; src="https://micropython.org/resources/source/micropython-1.20.zip#6a2ce86e372ee8c5b9310778fff7fca1daa580afa28ea755f1a303675a8612b7"; }
+$install micropython-1.20 "$src" micropython


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR
Adds micropython 1.20 support
### Tests
- [ ] My PR adds the following unit tests (if any)
