### PR TITLE
Add Cinder 3.10 and Cinder configure patches

### DIFF
--- a/plugins/python-build/share/python-build/cinder-3.10-dev
+++ b/plugins/python-build/share/python-build/cinder-3.10-dev
@@ -1,28 +1,40 @@
-require_distro Fedora 32 &>/dev/null || \
-{ echo
-  colorize 1 "WARNING"
-  cat >&2 <<!
-: The Cinder compiler only officially supports
-Facebook's Docker images which are Fedora 32 - based.
-It may fail to build on a system
-with a different GCC and/or Glibc version.
-!
-  echo
-}
+if [ "$(expr substr "$(uname -s)" 1 5)" != "Linux" ]; then
+  {
+    echo
+    colorize 1 "ERROR"
+    echo ": Cinder currently only supports Linux."
+    echo
+    return 1
+  } >&2
+fi
 
-[[ $(${CC:-gcc} -dumpversion 2>/dev/null) == 10 ]] || \
-{ command -v "gcc-10" >/dev/null && \
-  export CC="gcc-10" && \
-  echo "python-build: setting the compiler to \`gcc-10'"; } || \
-{
-  echo
-  colorize 1 WARNING
-  cat >&2 <<!
-: GCC 10 is not found on PATH.
-The build may fail.
-!
-  echo
-}
+if [[ $(${CC:-gcc} -dumpversion 2>/dev/null) != 10 ]] &&
+  (command -v "gcc-10" >/dev/null) &&
+  (command -v "g++-10" >/dev/null); then
+  echo "python-build: setting the compiler to GCC 10"
+  export CC="gcc-10"
+  export CXX="g++-10"
+fi
+
+if [[ $(awk -F. '{print $1}' <<< "$(${CC:-gcc} -dumpversion)") -lt 10 ]]; then
+  {
+    echo
+    colorize 1 "ERROR"
+    echo ": Cinder requires at least GCC 10."
+    echo
+    return 1
+  } >&2
+fi
+
+require_distro Fedora 32 &> /dev/null ||
+  {
+    echo
+    colorize 1 "WARNING"
+    echo ": Cinder officially only supports Facebook's Docker"
+    echo "images which are based on Fedora 32. It may fail to build"
+    echo "on a system with a different GCC and/or Glibc version."
+    echo
+  } >&2
 
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1

--- a/plugins/python-build/share/python-build/cinder-3.10-dev
+++ b/plugins/python-build/share/python-build/cinder-3.10-dev
@@ -1,0 +1,31 @@
+require_distro Fedora 32 &>/dev/null || \
+{ echo
+  colorize 1 "WARNING"
+  cat >&2 <<!
+: The Cinder compiler only officially supports
+Facebook's Docker images which are Fedora 32 - based.
+It may fail to build on a system
+with a different GCC and/or Glibc version.
+!
+  echo
+}
+
+[[ $(${CC:-gcc} -dumpversion 2>/dev/null) == 10 ]] || \
+{ command -v "gcc-10" >/dev/null && \
+  export CC="gcc-10" && \
+  echo "python-build: setting the compiler to \`gcc-10'"; } || \
+{
+  echo
+  colorize 1 WARNING
+  cat >&2 <<!
+: GCC 10 is not found on PATH.
+The build may fail.
+!
+  echo
+}
+
+prefer_openssl11
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+install_git "Cinder-3.10-dev" "https://github.com/facebookincubator/cinder" "cinder/3.10" standard verify_py310 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/cinder-3.8-dev
+++ b/plugins/python-build/share/python-build/cinder-3.8-dev
@@ -1,28 +1,40 @@
-require_distro Fedora 32 &>/dev/null || \
-{ echo
-  colorize 1 "WARNING"
-  cat >&2 <<!
-: The Cinder compiler only officially supports
-Facebook's Docker images which are Fedora 32 - based.
-It may fail to build on a system
-with a different GCC and/or Glibc version.
-!
-  echo
-}
+if [ "$(expr substr "$(uname -s)" 1 5)" != "Linux" ]; then
+  {
+    echo
+    colorize 1 "ERROR"
+    echo ": Cinder currently only supports Linux."
+    echo
+    return 1
+  } >&2
+fi
 
-[[ $(${CC:-gcc} -dumpversion 2>/dev/null) == 10 ]] || \
-{ command -v "gcc-10" >/dev/null && \
-  export CC="gcc-10" && \
-  echo "python-build: setting the compiler to \`gcc-10'"; } || \
-{
-  echo
-  colorize 1 WARNING
-  cat >&2 <<!
-: GCC 10 is not found on PATH.
-The build may fail.
-!
-  echo
-}
+if [[ $(${CC:-gcc} -dumpversion 2>/dev/null) != 10 ]] &&
+  (command -v "gcc-10" >/dev/null) &&
+  (command -v "g++-10" >/dev/null); then
+  echo "python-build: setting the compiler to GCC 10"
+  export CC="gcc-10"
+  export CXX="g++-10"
+fi
+
+if [[ $(awk -F. '{print $1}' <<< "$(${CC:-gcc} -dumpversion)") -lt 10 ]]; then
+  {
+    echo
+    colorize 1 "ERROR"
+    echo ": Cinder requires at least GCC 10."
+    echo
+    return 1
+  } >&2
+fi
+
+require_distro Fedora 32 &> /dev/null ||
+  {
+    echo
+    colorize 1 "WARNING"
+    echo ": Cinder officially only supports Facebook's Docker"
+    echo "images which are based on Fedora 32. It may fail to build"
+    echo "on a system with a different GCC and/or Glibc version."
+    echo
+  } >&2
 
 prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1

--- a/plugins/python-build/share/python-build/patches/cinder-3.10-dev/Cinder-3.10-dev/001-disable-werror.patch
+++ b/plugins/python-build/share/python-build/patches/cinder-3.10-dev/Cinder-3.10-dev/001-disable-werror.patch
@@ -1,0 +1,30 @@
+diff --git a/configure b/configure
+index 5c74f00a..8bb51f40 100755
+--- a/configure
++++ b/configure
+@@ -7057,8 +7057,8 @@ $as_echo "$ac_cv_extra_warnings" >&6; }
+ 
+     if test $ac_cv_extra_warnings = yes
+     then
+-      CFLAGS_NODIST="$CFLAGS_NODIST -Wextra -Werror"
+-      CXXFLAGS_NODIST="$CXXFLAGS_NODIST -Wextra -Werror -Wno-implicit-fallthrough"
++      CFLAGS_NODIST="$CFLAGS_NODIST -Wextra"
++      CXXFLAGS_NODIST="$CXXFLAGS_NODIST -Wextra -Wno-implicit-fallthrough"
+     fi
+ 
+     # Python doesn't violate C99 aliasing rules, but older versions of
+diff --git a/configure.ac b/configure.ac
+index c06b992d..6dee6632 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1622,8 +1622,8 @@ yes)
+ 
+     if test $ac_cv_extra_warnings = yes
+     then
+-      CFLAGS_NODIST="$CFLAGS_NODIST -Wextra -Werror"
+-      CXXFLAGS_NODIST="$CXXFLAGS_NODIST -Wextra -Werror -Wno-implicit-fallthrough"
++      CFLAGS_NODIST="$CFLAGS_NODIST -Wextra"
++      CXXFLAGS_NODIST="$CXXFLAGS_NODIST -Wextra -Wno-implicit-fallthrough"
+     fi
+ 
+     # Python doesn't violate C99 aliasing rules, but older versions of

--- a/plugins/python-build/share/python-build/patches/cinder-3.8-dev/Cinder-3.8-dev/001-disable-werror.patch
+++ b/plugins/python-build/share/python-build/patches/cinder-3.8-dev/Cinder-3.8-dev/001-disable-werror.patch
@@ -1,0 +1,30 @@
+diff --git a/configure b/configure
+index 0df332f7..df8143cf 100755
+--- a/configure
++++ b/configure
+@@ -6952,8 +6952,8 @@ $as_echo "$ac_cv_extra_warnings" >&6; }
+ 
+     if test $ac_cv_extra_warnings = yes
+     then
+-      CFLAGS_NODIST="$CFLAGS_NODIST -Wextra -Werror"
+-      CXXFLAGS_NODIST="$CXXFLAGS_NODIST -Wextra -Werror -Wno-implicit-fallthrough"
++      CFLAGS_NODIST="$CFLAGS_NODIST -Wextra"
++      CXXFLAGS_NODIST="$CXXFLAGS_NODIST -Wextra -Wno-implicit-fallthrough"
+     fi
+ 
+     # Python doesn't violate C99 aliasing rules, but older versions of
+diff --git a/configure.ac b/configure.ac
+index f6718e36..0a651e7d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1579,8 +1579,8 @@ yes)
+ 
+     if test $ac_cv_extra_warnings = yes
+     then
+-      CFLAGS_NODIST="$CFLAGS_NODIST -Wextra -Werror"
+-      CXXFLAGS_NODIST="$CXXFLAGS_NODIST -Wextra -Werror -Wno-implicit-fallthrough"
++      CFLAGS_NODIST="$CFLAGS_NODIST -Wextra"
++      CXXFLAGS_NODIST="$CXXFLAGS_NODIST -Wextra -Wno-implicit-fallthrough"
+     fi
+ 
+     # Python doesn't violate C99 aliasing rules, but older versions of


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.

### Description
- [x] Adds script to install Cinder 3.10, similarly to Cinder 3.8 (#2433). All distro and GCC warnings have been kept because Cinder still doesn't officially support building outside their Docker container
- [x] Also adds patches for Cinder configure scripts (both for 3.8 and 3.10) to disable `-Werror`. There are some warnings (`Wdeprecated-declarations`, `Wmaybe-uninitialized`, and others) that occur on newer (GCC 11+) versions and cause the build to fail. I'm not sure why those warnings/error occur on those newer versions, but from a quick search, it appears that at least some of them might be false-positive because of bugs in GCC. When `-Werror` is removed, the build works fine (it compiles and runs a simple Numpy test, not sure if everything is perfectly supported though). There is also existing issue about that (facebookincubator/cinder#114).

Supported distros:
- Ubuntu 22.04+
- Debian 11+
- Fedora 32+
- Arch

Basically, distros that have at least GCC 10 / support for C++20 should work. Alpine is not supported because it uses MUSL. Older distro versions are not supported because of of too old GCC version. I haven't tested macOS, but it probably doesn't work.

Test runs:
- Cinder 3.10: https://github.com/filips123/pyenv-cinder-testing/actions/runs/5400882249/jobs/9809934704
- Cinder 3.8: https://github.com/filips123/pyenv-cinder-testing/actions/runs/5400895786/jobs/9809967403

### Tests
- [ ] My PR adds the following unit tests (if any)
