### PR TITLE
Fix macos CI

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1420,7 +1420,7 @@ use_freebsd_pkg() {
   # check if FreeBSD
   if [ "FreeBSD" = "$(uname -s)" ]; then
     # use openssl if installed from Ports Collection
-    if [ -f /usr/local/include/openssl/ssl.h ]; then
+    if pkg info -e openssl; then
       package_option python configure --with-openssl="/usr/local"
     fi
 

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -259,6 +259,38 @@ make install
 OUT
 }
 
+@test "openssl is linked from Ports in FreeBSD if present" {
+  cached_tarball "Python-3.6.2"
+
+  for i in {1..7}; do stub uname '-s : echo FreeBSD'; done
+  stub uname '-r : echo 11.0-RELEASE'
+  for i in {1..2}; do stub uname '-s : echo FreeBSD'; done
+  stub sysctl '-n hw.ncpu : echo 1'
+
+  stub pkg "info -e openssl : true"
+  for in in {1..2}; do stub pkg false; done
+
+  stub_make_install
+
+  export -n MAKE_OPTS
+  run_inline_definition <<DEF
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub make
+  unstub pkg
+  unstub sysctl
+
+  assert_build_log <<OUT
+Python-3.6.2: CPPFLAGS="-I${TMP}/install/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib --with-openssl=/usr/local
+make -j 1
+make install
+OUT
+}
+
 @test "readline and sqlite3 are linked from Ports in FreeBSD" {
   cached_tarball "Python-3.6.2"
 
@@ -269,6 +301,7 @@ OUT
     for i in {1..2}; do stub uname '-s : echo FreeBSD'; done
     stub sysctl '-n hw.ncpu : echo 1'
 
+    stub pkg false
     stub pkg "$([[ $lib == readline ]] && echo "info -e $lib : true" || echo false)"
     if [[ $lib == sqlite3 ]]; then stub pkg "info -e $lib : true"; fi
 
@@ -538,7 +571,7 @@ OUT
   for i in {1..7}; do stub uname '-s : echo FreeBSD'; done
   stub uname '-r : echo 11.0-RELEASE'
   for i in {1..2}; do stub uname '-s : echo FreeBSD'; done
-  for i in {1..2}; do stub pkg false; done
+  for i in {1..3}; do stub pkg false; done
 
   stub sysctl '-n hw.ncpu : echo 1'
   stub_make_install


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

Guthub have recently preinstalled x64 Homebrew OpenSSL to stock MacOS runners. This has caused FreeBSD OpenSSL detection logic to erroneously trigger when running FreeBSD tests in MacOS because their paths happened to coincide.

Replaced checking a specific path with checking with `pkg`.

### Tests
- [x] My PR adds the following unit tests (if any)
N/A