### PR TITLE
Fix fish shell config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ See [Advanced configuration](#advanced-configuration) for details and more confi
 
     ~~~ fish
     set -Ux PYENV_ROOT $HOME/.pyenv
+    mkdir -p $PYENV_ROOT/bin
     fish_add_path $PYENV_ROOT/bin
     ~~~
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

Copying the instructions for configuring the fish shell for pyenv verbatim fails because `fish_add_path` fails when the target directory doesn't exist.

### Tests
- [ ] My PR adds the following unit tests (if any)

N/A - doc change only.