### PR TITLE
Fix occasional 'libexec/pyenv-latest: line 39: printf: write error: Broken pipe'

### DIFF
--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -36,7 +36,7 @@ IFS=$'\n'
         DEFINITION_CANDIDATES=( $(python-build --definitions ) )
     fi
     
-    if printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | grep -qxFe "$prefix"; then
+    if printf '%s\n' "${DEFINITION_CANDIDATES[@]}" 2>/dev/null | grep -qxFe "$prefix"; then
         echo "$prefix"
         exit $exitcode;
     fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - E.g. https://github.com/pyenv/pyenv/actions/runs/5316697716/jobs/9626475046#step:6:215

### Description
- [x] Here are some details about my PR
looks like `grep -q` closes stdin without reading everything just like `head`, causing the same error intermittently.

### Tests
- [x] My PR adds the following unit tests (if any)
N/A