### PR TITLE
Add new anaconda and miniconda definitions

### DIFF
--- a/plugins/python-build/scripts/add_miniconda.py
+++ b/plugins/python-build/scripts/add_miniconda.py
@@ -109,6 +109,7 @@ class PyVersion(StrEnum):
     PY38 = "py38"
     PY39 = "py39"
     PY310 = "py310"
+    PY311 = "py311"
 
     def version(self):
         first, *others = self.value[2:]

--- a/plugins/python-build/scripts/add_miniconda.py
+++ b/plugins/python-build/scripts/add_miniconda.py
@@ -289,7 +289,7 @@ def get_existing_condas(name):
                 logger.debug("Found existing %(name)s version %(v)s", locals())
                 yield v
         except ValueError:
-            pass
+            logger.error("Unable to parse existing version %s", entry_name)
 
 
 def get_available_condas(name, repo):

--- a/plugins/python-build/scripts/add_miniconda.py
+++ b/plugins/python-build/scripts/add_miniconda.py
@@ -150,20 +150,23 @@ class CondaVersion(NamedTuple):
         """
         Convert a string of the form "miniconda_n-ver" or "miniconda_n-py_ver-ver" to a :class:`CondaVersion` object.
         """
-        components = s.split("-")
-        if len(components) == 3:
-            miniconda_n, py_ver, ver = components
-            py_ver = PyVersion(f"py{py_ver.replace('.', '')}")
-        else:
-            miniconda_n, ver = components
-            py_ver = None
-
+        miniconda_n, _, remainder = s.partition("-")
         suffix = miniconda_n[-1]
         if suffix in string.digits:
             flavor = miniconda_n[:-1]
         else:
             flavor = miniconda_n
             suffix = ""
+
+        components = remainder.split("-")
+        if flavor == Flavor.MINICONDA and len(components) >= 2:
+            py_ver, *ver_parts = components
+            py_ver = PyVersion(f"py{py_ver.replace('.', '')}")
+            ver = "-".join(ver_parts)
+        else:
+            ver = "-".join(components)
+            py_ver = None
+
         return CondaVersion(Flavor(flavor), Suffix(suffix), VersionStr(ver), py_ver)
 
     def to_filename(self):

--- a/plugins/python-build/share/python-build/anaconda3-2023.03-0
+++ b/plugins/python-build/share/python-build/anaconda3-2023.03-0
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Anaconda3-2023.03-0-Linux-aarch64" "https://repo.anaconda.com/archive/Anaconda3-2023.03-0-Linux-aarch64.sh#613797154d9383355677f7dfee10db32b2c327cbedabddcb303598f242c79883" "anaconda" verify_py39
+  ;;
+"Linux-ppc64le" )
+  install_script "Anaconda3-2023.03-0-Linux-ppc64le" "https://repo.anaconda.com/archive/Anaconda3-2023.03-0-Linux-ppc64le.sh#eafeaccca96f60ebb0aa0052d9baac8eaa2ee422358ee35b12f60f37e8a3ebb2" "anaconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Anaconda3-2023.03-0-Linux-s390x" "https://repo.anaconda.com/archive/Anaconda3-2023.03-0-Linux-s390x.sh#2648337081c3ce4b760457c5f00fb768ecd7d1d0957051ef5252ab380bb78233" "anaconda" verify_py39
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda3-2023.03-0-Linux-x86_64" "https://repo.anaconda.com/archive/Anaconda3-2023.03-0-Linux-x86_64.sh#19737d5c27b23a1d8740c5cb2414bf6253184ce745d0a912bb235a212a15e075" "anaconda" verify_py39
+  ;;
+"MacOSX-arm64" )
+  install_script "Anaconda3-2023.03-0-MacOSX-arm64" "https://repo.anaconda.com/archive/Anaconda3-2023.03-0-MacOSX-arm64.sh#d27ee5432438972e90548e3dfa89490c5dc38a723f4dcd53061f0bd9d53b1bd0" "anaconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda3-2023.03-0-MacOSX-x86_64" "https://repo.anaconda.com/archive/Anaconda3-2023.03-0-MacOSX-x86_64.sh#cc37b1eb85bdc2ade3f95201a746cdc63ee4fbfae48ee9d0c7a3cf319562452d" "anaconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/anaconda3-2023.03-1
+++ b/plugins/python-build/share/python-build/anaconda3-2023.03-1
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Anaconda3-2023.03-1-Linux-aarch64" "https://repo.anaconda.com/archive/Anaconda3-2023.03-1-Linux-aarch64.sh#54e600faa2af63a25717af30ecaddf1ee428cdfebd3721a70f41462e232e8153" "anaconda" verify_py39
+  ;;
+"Linux-ppc64le" )
+  install_script "Anaconda3-2023.03-1-Linux-ppc64le" "https://repo.anaconda.com/archive/Anaconda3-2023.03-1-Linux-ppc64le.sh#a31f2d6da83534cff7c994403cc11fa634b31fcd10eb4153d00233345ee084b2" "anaconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Anaconda3-2023.03-1-Linux-s390x" "https://repo.anaconda.com/archive/Anaconda3-2023.03-1-Linux-s390x.sh#5af1406c6350b4ba6839c49faa32a3c90f2b9845a03c35843f118dd9dd013421" "anaconda" verify_py39
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda3-2023.03-1-Linux-x86_64" "https://repo.anaconda.com/archive/Anaconda3-2023.03-1-Linux-x86_64.sh#95102d7c732411f1458a20bdf47e4c1b0b6c8a21a2edfe4052ca370aaae57bab" "anaconda" verify_py39
+  ;;
+"MacOSX-arm64" )
+  install_script "Anaconda3-2023.03-1-MacOSX-arm64" "https://repo.anaconda.com/archive/Anaconda3-2023.03-1-MacOSX-arm64.sh#85152324c423fedbeed2e7491cb32e597eaeb1b86ae7a61ff7597b401fd053ce" "anaconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda3-2023.03-1-MacOSX-x86_64" "https://repo.anaconda.com/archive/Anaconda3-2023.03-1-MacOSX-x86_64.sh#3593921c8a5516db82f0d7dd1c691f7ee7794236852e7da614e9ad6e93eeb342" "anaconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/anaconda3-2023.07-0
+++ b/plugins/python-build/share/python-build/anaconda3-2023.07-0
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Anaconda3-2023.07-0-Linux-aarch64" "https://repo.anaconda.com/archive/Anaconda3-2023.07-0-Linux-aarch64.sh#5f4865448c1111fb80cb49abff0f9b38b2970857dba7a4627c499ba102b82af5" "anaconda" verify_py39
+  ;;
+"Linux-ppc64le" )
+  install_script "Anaconda3-2023.07-0-Linux-ppc64le" "https://repo.anaconda.com/archive/Anaconda3-2023.07-0-Linux-ppc64le.sh#98efb73758680b84f890d818b5748d7a08e82c4b825d597f7e3c4467125da278" "anaconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Anaconda3-2023.07-0-Linux-s390x" "https://repo.anaconda.com/archive/Anaconda3-2023.07-0-Linux-s390x.sh#f6933a8b70d346d423e089843fc151c46bdaee4e3e4e4fd0fb81ca06b8766892" "anaconda" verify_py39
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda3-2023.07-0-Linux-x86_64" "https://repo.anaconda.com/archive/Anaconda3-2023.07-0-Linux-x86_64.sh#ac738639aba0b676a618911600d0a0e7825ee7fd10efb6b3d95cc2e570d9ee7b" "anaconda" verify_py39
+  ;;
+"MacOSX-arm64" )
+  install_script "Anaconda3-2023.07-0-MacOSX-arm64" "https://repo.anaconda.com/archive/Anaconda3-2023.07-0-MacOSX-arm64.sh#23a9deb80acb145c65375bd73cbaa8793be81447278c4db7be50ef7c32a58635" "anaconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda3-2023.07-0-MacOSX-x86_64" "https://repo.anaconda.com/archive/Anaconda3-2023.07-0-MacOSX-x86_64.sh#b6ea24fe16544d5b2d5adf6c913c1fc89a6dbdef12a4caff76ff574b33d0f3cb" "anaconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.10-23.3.1-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.10-23.3.1-0
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py310_23.3.1-0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-Linux-aarch64.sh#6950c7b1f4f65ce9b87ee1a2d684837771ae7b2e6044e0da9e915d1dee6c924c" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py310_23.3.1-0-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-Linux-ppc64le.sh#b3de538cd542bc4f5a2f2d2a79386288d6e04f0e1459755f3cefe64763e51d16" "miniconda" verify_py310
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py310_23.3.1-0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-Linux-s390x.sh#ed4f51afc967e921ff5721151f567a4c43c4288ac93ec2393c6238b8c4891de8" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py310_23.3.1-0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-Linux-x86_64.sh#aef279d6baea7f67940f16aad17ebe5f6aac97487c7c03466ff01f4819e5a651" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py310_23.3.1-0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-MacOSX-arm64.sh#9d1d12573339c49050b0d5a840af0ff6c32d33c3de1b3db478c01878eb003d64" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py310_23.3.1-0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-MacOSX-x86_64.sh#5abc78b664b7da9d14ade330534cc98283bb838c6b10ad9cfd8b9cc4153f8104" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.10-23.5.0-3
+++ b/plugins/python-build/share/python-build/miniconda3-3.10-23.5.0-3
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py310_23.5.0-3-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.0-3-Linux-aarch64.sh#a632110a9ebddd8528b26241663ee9368d218e36b40e570072774897762f1de8" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py310_23.5.0-3-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.0-3-Linux-ppc64le.sh#5ed0af4645f49c4412e33a3f94396bcb3eb25f4a3ccb0bfe5bc23ef06bad6f3f" "miniconda" verify_py310
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py310_23.5.0-3-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.0-3-Linux-s390x.sh#5701eba074e3c2894949370ab456df48361a2efaad9b11209dbf8258ddf1e331" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py310_23.5.0-3-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.0-3-Linux-x86_64.sh#738890e7a6f0719a942c632a0aab1df7a5a592c5667d0495d1f0495990a709ba" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py310_23.5.0-3-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.0-3-MacOSX-arm64.sh#ff2121c0a8245bbe63ff70cdb76b492c831889225f9c5277e096f08fd03e7f17" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py310_23.5.0-3-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.0-3-MacOSX-x86_64.sh#03a98ff5d1c813d7bf969203fe404d7a6f149b335c2077703656807721603495" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.11-23.5.0-3
+++ b/plugins/python-build/share/python-build/miniconda3-3.11-23.5.0-3
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py311_23.5.0-3-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.5.0-3-Linux-aarch64.sh#6e3e60e7093194b3435fde19efc54d0dd78be393bf5b7487cc28cd1039ebed4d" "miniconda" verify_py311
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py311_23.5.0-3-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.5.0-3-Linux-ppc64le.sh#c1ab8b5d629f66a1609e456a0d6a83a2896af6dc0b2b702025cb19456030eacd" "miniconda" verify_py311
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py311_23.5.0-3-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.5.0-3-Linux-s390x.sh#42e7cc490fc81d9b1dc56cf8bd951e084e804824d60aca3a4b15d35c57ad373e" "miniconda" verify_py311
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py311_23.5.0-3-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.5.0-3-Linux-x86_64.sh#61a5c087893f6210176045931b89ee6e8760c17abd9c862b2cab4c1b7d00f7c8" "miniconda" verify_py311
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py311_23.5.0-3-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.5.0-3-MacOSX-arm64.sh#c4ce7311d2d1c729bf8d98e6d5aa2581ce0b08a1480985e63efaf8529b2fc6ca" "miniconda" verify_py311
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py311_23.5.0-3-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.5.0-3-MacOSX-x86_64.sh#2503d9e852fcaf85adca825bde84bdc297b118fd2c14316e4f27a93a190a7bdd" "miniconda" verify_py311
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.8-23.3.1-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.8-23.3.1-0
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py38_23.3.1-0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-Linux-aarch64.sh#ad491ebad6efec7470fe2139c8b407a895cb2c828b3233b97da6e4f22cae0cde" "miniconda" verify_py38
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py38_23.3.1-0-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-Linux-ppc64le.sh#8aa819800ba3ec88ad8518a9e4fc71ada8087547300fc53527c4ecc8072a4d50" "miniconda" verify_py38
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py38_23.3.1-0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-Linux-s390x.sh#e4d83bb9f0900c9128504f7e3c4d3b9e5eaf3b87c4bb5190a3086947e92bd3fa" "miniconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py38_23.3.1-0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-Linux-x86_64.sh#d1f3a4388c1a6fd065e32870f67abc39eb38f4edd36c4947ec7411e32311bd59" "miniconda" verify_py38
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py38_23.3.1-0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-MacOSX-arm64.sh#e0151c68f6a11a38b29c2f4a775bf6a22187fa2c8ca0f31930d69f2f013c0810" "miniconda" verify_py38
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py38_23.3.1-0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-MacOSX-x86_64.sh#eb7b2d285f6d3b7c9cde9576c8c647e70b65361426b0e0e069b4ab23ccbb79e2" "miniconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.8-23.5.0-3
+++ b/plugins/python-build/share/python-build/miniconda3-3.8-23.5.0-3
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py38_23.5.0-3-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.5.0-3-Linux-aarch64.sh#853e1c3c24f1c4cc2a1c57b05059740127724a2b346f887e3f0bb92a6cd05fe1" "miniconda" verify_py38
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py38_23.5.0-3-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.5.0-3-Linux-ppc64le.sh#5bef0b71b9c9c6a27e534894e913e47e545793a549a8815bb4a66a8c9d793d45" "miniconda" verify_py38
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py38_23.5.0-3-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.5.0-3-Linux-s390x.sh#e0271bc3af023053258cfe01059d53769bbd32dc5542b5c96280d29dcd8568f6" "miniconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py38_23.5.0-3-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.5.0-3-Linux-x86_64.sh#f833ae8ad96db31d4f2a09d12f1b188721c769d60d813d7e6341c19e77bc791f" "miniconda" verify_py38
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py38_23.5.0-3-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.5.0-3-MacOSX-arm64.sh#5daf6837136d08a17f039b29993f67207ba90dcc90abe94c6d5a8925f6888076" "miniconda" verify_py38
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py38_23.5.0-3-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.5.0-3-MacOSX-x86_64.sh#54ead65ad1ff77d9cba2512a8765d64e6b7d8ae154e2fc1a6fcb01395b9a8cf3" "miniconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.9-23.3.1-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-23.3.1-0
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py39_23.3.1-0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-Linux-aarch64.sh#e93ccab720b57f821e0d758f54e9aee9bd2f0ea931ebb26b78d866704437a296" "miniconda" verify_py39
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py39_23.3.1-0-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-Linux-ppc64le.sh#d2bcef86812863adaf11fcda6df829aa508760cbde4a19174cf0fec03e8498f5" "miniconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py39_23.3.1-0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-Linux-s390x.sh#d0b658566edd239dd50fc28ab1d3a57b8b0da707481b3b18c27d11273c4fdb5a" "miniconda" verify_py39
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py39_23.3.1-0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-Linux-x86_64.sh#1564571a6a06a9999a75a6c65d63cb82911fc647e96ba5b729f904bf00c177d3" "miniconda" verify_py39
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py39_23.3.1-0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-MacOSX-arm64.sh#c74474bab188b8b3dcaf0f0ca52f5e0743591dbe171766016023d052acf96502" "miniconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py39_23.3.1-0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.3.1-0-MacOSX-x86_64.sh#54d739715feb0cd5c127865215cc9f50697709d71e9ee7da430576c5a1c8010d" "miniconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.9-23.5.0-3
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-23.5.0-3
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py39_23.5.0-3-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.5.0-3-Linux-aarch64.sh#f77868e96eee904cd137ebe463439258d76281830bb9e2bd330d23aea1ddd31a" "miniconda" verify_py39
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py39_23.5.0-3-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.5.0-3-Linux-ppc64le.sh#4bbda8ba3b8d1d26f04a469bbe29b3ef626a8b10b823f64314719e132f7c3696" "miniconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py39_23.5.0-3-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.5.0-3-Linux-s390x.sh#7ef72ef1411b028788c81308238b604cba46315cb42e70a2d65511c05440ebca" "miniconda" verify_py39
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py39_23.5.0-3-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.5.0-3-Linux-x86_64.sh#b7fc320922235ccbaacba7b5a61e34671e75f3a2c7110c63db0c6a9f98ecf8a8" "miniconda" verify_py39
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py39_23.5.0-3-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.5.0-3-MacOSX-arm64.sh#d006d99f86850510f9aed1a81e16a4213a4829e7ea6913f0c42054b4b0ac05a7" "miniconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py39_23.5.0-3-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.5.0-3-MacOSX-x86_64.sh#86ae780b5c5a32c45bc0f2e146941afea6dd1ca48e8d5e1bf99a83df255a0a78" "miniconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
I used `add_miniconda.py` to generate definitions files for anaconda `2023.03`, anaconda `2023.07`, miniconda `23.3.1`, and miniconda `23.5.0`. I needed to change the conda version processing logic to handle this. In addition, I realized that `add_miniconda.py` was missing support for Python 3.11, so I added it as an acceptable Python version.

I'm not sure how to best include multiple new definition files. Should each version have its own commit, or is including all the autogenerated files together fine?