### PR TITLE
use -I with ensurepip

### DIFF
--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -2,3 +2,4 @@
 !/.gitignore
 !/version-ext-compat
 !/python-build
+/python-build/test/build

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2025,7 +2025,7 @@ build_package_ensurepip() {
     ensurepip_opts="--altinstall"
   fi
   # FIXME: `--altinstall` with `get-pip.py`
-  "$PYTHON_BIN" -s -m ensurepip ${ensurepip_opts} 1>/dev/null 2>&1 || build_package_get_pip "$@" || return 1
+  "$PYTHON_BIN" -I -m ensurepip ${ensurepip_opts} 1>/dev/null 2>&1 || build_package_get_pip "$@" || return 1
   build_package_symlink_version_suffix
 }
 

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -200,7 +200,7 @@ OUT
   assert_success
 
   assert_build_log <<OUT
-python -s -m ensurepip
+python -I -m ensurepip
 OUT
 }
 
@@ -218,7 +218,7 @@ OUT
   assert_success
 
   assert_build_log <<OUT
-python -s -m ensurepip --altinstall
+python -I -m ensurepip --altinstall
 OUT
 }
 


### PR DESCRIPTION
Helps to workaround #2417

The `-s` flag assures that nothing can be installed to user site-package but doesn't seem to keep `ensurepip` from looking there for pip. If pip is installed in the user site-package directory pip isn't installed for the newly built python. `-I` leaves user site-package out entirely during the pip installation.