### PR TITLE
Add GraalPy 23.1.0 definition using the faster Oracle GraalVM distribution

### DIFF
--- a/plugins/python-build/share/python-build/graalpy-23.1.0
+++ b/plugins/python-build/share/python-build/graalpy-23.1.0
@@ -1,0 +1,63 @@
+# Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+VERSION='23.1.0'
+BUILD=''
+
+colorize 1 "GraalPy 23.1 and later installed by python-build use the faster Oracle GraalVM distribution" && echo
+colorize 1 "Oracle GraalVM uses the GFTC license, which is free for development and production use, see https://medium.com/graalvm/161527df3d76" && echo
+colorize 1 "The GraalVM Community Edition variant of GraalPy is also available, under the name graalpy-community-23.1.0" && echo
+
+graalpy_arch="$(graalpy_architecture 2>/dev/null || true)"
+
+case "$graalpy_arch" in
+"linux-amd64" )
+  checksum="afbb81f034e77aecf4717fe14f2a7403aa1b82f0abf53a2e55e46bd49efe8c39"
+  ;;
+"linux-aarch64" )
+  checksum="be1e21ea245ddbdb9c266e670d6f1e76a55c693f98cee44aa74a76b249e53f96"
+  ;;
+"macos-amd64" )
+  checksum="6445537c597567ccf5ae37d296ecd988a92149fb4a1fb57088811e75f19c6da4"
+  ;;
+"macos-aarch64" )
+  checksum="f1b9b22cd8c0afb7eabd59fad554c23f452fbafcdffccf8a22eca037199d62ae"
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": No binary distribution of GraalPy is available for $(uname -sm)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac
+
+if [ -n "${BUILD}" ]; then
+  { echo
+    colorize 1 "ERROR"
+    echo "Oracle GraalPy currently doesn't provide snapshot builds. Use graalpy-community if you need snapshots."
+    echo
+  } >&2
+  exit 1
+fi
+
+url="https://github.com/oracle/graalpython/releases/download/graal-${VERSION}/graalpy-${VERSION}-${graalpy_arch}.tar.gz#${checksum}"
+
+install_package "graalpy-${VERSION}" "${url}" "copy" ensurepip


### PR DESCRIPTION
#### Summary (from the commit message)

* Use the new Oracle GraalVM distribution to provide the best user experience,
  as it significantly faster than GraalVM CE and is free for development and production use:
  https://medium.com/graalvm/whats-new-in-graalvm-languages-161527df3d76

### Description

Hello,

I would like to give the best experience to GraalPy users, and Oracle GraalVM provides that through being faster and more efficient (also in memory used).

I see that this has been briefly discussed in https://github.com/pyenv/pyenv/pull/2796 before but I would like to continue the discussion, in this PR.
The concern raised there by @native-api is:
> IMO we cannot provide non-OSS flavors in the core codebase. At the very least, because we can't help users solve problems with them -- which they will come here with.

I believe that at least the part about `because we can't help users solve problems with them` can be solved.
When a pyenv/python-build user reports a problem, either:
* It is a bug in python-build, and then it is very likely that if the bug happens with `graalpy` it would happen with `graalpy-community` too. So then it can be reproduced with `graalpy-community`. `graalpy` from an installer POV is very similar to `graalpy-community`, the difference is mainly in the JIT and optimizations, not in the file layout or so. Bugs from the JIT or extra optimizations are unlikely to be reported as python-build issues (i.e., they would happen at runtime not install time).
* It is a bug in the Python being installed, i.e., in GraalPy. It makes most sense to ask to report such bugs to [the GraalPy bug tracker](https://github.com/oracle/graalpython/issues).
* If the bug happens with `graalpy` but not with `graalpy-community` I think it makes sense to either tag @msimacek or @timfel or [report a GraalPy issue](https://github.com/oracle/graalpython/issues). Also I would expect most of these bugs can be investigated without needing the sources of Oracle GraalVM, in fact I don't expect any python-build maintainer to have to look at the sources of even GraalPy, if they do I think it's time to file a GraalPy issue.
* It could of course also be a bug in the user dev environment, and the same reasoning as above applies (e.g. likely to happen on `graalpy-community` too otherwise mention/file a GraalPy issue).

If there are other concerns, let's discuss them here.

Regarding OSS, GraalPy itself is [open-source](https://github.com/oracle/graalpython). As said in https://github.com/pyenv/pyenv/pull/2796:
> The difference in the versions is mostly performance, as _Oracle GraalPy_ features more compiler optimizations. The python runtime is identical with the exception of two modules, `struct` and `pickle` that have optimized versions in _Oracle GraalPy_.

For background I am a maintainer of ruby-build, setup-ruby and I contributed TruffleRuby (= Ruby on GraalVM) support to all 3 Ruby installers and switchers, so I think I understand fairly well the concerns with language installers in general and with users reporting issues to installers instead of to implementations of the language.
In `ruby-build` this was mostly solved by moving such "it does not work on my machine" to discussions instead of issues, done through [issue templates](https://github.com/rbenv/ruby-build/issues/new/choose). That avoids spamming the maintainers of the installer with issues which are in large majority not a bug of the installer (but either of that implementation or broken user dev environment).

I see that pyenv uses [a checklist in issues](https://github.com/pyenv/pyenv/blob/master/.github/ISSUE_TEMPLATE.md#prerequisite) for a similar purpose, that's great.
I think adding this item could help address the concern above:
* [x] If the problem happens with `graalpy`, try with `graalpy-community`, if it only happens with `graalpy` and not `graalpy-community` report it [here](https://github.com/oracle/graalpython/issues) instead.

This could even be generalized to:
* [x] If the problem happens with an alternative Python implementation (i.e., not CPython) and does not happen with CPython (check this), report it to that Python implementation instead, because then it is most likely a bug of that Python implementation rather than pyenv/python-build.