### PR TITLE
Prevent `grep` warning in `conda.bash`

### DIFF
--- a/pyenv.d/rehash/conda.bash
+++ b/pyenv.d/rehash/conda.bash
@@ -35,7 +35,7 @@ make_shims() {
 
 deregister_conda_shims() {
   # adapted for Bash 4.x's associative array (#1749)
-  if declare -p registered_shims 2> /dev/null | grep -Eq '^(declare|typeset) \-A'; then
+  if declare -p registered_shims 2> /dev/null | grep -Eq '^(declare|typeset) -A'; then
     for shim in ${!registered_shims[*]}; do
       if conda_shim "${shim}" 1>&2; then
         unset registered_shims[${shim}]


### PR DESCRIPTION
I was getting warnings when running various `pyenv` commands because of an improper call to `grep`:

```bash
$ grep -Eq '^(declare|typeset) \-A' </dev/null
grep: warning: stray \ before -
$ grep -Eq '^(declare|typeset) -A' </dev/null
```

This call was added in dfeda54,[^1] and there is no documented reason for having the `\`.

According to the GNU grep manual:[^2]

> The behavior of `grep` is unspecified if a unescaped backslash is not followed by a special character, a nonzero digit, or a character in the above list. Although `grep` might issue a diagnostic and/or give the backslash an interpretation now, its behavior may change if the syntax of regular expressions is extended in future versions.

This became an error in GNU grep 3.8 (2022-09-02),[^3] which explains why this problem was not found when the original code was added. This undefined behavior is part of the POSIX spec,[^4] so this fix should not break any other versions of `grep` being used.

[^1]:
    https://github.com/pyenv/pyenv/commit/dfeda54079f31471f1eb194e692284514b16be54

[^2]:
    https://www.gnu.org/software/grep/manual/grep.html#Special-Backslash-Expressions
    (Permalink: https://git.savannah.gnu.org/cgit/grep.git/tree/doc/grep.texi?id=d1c3fbe7722662b449bae23130b644c726473fe3#n1528)

[^3]:
    https://savannah.gnu.org/news/?id=10191
    (Permalink: https://git.savannah.gnu.org/cgit/grep.git/tree/NEWS?id=d1c3fbe7722662b449bae23130b644c726473fe3#n99)

[^4]:
    https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_04_02,
    https://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html