### PR TITLE
Update openssl url for 3.12.0rc2

### DIFF
--- a/plugins/python-build/share/python-build/3.12.0rc2
+++ b/plugins/python-build/share/python-build/3.12.0rc2
@@ -1,6 +1,6 @@
 prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-3.1.1s" "https://www.openssl.org/source/openssl-3.1.1s.tar.gz#b3aa61334233b852b63ddb048df181177c2c659eb9d4376008118f9c08d07674" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.1.2" "https://www.openssl.org/source/openssl-3.1.2.tar.gz#a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.12.0rc2" "https://www.python.org/ftp/python/3.12.0/Python-3.12.0rc2.tar.xz#11eb10376e6baf7bea53001f5181eaee1797788c4db6e83a061e422357927674" standard verify_py312 copy_python_gdb ensurepip


### PR DESCRIPTION
The old 3.1.1s URL returns a 404

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.

### Description
The old 3.1.1s URL returns a 404

### Tests
N/A
