### PR TITLE
Add PowerShell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,16 @@ See [Advanced configuration](#advanced-configuration) for details and more confi
     pyenv init - | source
     ~~~
 
+  - For **Microsoft PowerShell**:
+
+    Add the commands to `$profile.CurrentUserAllHosts` by running the following in your terminal:
+
+    ~~~ pwsh
+    echo '$Env:PYENV_ROOT="$HOME/.pyenv"' >> $profile.CurrentUserAllHosts
+    echo '$Env:PATH="$Env:PYENV_ROOT/bin:$Env:PATH"' >> $profile.CurrentUserAllHosts
+    echo 'iex ((pyenv init -) -join "`n")' >> $profile.CurrentUserAllHosts
+    ~~~
+
    **Bash warning**: There are some systems where the `BASH_ENV` variable is configured
    to point to `.bashrc`. On such systems, you should almost certainly put the
    `eval "$(pyenv init -)"` line into `.bash_profile`, and **not** into `.bashrc`. Otherwise, you

--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ opposed to this idea. Here's what `eval "$(pyenv init -)"` actually does:
 
 2. **Installs autocompletion.** This is entirely optional but pretty
    useful. Sourcing `$(pyenv root)/completions/pyenv.bash` will set that
-   up. There are also completions for Zsh and Fish.
+   up. There are also completions for Zsh, Fish and PowerShell.
 
 3. **Rehashes shims.** From time to time you'll need to rebuild your
    shim files. Doing this on init makes sure everything is up to

--- a/completions/pyenv.pwsh
+++ b/completions/pyenv.pwsh
@@ -1,0 +1,17 @@
+$scriptblock = {
+    param($wordToComplete, $commandAst, $cursorPosition)
+        $words = $commandAst.ToString() 
+        if ( $wordToComplete ) {
+          $matches = (($words[0..$cursorPosition] -join '') | Select-String -Pattern "\s+" -AllMatches).Matches
+          if ( $matches ) {
+            $cursorPosition = $matches[-1].Index - 1
+          }
+        }
+        $words = $words[0..$cursorPosition] -join '' -split "\s+"
+        if ( $words.Count -ge 2 ) {
+          pyenv completions $words[1] | where { $_ -match $wordToComplete }
+        } else {
+          pyenv commands | where { $_ -match $wordToComplete }
+        }
+}
+Register-ArgumentCompleter -Native -CommandName pyenv -ScriptBlock $scriptblock

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -281,7 +281,14 @@ function print_env() {
 function print_completion() {
   completion="${root}/completions/pyenv.${shell}"
   if [ -r "$completion" ]; then
-    echo "source '$completion'"
+    case "$shell" in
+    pwsh )
+      echo "iex (gc $completion -Raw)"
+      ;;
+    * )
+      echo "source '$completion'"
+      ;;
+    esac
   fi
 }
 
@@ -292,7 +299,7 @@ function print_rehash() {
       echo '& pyenv rehash 2>/dev/null'
       ;;
     * )
-    echo 'command pyenv rehash 2>/dev/null'
+      echo 'command pyenv rehash 2>/dev/null'
       ;;
     esac
   fi
@@ -348,7 +355,7 @@ pyenv() {
 EOS
     ;;
   esac
-
+  
   if [ "$shell" != "fish" ] && [ "$shell" != "pwsh" ]; then
     IFS="|"
     cat <<EOS

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -15,6 +15,7 @@ if [ "$1" = "--complete" ]; then
   echo bash
   echo fish
   echo ksh
+  echo pwsh
   echo zsh
   exit
 fi
@@ -105,6 +106,10 @@ function detect_profile() {
     profile_explain="~/.bash_profile if it exists, otherwise ~/.profile"
     rc='~/.bashrc'
     ;;
+  pwsh )
+    profile='~/.config/powershell/profile.ps1'
+    rc='~/.config/powershell/profile.ps1'
+    ;;
   zsh )
     profile='~/.zprofile'
     rc='~/.zshrc'
@@ -153,6 +158,21 @@ function help_() {
       echo 'pyenv init - | source'
       echo
       ;;
+    pwsh )
+      echo '# Load pyenv automatically by appending'
+      echo -n "# the following to "
+      if [ "$profile" == "$rc" ]; then
+        echo "$profile :"
+      else
+        echo
+        echo "${profile_explain:-$profile} (for login shells)"
+        echo "and $rc (for interactive shells) :"
+      fi
+      echo
+      echo '$Env:PYENV_ROOT="$HOME/.pyenv"'
+      echo '$Env:PATH="$Env:PYENV_ROOT/bin:$Env:PATH"'
+      echo 'iex ((pyenv init -) -join "`n")'
+      ;;
     * )
       echo '# Load pyenv automatically by appending'
       echo -n "# the following to "
@@ -189,6 +209,11 @@ function print_path() {
           print_path_prepend_shims
           echo 'end'
           ;;
+      pwsh )
+          echo 'if ( $Env:PATH -match "'"${PYENV_ROOT}/shims"'" ) {'
+          print_path_prepend_shims
+          echo '}'
+          ;;
       * )
           echo 'if [[ ":$PATH:" != *'\':"${PYENV_ROOT}"/shims:\''* ]]; then'
           print_path_prepend_shims
@@ -200,6 +225,10 @@ function print_path() {
       fish )
         echo 'while set pyenv_index (contains -i -- "'"${PYENV_ROOT}/shims"'" $PATH)'
         echo 'set -eg PATH[$pyenv_index]; end; set -e pyenv_index'
+        print_path_prepend_shims
+        ;;
+      pwsh )
+        echo '$Env:PATH="$(($Env:PATH -split '"':'"' | where { -not ($_ -match '"'${PYENV_ROOT}/shims'"') }) -join '"':'"')"'
         print_path_prepend_shims
         ;;
       * )
@@ -226,6 +255,9 @@ function print_path_prepend_shims() {
       fish )
           echo 'set -gx PATH '\'"${PYENV_ROOT}/shims"\'' $PATH'
           ;;
+      pwsh )
+          echo '$Env:PATH="'"${PYENV_ROOT}"'/shims:$Env:PATH"'
+          ;;
       * )
           echo 'export PATH="'"${PYENV_ROOT}"'/shims:${PATH}"'
           ;;
@@ -236,6 +268,9 @@ function print_env() {
   case "$shell" in
   fish )
     echo "set -gx PYENV_SHELL $shell"
+    ;;
+  pwsh )
+    echo '$Env:PYENV_SHELL="'"$shell"'"'
     ;;
   * )
     echo "export PYENV_SHELL=$shell"
@@ -252,7 +287,14 @@ function print_completion() {
 
 function print_rehash() {
   if [ -z "$no_rehash" ]; then
+    case "$shell" in
+    pwsh )
+      echo '& pyenv rehash 2>/dev/null'
+      ;;
+    * )
     echo 'command pyenv rehash 2>/dev/null'
+      ;;
+    esac
   fi
 }
 
@@ -274,6 +316,25 @@ function pyenv
 end
 EOS
     ;;
+  pwsh )
+    cat <<EOS
+function pyenv {
+  \$command=""
+  if ( \$args.Count -gt 0 ) {
+    \$command, \$args = \$args
+  }
+
+  if ( ("${commands[*]}" -split ' ') -contains \$command ) {
+    \$shell_cmds = & \$Env:PYENV_ROOT/bin/pyenv sh-\$command \$args
+    if ( \$shell_cmds.Count -gt 0 ) {
+      iex (\$shell_cmds -join "\`n")
+    }
+  } else {
+    & \$Env:PYENV_ROOT/bin/pyenv \$command \$args
+  }
+}
+EOS
+    ;;
   ksh | ksh93 | mksh )
     cat <<EOS
 function pyenv {
@@ -288,7 +349,7 @@ EOS
     ;;
   esac
 
-  if [ "$shell" != "fish" ]; then
+  if [ "$shell" != "fish" ] && [ "$shell" != "pwsh" ]; then
     IFS="|"
     cat <<EOS
   command="\${1:-}"

--- a/libexec/pyenv-sh-rehash
+++ b/libexec/pyenv-sh-rehash
@@ -14,7 +14,7 @@ shell="$(basename "${PYENV_SHELL:-$SHELL}")"
 pyenv-rehash
 
 case "$shell" in
-fish )
+fish | pwsh )
   # no rehash support
   ;;
 * )

--- a/libexec/pyenv-sh-shell
+++ b/libexec/pyenv-sh-shell
@@ -48,6 +48,9 @@ if [ "$versions" = "--unset" ]; then
     echo 'set -gu PYENV_VERSION_OLD "$PYENV_VERSION"'
     echo "set -e PYENV_VERSION"
     ;;
+  pwsh )
+    echo '$Env:PYENV_VERSION, $Env:PYENV_VERSION_OLD = $null, $Env:PYENV_VERSION'
+    ;;
   * )
     echo 'PYENV_VERSION_OLD="${PYENV_VERSION-}"'
     echo "unset PYENV_VERSION"
@@ -74,6 +77,16 @@ else
   echo "pyenv: PYENV_VERSION_OLD is not set" >&2
   false
 end
+EOS
+    ;;
+  pwsh )
+    cat <<EOS
+if ( Get-Item -Path Env:\PYENV_VERSION* ) {
+  \$Env:PYENV_VERSION, \$Env:PYENV_VERSION_OLD = \$Env:PYENV_VERSION_OLD, \$Env:PYENV_VERSION
+} else {
+  Write-Error "pyenv: Env:PYENV_VERSION_OLD is not set"
+  return \$false
+} 
 EOS
     ;;
   * )
@@ -108,6 +121,9 @@ if pyenv-prefix "${versions[@]}" >/dev/null; then
     fish )
       echo 'set -gu PYENV_VERSION_OLD "$PYENV_VERSION"'
       echo "set -gx PYENV_VERSION \"$version\""
+      ;;
+    pwsh )
+      echo '$Env:PYENV_VERSION, $Env:PYENV_VERSION_OLD = "'"${version}"'", $Env:PYENV_VERSION'
       ;;
     * )
       echo 'PYENV_VERSION_OLD="${PYENV_VERSION-}"'

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -120,3 +120,10 @@ SH
   assert_success ""
   assert [ -x "${PYENV_ROOT}/shims/python" ]
 }
+
+@test "sh-rehash in pwsh" {
+  create_executable "3.4" "python"
+  PYENV_SHELL=pwsh run pyenv-sh-rehash
+  assert_success ""
+  assert [ -x "${PYENV_ROOT}/shims/python" ]
+}

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -31,6 +31,11 @@ load test_helper
   assert_success 'echo "$PYENV_VERSION"'
 }
 
+@test "shell version (pwsh)" {
+  PYENV_SHELL=pwsh PYENV_VERSION="1.2.3" run pyenv-sh-shell
+  assert_success 'echo "$PYENV_VERSION"'
+}
+
 @test "shell revert" {
   PYENV_SHELL=bash run pyenv-sh-shell -
   assert_success
@@ -39,6 +44,12 @@ load test_helper
 
 @test "shell revert (fish)" {
   PYENV_SHELL=fish run pyenv-sh-shell -
+  assert_success
+  assert_line 0 'if set -q PYENV_VERSION_OLD'
+}
+
+@test "shell revert (pwsh)" {
+  PYENV_SHELL=pwsh run pyenv-sh-shell -
   assert_success
   assert_line 0 'if set -q PYENV_VERSION_OLD'
 }
@@ -58,6 +69,14 @@ OUT
   assert_output <<OUT
 set -gu PYENV_VERSION_OLD "\$PYENV_VERSION"
 set -e PYENV_VERSION
+OUT
+}
+
+@test "shell unset (pwsh)" {
+  PYENV_SHELL=pwsh run pyenv-sh-shell --unset
+  assert_success
+  assert_output <<OUT
+\$Env:PYENV_VERSION, \$Env:PYENV_VERSION_OLD = \$null, \$Env:PYENV_VERSION
 OUT
 }
 
@@ -87,5 +106,14 @@ OUT
   assert_output <<OUT
 set -gu PYENV_VERSION_OLD "\$PYENV_VERSION"
 set -gx PYENV_VERSION "1.2.3"
+OUT
+}
+
+@test "shell change version (pwsh)" {
+  mkdir -p "${PYENV_ROOT}/versions/1.2.3"
+  PYENV_SHELL=pwsh run pyenv-sh-shell 1.2.3
+  assert_success
+  assert_output <<OUT
+\$Env:PYENV_VERSION, \$Env:PYENV_VERSION_OLD = "1.2.3", \$Env:PYENV_VERSION
 OUT
 }


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

I added support for PowerShell (on Linux), it could probably be implemented for rbenv also, however I never used ruby and don't feel confident to implement it.

I know it's maybe a patch too important for the core code, if so just close this (draft) PR.

### Tests
- [ ] My PR adds the following unit tests (if any): WIP

I don't know how BATS works, I need help / hints to understand what should I do -- where is the tested shell specified?