### PR TITLE
Update the OpenSSL dependency for Python 2.7.18

### DIFF
--- a/plugins/python-build/share/python-build/2.7.18
+++ b/plugins/python-build/share/python-build/2.7.18
@@ -1,5 +1,5 @@
 export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="openssl@1.1 openssl@1.0 openssl"
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1v" "https://www.openssl.org/source/openssl-1.1.1v.tar.gz" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.18" "https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tar.xz#b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43" standard verify_py27 copy_python_gdb ensurepip


### PR DESCRIPTION
It seems that pyenv cannot install 2.7.18 on Mac M1 (Apple ARM).

    pyenv install 2.7.18          Downloading openssl-1.0.2q.tar.gz...
    -> https://www.openssl.org/source/old/1.0.2/openssl-1.0.2q.tar.gz
    Installing openssl-1.0.2q...

    BUILD FAILED (OS X 13.5 using python-build 20180424)

    Inspect or clean up the working tree at /var/folders/9_/wjqg43y12bz8cnhlmmwh7rgc0000gq/T/python-build.20230816131951.19737
    Results logged to /var/folders/9_/wjqg43y12bz8cnhlmmwh7rgc0000gq/T/python-build.20230816131951.19737.log

    Last 10 log lines:
       _dgram_write in libcrypto.a(bss_dgram.o)
       _RAND_query_egd_bytes in libcrypto.a(rand_egd.o)
       ...
    ld: symbol(s) not found for architecture i386
    clang: error: linker command failed with exit code 1 (use -v to see invocation)
    make[4]: *** [link_a.darwin] Error 1
    make[3]: *** [do_darwin-shared] Error 2
    make[2]: *** [libcrypto.1.0.0.dylib] Error 2
    make[1]: *** [shared] Error 2
    make: *** [build_crypto] Error 1

This is because the pyenv "recipe" for 2.7.18 fetches openssl 1.0.2 which did not have ARM support at the time. M1 support was added in 1.1.1i according to https://www.openssl.org/news/cl111.txt.

So, this change is pulling in the latest of that series at the time of authoring this change, which is 1.1.1v.

This could also potentially bring more security to 2.7.18.

There is some evidence here that the corresponding Python maintainer tried to support a more recent OpenSSL version:

https://mail.python.org/pipermail/python-dev/2019-February/156333.html

For testing, I tried to exercise the Python test suite to see whether the ssl tests work ok. I have run the following commands to double check that:

    pyenv uninstall 2.7.18 (just to start clean)
    pyenv install --keep 2.7.18
    cd ~/.pyenv/sources/2.7.18/Python-2.7.18
    make test

It seems that importing openssl worked. There are some connection resets by peer in certain threads, but they are not test failures.

Make sure you have checked all steps below.

Closes https://github.com/pyenv/pyenv/issues/2757