### PR TITLE
Fix get-pip urls for older pypy versions

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2337,7 +2337,7 @@ if [ -z "${GET_PIP_URL}" ]; then
     2.6 | 2.6.* )
       GET_PIP_URL="https://bootstrap.pypa.io/pip/2.6/get-pip.py"
       ;;
-    2.7 | 2.7.* )
+    2.7 | 2.7.* | pypy2.7 | pypy2.7-* )
       GET_PIP_URL="https://bootstrap.pypa.io/pip/2.7/get-pip.py"
       ;;
     3.2 | 3.2.* )
@@ -2349,10 +2349,10 @@ if [ -z "${GET_PIP_URL}" ]; then
     3.4 | 3.4.* )
       GET_PIP_URL="https://bootstrap.pypa.io/pip/3.4/get-pip.py"
       ;;
-    3.5 | 3.5.* )
+    3.5 | 3.5.* | pypy3.5 | pypy3.5-* )
       GET_PIP_URL="https://bootstrap.pypa.io/pip/3.5/get-pip.py"
       ;;
-    3.6 | 3.6.* )
+    3.6 | 3.6.* | pypy3.6 | pypy3.6-* )
       GET_PIP_URL="https://bootstrap.pypa.io/pip/3.6/get-pip.py"
       ;;
     * )

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -393,6 +393,14 @@ OUT
   assert_success
 }
 
+@test "use the custom GET_PIP_URL for 2.7 versions" {
+  run_inline_definition_with_name --name=2.7 <<OUT
+echo "\${GET_PIP_URL}"
+OUT
+  assert_output "https://bootstrap.pypa.io/pip/2.7/get-pip.py"
+  assert_success
+}
+
 @test "use the custom GET_PIP_URL for 3.2 versions" {
   run_inline_definition_with_name --name=3.2 <<OUT
 echo "\${GET_PIP_URL}"
@@ -406,5 +414,53 @@ OUT
 echo "\${GET_PIP_URL}"
 OUT
   assert_output "https://bootstrap.pypa.io/pip/3.3/get-pip.py"
+  assert_success
+}
+
+@test "use the custom GET_PIP_URL for 3.4 versions" {
+  run_inline_definition_with_name --name=3.4 <<OUT
+echo "\${GET_PIP_URL}"
+OUT
+  assert_output "https://bootstrap.pypa.io/pip/3.4/get-pip.py"
+  assert_success
+}
+
+@test "use the custom GET_PIP_URL for 3.5 versions" {
+  run_inline_definition_with_name --name=3.5 <<OUT
+echo "\${GET_PIP_URL}"
+OUT
+  assert_output "https://bootstrap.pypa.io/pip/3.5/get-pip.py"
+  assert_success
+}
+
+@test "use the custom GET_PIP_URL for 3.6 versions" {
+  run_inline_definition_with_name --name=3.6 <<OUT
+echo "\${GET_PIP_URL}"
+OUT
+  assert_output "https://bootstrap.pypa.io/pip/3.6/get-pip.py"
+  assert_success
+}
+
+@test "use the custom GET_PIP_URL for pypy2.7 versions" {
+  run_inline_definition_with_name --name=pypy2.7-7.3.12 <<OUT
+echo "\${GET_PIP_URL}"
+OUT
+  assert_output "https://bootstrap.pypa.io/pip/2.7/get-pip.py"
+  assert_success
+}
+
+@test "use the custom GET_PIP_URL for pypy3.5 versions" {
+  run_inline_definition_with_name --name=pypy3.5-7.0.0 <<OUT
+echo "\${GET_PIP_URL}"
+OUT
+  assert_output "https://bootstrap.pypa.io/pip/3.5/get-pip.py"
+  assert_success
+}
+
+@test "use the custom GET_PIP_URL for pypy3.6 versions" {
+  run_inline_definition_with_name --name=pypy3.6-7.3.3 <<OUT
+echo "\${GET_PIP_URL}"
+OUT
+  assert_output "https://bootstrap.pypa.io/pip/3.6/get-pip.py"
   assert_success
 }


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description

On older recipes for `PyPy` the current `get-pip.py` is called, when it returns and incompatible script. Older `CPython` work around this by supplying the appropriate unsupported minor version number in the URL, such as `https://bootstrap.pypa.io/pip/2.7/get-pip.py`. This change would incorporate this same logic into `PyPy` installs such as `pypy2.7-7.3.12` where the minor version of Python is specified.

### Tests

* Adds unittests to `pyenv_ext.bats` for previously untested and new pinned bootstrap script versions.
