### PR TITLE
add removal of pyenv fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,10 +557,18 @@ uninstall from the system.
   its root directory. This will **delete all Python versions** that were
   installed under the `` $(pyenv root)/versions/ `` directory:
 
-    ```sh
-    rm -rf $(pyenv root)
-    ```
+    - For **shell**
 
+      ```sh
+      rm -rf $(pyenv root)
+      ```
+
+    - For **Fish shell**:
+
+      ~~~ fish
+      rm -rf $PYENV_ROOT
+      ~~~
+    
     If you've installed Pyenv using a package manager, as a final step,
     perform the Pyenv package removal. For instance, for Homebrew:
 

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ uninstall from the system.
   its root directory. This will **delete all Python versions** that were
   installed under the `` $(pyenv root)/versions/ `` directory:
 
-    - For **shell**
+    - For **Bash/Zsh**:
 
       ```sh
       rm -rf $(pyenv root)
@@ -566,7 +566,7 @@ uninstall from the system.
     - For **Fish shell**:
 
       ~~~ fish
-      rm -rf $PYENV_ROOT
+      rm -rf (pyenv root)
       ~~~
     
     If you've installed Pyenv using a package manager, as a final step,


### PR DESCRIPTION
### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [N/A ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

Some small doc improvement. 
Environment variables work a bit differently in Fish. Hereby explicitly how to remove the pyenv_dir in Fish. 

If this is accepted, I'll make contribution upstream to rbenv. 

