### PR TITLE
Add --bare option to `pyenv version`

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -268,8 +268,14 @@ version of Python, or install a package that provides binaries.
 Displays the currently active Python version, along with information on
 how it was set.
 
+Usage: pyenv version [--bare]
+
+    --bare    show just the version name. An alias to `pyenv version-name'
+
     $ pyenv version
     2.7.6 (set by /home/yyuu/.pyenv/version)
+    $ pyenv version --bare
+    2.7.6
 
 
 ## `pyenv versions`

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -268,9 +268,10 @@ version of Python, or install a package that provides binaries.
 Displays the currently active Python version, along with information on
 how it was set.
 
-Usage: pyenv version [--bare]
+    Usage: pyenv version [--bare]
 
     --bare    show just the version name. An alias to `pyenv version-name'
+
 
     $ pyenv version
     2.7.6 (set by /home/yyuu/.pyenv/version)

--- a/libexec/pyenv-version
+++ b/libexec/pyenv-version
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Summary: Show the current Python version(s) and its origin
+# Usage: pyenv version [--bare]
 #
 # Shows the currently selected Python version(s) and how it was
-# selected. To obtain only the version string, use `pyenv
-# version-name'.
+# selected. To obtain only the version string, use `pyenv version
+# --bare` or `pyenv version-name'.
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
@@ -13,8 +14,25 @@ OLDIFS="$IFS"
 IFS=: PYENV_VERSION_NAMES=($(pyenv-version-name)) || exitcode=$?
 IFS="$OLDIFS"
 
+unset bare
+for arg; do
+    case "$arg" in
+        --complete )
+            echo --bare
+            exit ;;
+        --bare ) bare=1 ;;
+        * )
+          pyenv-help --usage version >&2
+          exit 1
+          ;;
+    esac
+done
 for PYENV_VERSION_NAME in "${PYENV_VERSION_NAMES[@]}"; do
-  echo "$PYENV_VERSION_NAME (set by $(pyenv-version-origin))"
+  if [[ -n $bare ]]; then
+      echo "$PYENV_VERSION_NAME"
+  else
+      echo "$PYENV_VERSION_NAME (set by $(pyenv-version-origin))"
+  fi
 done
 
 exit $exitcode

--- a/libexec/pyenv-version
+++ b/libexec/pyenv-version
@@ -2,9 +2,7 @@
 # Summary: Show the current Python version(s) and its origin
 # Usage: pyenv version [--bare]
 #
-# Shows the currently selected Python version(s) and how it was
-# selected. To obtain only the version string, use `pyenv version
-# --bare` or `pyenv version-name'.
+#     --bare    show just the version name. An alias to `pyenv version-name'
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x

--- a/test/version.bats
+++ b/test/version.bats
@@ -71,7 +71,7 @@ pyenv-version-without-stderr() {
 OUT
 }
 
-@test "--bare" {
+@test "--bare prints just the name" {
   create_version "3.3.3"
   PYENV_VERSION=3.3.3 run pyenv-version --bare
   assert_success

--- a/test/version.bats
+++ b/test/version.bats
@@ -71,16 +71,11 @@ pyenv-version-without-stderr() {
 OUT
 }
 
-@test "--bare is an alias to pyenv-version-name" {
-  mkdir -p "$PYENV_TEST_DIR/bin"
-  export PATH="$PYENV_TEST_DIR/bin:$PATH"
-  echo >"$PYENV_TEST_DIR/bin/pyenv-version-name" <<!
-#!/bin/sh
-echo 'pyenv-version-name stub'
-!
+@test "--bare" {
+  create_version "3.3.3"
   run pyenv-version --bare
   assert_success
   assert_output <<OUT
-pyenv-version-name stub
+3.3.3
 OUT
 }

--- a/test/version.bats
+++ b/test/version.bats
@@ -70,3 +70,17 @@ pyenv-version-without-stderr() {
 3.3.3 (set by PYENV_VERSION environment variable)
 OUT
 }
+
+@test "--bare is an alias to pyenv-version-name" {
+  mkdir -p "$PYENV_TEST_DIR/bin"
+  export PATH="$PYENV_TEST_DIR/bin:$PATH"
+  echo >"$PYENV_TEST_DIR/bin/pyenv-version-name" <<!
+#!/usr/bin/env bash
+echo 'pyenv-version-name stub'
+!
+  run pyenv-version --bare
+  assert_success
+  assert_output <<OUT
+pyenv-version-name stub
+OUT
+}

--- a/test/version.bats
+++ b/test/version.bats
@@ -73,7 +73,7 @@ OUT
 
 @test "--bare" {
   create_version "3.3.3"
-  run pyenv-version --bare
+  PYENV_VERSION=3.3.3 run pyenv-version --bare
   assert_success
   assert_output <<OUT
 3.3.3

--- a/test/version.bats
+++ b/test/version.bats
@@ -75,7 +75,7 @@ OUT
   mkdir -p "$PYENV_TEST_DIR/bin"
   export PATH="$PYENV_TEST_DIR/bin:$PATH"
   echo >"$PYENV_TEST_DIR/bin/pyenv-version-name" <<!
-#!/usr/bin/env bash
+#!/bin/sh
 echo 'pyenv-version-name stub'
 !
   run pyenv-version --bare


### PR DESCRIPTION
It just points at pyenv version-name.  This adds consistency with the behavior of `pyenv versions --bare`

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.

I don't use `rbenv`, but from a quick look, I *could* make a similar change there. However, the files in question are already different (though the behavior is similar).

* [] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2779

### Description
- [x] Here are some details about my PR
Adds a `--bare` flag to `pyenv version`

### Tests
- [ ] My PR adds the following unit tests (if any)
