### PR TITLE
Install named version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This project was forked from [rbenv](https://github.com/rbenv/rbenv) and
   * [Install additional Python versions](#install-additional-python-versions)
     * [Prefix auto-resolution to the latest version](#prefix-auto-resolution-to-the-latest-version)
     * [Python versions with extended support](#python-versions-with-extended-support)
-    * [Install a named python version](#intstall-a-named-python-version)
+    * [Install a named python version](#install-a-named-python-version)
   * [Switch between Python versions](#switch-between-python-versions)
   * [Uninstall Python versions](#uninstall-python-versions)
   * [Other operations](#other-operations)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This project was forked from [rbenv](https://github.com/rbenv/rbenv) and
   * [Install additional Python versions](#install-additional-python-versions)
     * [Prefix auto-resolution to the latest version](#prefix-auto-resolution-to-the-latest-version)
     * [Python versions with extended support](#python-versions-with-extended-support)
+    * [Install a named python version](#intstall-a-named-python-version)
   * [Switch between Python versions](#switch-between-python-versions)
   * [Uninstall Python versions](#uninstall-python-versions)
   * [Other operations](#other-operations)
@@ -443,6 +444,20 @@ in a later version of those environments.
 * *3.7.8-3.7.15, 3.8.4-3.8.12, 3.9.0-3.9.7* : XCode 13.3
 * *3.5.10, 3.6.15* : MacOS 11+ and XCode 13.3
 * *2.7.18* : MacOS 10.15+ and Apple Silicon
+
+
+#### Install a named python version
+
+To install a named python version, the `--name <name>` argument can be given when installing a new version. This will
+append a `-<name>` string to the end of the version being installed. The `name` argument can only contain alpha-numeric,
+`-`, and `_` characters.
+
+E.g. to install and switch to a 3.11.3 version named `test-environment`
+
+```sh
+pyenv install --name test-environment 3.11.3
+pyenv global 3.11.3-test-environment
+```
 
 
 ### Switch between Python versions

--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -19,6 +19,7 @@
 #   -v/--verbose       Verbose mode: print compilation status to stdout
 #   --version          Show version of python-build
 #   -g/--debug         Build a debug version
+#   -n/--name <name>   Build named version as <version>-<name> (name: cannot contain spaces)
 #
 # For detailed information on installing Python versions with
 # python-build, including a list of environment variables for adjusting
@@ -46,6 +47,7 @@ if [ "$1" = "--complete" ]; then
   echo --verbose
   echo --version
   echo --debug
+  echo --name
   exec python-build --definitions
 fi
 
@@ -104,6 +106,11 @@ for option in "${OPTIONS[@]}"; do
   "g" | "debug" )
     DEBUG="-g"
     ;;
+  "n" | "name" )
+    [[ "${#ARGUMENTS[*]}" -eq 0 ]] && echo -e "Error: Expected argument for --name\n" >&2 && usage 1 >&2
+    NAME=${ARGUMENTS[0]}
+    unset ARGUMENTS[0]
+    ;;
   "version" )
     exec python-build --version
     ;;
@@ -122,6 +129,12 @@ unset VERSION_NAME
 DEFINITIONS=("${ARGUMENTS[@]}")
 [[ "${#DEFINITIONS[*]}" -eq 0 ]] && DEFINITIONS=($(pyenv-local 2>/dev/null || true))
 [[ "${#DEFINITIONS[*]}" -eq 0 ]] && usage 1 >&2
+
+# If the `name` argument has been used, validate the name given is valid
+if [ ! $(grep '^[-0-9a-zA-Z_]*$' <<< $NAME) ]; then
+  echo -e "Error: --name argument can only contain alpha-numeric, '-', and '_' characters\n" >&2
+  usage 1 >&2
+fi
 
 # Define `before_install` and `after_install` functions that allow
 # plugin hooks to register a string of code for execution before or
@@ -163,6 +176,7 @@ for DEFINITION in "${DEFINITIONS[@]}"; do
   # Set VERSION_NAME from $DEFINITION. Then compute the installation prefix.
   VERSION_NAME="${DEFINITION##*/}"
   [ -n "$DEBUG" ] && VERSION_NAME="${VERSION_NAME}-debug"
+  [ -n "$NAME" ] && VERSION_NAME="${VERSION_NAME}-${NAME}"
   PREFIX="${PYENV_ROOT}/versions/${VERSION_NAME}"
 
   [ -d "${PREFIX}" ] && PREFIX_EXISTS=1


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

This PR will add support for installing a named version using the
following:

```
pyenv install --name <name> <version>
```

This will add the user supplied `<name>` to the end of the version as
`<version>-<name>`. For example:

```
~$ pyenv install --name test-environment 3.11.3
Downloading Python-3.11.3.tar.xz...
-> https://www.python.org/ftp/python/3.11.3/Python-3.11.3.tar.xz
Installing Python-3.11.3...
Installed Python-3.11.3 to /home/user/.pyenv/versions/3.11.3-test-environment
~$ pyenv versions
* system (set by /home/user/.pyenv/version)
  3.8.5
  3.11.3
  3.11.3-test-environment
~$ pyenv 3.11.3-test-environment
~$ pyenv global 3.11.3-test-environment
~$ pyenv versions
  system
  3.8.5
  3.11.3
* 3.11.3-test-environment (set by /home/user/.pyenv/version)
~$
```

### Tests
- [ ] My PR adds the following unit tests (if any)
