### PR TITLE
Install ncurses from Homebrew, if available

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -803,6 +803,7 @@ build_package_standard_build() {
     use_homebrew || true
     use_tcltk || true
     use_homebrew_readline || use_freebsd_pkg || true
+    use_homebrew_ncurses || true
     if is_mac -ge 1014; then
       use_xcode_sdk_zlib || use_homebrew_zlib || true
     else
@@ -1465,6 +1466,18 @@ use_homebrew_readline() {
     else
       return 1
     fi
+  fi
+}
+
+use_homebrew_ncurses() {
+  can_use_homebrew || return 1
+  local libdir="$(brew --prefix ncurses 2>/dev/null || true)"
+  if [ -d "$libdir" ]; then
+    echo "python-build: use ncurses from homebrew"
+    export CPPFLAGS="-I$libdir/include${CPPFLAGS:+ $CPPFLAGS}"
+    export LDFLAGS="-L$libdir/lib${LDFLAGS:+ $LDFLAGS}"
+  else
+    return 1
   fi
 }
 

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -259,6 +259,36 @@ make install
 OUT
 }
 
+@test "ncurses is linked from Homebrew" {
+  cached_tarball "Python-3.6.2"
+
+  ncurses_libdir="$TMP/homebrew-ncurses"
+  mkdir -p "$ncurses_libdir"
+  for i in {1..9}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
+  for i in {1..3}; do stub brew false; done
+  stub brew "--prefix ncurses : echo '$ncurses_libdir'"
+  stub brew false
+  stub_make_install
+
+  run_inline_definition <<DEF
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub sw_vers
+  unstub brew
+  unstub make
+
+  assert_build_log <<OUT
+Python-3.6.2: CPPFLAGS="-I$ncurses_libdir/include -I${TMP}/install/include" LDFLAGS="-L$ncurses_libdir/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
+make -j 2
+make install
+OUT
+}
+
 @test "openssl is linked from Ports in FreeBSD if present" {
   cached_tarball "Python-3.6.2"
 

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -62,7 +62,7 @@ assert_build_log() {
   cached_tarball "yaml-0.1.6"
   cached_tarball "Python-3.6.2"
 
-  for i in {1..9}; do stub uname '-s : echo Linux'; done
+  for i in {1..10}; do stub uname '-s : echo Linux'; done
   stub brew false
   stub_make_install
   stub_make_install
@@ -89,7 +89,7 @@ OUT
   cached_tarball "yaml-0.1.6"
   cached_tarball "Python-3.6.2"
 
-  for i in {1..9}; do stub uname '-s : echo Linux'; done
+  for i in {1..10}; do stub uname '-s : echo Linux'; done
   stub brew false
   stub_make_install
   stub_make_install
@@ -119,7 +119,7 @@ OUT
   cached_tarball "yaml-0.1.6"
   cached_tarball "Python-3.6.2"
 
-  for i in {1..9}; do stub uname '-s : echo Linux'; done
+  for i in {1..10}; do stub uname '-s : echo Linux'; done
   stub brew false
   stub_make_install
   stub_make_install
@@ -151,7 +151,7 @@ OUT
   BREW_PREFIX="$TMP/homebrew-prefix"
   mkdir -p "$BREW_PREFIX"
 
-  for i in {1..8}; do stub uname '-s : echo Darwin'; done
+  for i in {1..9}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
   stub brew "--prefix : echo '$BREW_PREFIX'" false
   stub_make_install
@@ -179,10 +179,10 @@ OUT
   brew_libdir="$TMP/homebrew-yaml"
   mkdir -p "$brew_libdir"
 
-  for i in {1..9}; do stub uname '-s : echo Darwin'; done
+  for i in {1..10}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
   stub brew "--prefix libyaml : echo '$brew_libdir'"
-  for i in {1..4}; do stub brew false; done
+  for i in {1..5}; do stub brew false; done
   stub_make_install
 
   install_fixture definitions/needs-yaml
@@ -205,7 +205,7 @@ OUT
   cached_tarball "yaml-0.1.6"
   cached_tarball "Python-3.6.2"
 
-  for i in {1..9}; do stub uname '-s : echo Linux'; done
+  for i in {1..10}; do stub uname '-s : echo Linux'; done
   stub brew true; brew
   stub_make_install
   stub_make_install
@@ -234,11 +234,11 @@ OUT
 
   readline_libdir="$TMP/homebrew-readline"
   mkdir -p "$readline_libdir"
-  for i in {1..7}; do stub uname '-s : echo Darwin'; done
+  for i in {1..8}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
   for i in {1..2}; do stub brew false; done
   stub brew "--prefix readline : echo '$readline_libdir'"
-  stub brew false
+  for i in {1..2}; do stub brew false; done
   stub_make_install
 
   run_inline_definition <<DEF
@@ -264,7 +264,7 @@ OUT
 
   for i in {1..7}; do stub uname '-s : echo FreeBSD'; done
   stub uname '-r : echo 11.0-RELEASE'
-  for i in {1..2}; do stub uname '-s : echo FreeBSD'; done
+  for i in {1..3}; do stub uname '-s : echo FreeBSD'; done
   stub sysctl '-n hw.ncpu : echo 1'
 
   stub pkg "info -e openssl : true"
@@ -298,7 +298,7 @@ OUT
 
     for i in {1..7}; do stub uname '-s : echo FreeBSD'; done
     stub uname '-r : echo 11.0-RELEASE'
-    for i in {1..2}; do stub uname '-s : echo FreeBSD'; done
+    for i in {1..3}; do stub uname '-s : echo FreeBSD'; done
     stub sysctl '-n hw.ncpu : echo 1'
 
     stub pkg false
@@ -331,7 +331,7 @@ OUT
 @test "no library searches performed during normal operation touch homebrew in non-MacOS" {
   cached_tarball "Python-3.6.2"
 
-  for i in {1..8}; do stub uname '-s : echo Linux'; done
+  for i in {1..9}; do stub uname '-s : echo Linux'; done
   stub brew true; brew
   stub_make_install
 
@@ -386,10 +386,10 @@ OUT
   mkdir -p "$readline_libdir/include/readline"
   touch "$readline_libdir/include/readline/rlconf.h"
 
-  for i in {1..7}; do stub uname '-s : echo Darwin'; done
+  for i in {1..8}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
 
-  for i in {1..3}; do stub brew false; done
+  for i in {1..4}; do stub brew false; done
   stub_make_install
 
   export PYTHON_CONFIGURE_OPTS="CPPFLAGS=-I$readline_libdir/include LDFLAGS=-L$readline_libdir/lib"
@@ -418,12 +418,12 @@ OUT
   mkdir -p "$tcl_tk_libdir/lib"
   echo "TCL_VERSION='$tcl_tk_version'" >>"$tcl_tk_libdir/lib/tclConfig.sh"
 
-  for i in {1..9}; do stub uname '-s : echo Darwin'; done
+  for i in {1..10}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
 
   stub brew false
   for i in {1..2}; do stub brew "--prefix tcl-tk : echo '$tcl_tk_libdir'"; done
-  for i in {1..2}; do stub brew false; done
+  for i in {1..3}; do stub brew false; done
 
   stub_make_install
 
@@ -452,10 +452,10 @@ OUT
   tcl_tk_version_long="8.6.10"
   tcl_tk_version="${tcl_tk_version_long%.*}"
 
-  for i in {1..8}; do stub uname '-s : echo Darwin'; done
+  for i in {1..9}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
 
-  for i in {1..4}; do stub brew false; done
+  for i in {1..5}; do stub brew false; done
   stub_make_install
 
   export PYTHON_CONFIGURE_OPTS="--with-tcltk-libs='-L${TMP}/custom-tcl-tk/lib -ltcl$tcl_tk_version -ltk$tcl_tk_version'"
@@ -480,7 +480,7 @@ OUT
 @test "tcl-tk is linked from Homebrew via pkgconfig only when envvar is set" {
   cached_tarball "Python-3.6.2"
 
-  for i in {1..9}; do stub uname '-s : echo Darwin'; done
+  for i in {1..10}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
 
   tcl_tk_libdir="$TMP/homebrew-tcl-tk"
@@ -488,7 +488,7 @@ OUT
 
   stub brew false
   for i in {1..2}; do stub brew "--prefix tcl-tk : echo '${tcl_tk_libdir}'"; done
-  for i in {1..2}; do stub brew false; done
+  for i in {1..3}; do stub brew false; done
 
   stub_make_install
 
@@ -513,7 +513,7 @@ OUT
 @test "number of CPU cores defaults to 2" {
   cached_tarball "Python-3.6.2"
 
-  for i in {1..9}; do stub uname '-s : echo Darwin'; done
+  for i in {1..10}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 10.10'; done
 
   stub sysctl false
@@ -540,7 +540,7 @@ OUT
 @test "number of CPU cores is detected on Mac" {
   cached_tarball "Python-3.6.2"
 
-  for i in {1..9}; do stub uname '-s : echo Darwin'; done
+  for i in {1..10}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 10.10'; done
 
   stub sysctl '-n hw.ncpu : echo 4'
@@ -570,7 +570,7 @@ OUT
 
   for i in {1..7}; do stub uname '-s : echo FreeBSD'; done
   stub uname '-r : echo 11.0-RELEASE'
-  for i in {1..2}; do stub uname '-s : echo FreeBSD'; done
+  for i in {1..3}; do stub uname '-s : echo FreeBSD'; done
   for i in {1..3}; do stub pkg false; done
 
   stub sysctl '-n hw.ncpu : echo 1'
@@ -597,7 +597,7 @@ OUT
 @test "setting PYTHON_MAKE_INSTALL_OPTS to a multi-word string" {
   cached_tarball "Python-3.6.2"
 
-  for i in {1..8}; do stub uname '-s : echo Linux'; done
+  for i in {1..9}; do stub uname '-s : echo Linux'; done
 
   stub_make_install
 
@@ -621,7 +621,7 @@ OUT
 @test "(PYTHON_)CONFIGURE_OPTS and (PYTHON_)MAKE_OPTS take priority over automatically added options" {
   cached_tarball "Python-3.6.2"
 
-  for i in {1..8}; do stub uname '-s : echo Linux'; done
+  for i in {1..9}; do stub uname '-s : echo Linux'; done
 
   stub_make_install
 
@@ -649,7 +649,7 @@ OUT
 @test "--enable-shared is not added if --disable-shared is passed" {
   cached_tarball "Python-3.6.2"
 
-  for i in {1..8}; do stub uname '-s : echo Linux'; done
+  for i in {1..9}; do stub uname '-s : echo Linux'; done
 
   stub_make_install
 
@@ -673,9 +673,9 @@ OUT
 @test "configuring with dSYM in MacOS" {
   cached_tarball "Python-3.6.2"
 
-  for i in {1..9}; do stub uname '-s : echo Darwin'; done
+  for i in {1..10}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
-  for i in {1..4}; do stub brew false; done
+  for i in {1..5}; do stub brew false; done
   stub_make_install
 
   run_inline_definition <<DEF
@@ -700,7 +700,7 @@ OUT
 @test "configuring with dSYM has no effect in non-MacOS" {
   cached_tarball "Python-3.6.2"
 
-  for i in {1..9}; do stub uname '-s : echo Linux'; done
+  for i in {1..10}; do stub uname '-s : echo Linux'; done
   stub_make_install
 
   run_inline_definition <<DEF
@@ -735,7 +735,7 @@ OUT
   stub uname "-s : echo FreeBSD" "-r : echo 9.1"
   for i in {1..6}; do stub uname "-s : echo FreeBSD"; done
   stub uname "-r : echo 9.1"
-  for i in {1..2}; do stub uname "-s : echo FreeBSD"; done
+  for i in {1..3}; do stub uname "-s : echo FreeBSD"; done
 
   MAKE=gmake stub_make_install
 
@@ -752,7 +752,7 @@ OUT
   stub uname "-s : echo FreeBSD" "-r : echo 10.0-RELEASE"
   for i in {1..6}; do stub uname "-s : echo FreeBSD"; done
   stub uname "-r : echo 10.0-RELEASE"
-  for i in {1..2}; do stub uname "-s : echo FreeBSD"; done
+  for i in {1..3}; do stub uname "-s : echo FreeBSD"; done
 
   stub_make_install
 
@@ -768,7 +768,7 @@ OUT
   stub uname "-s : echo FreeBSD" "-r : echo 11.0-RELEASE"
   for i in {1..6}; do stub uname "-s : echo FreeBSD"; done
   stub uname "-r : echo 11.0-RELEASE"
-  for i in {1..2}; do stub uname "-s : echo FreeBSD"; done
+  for i in {1..3}; do stub uname "-s : echo FreeBSD"; done
 
   stub_make_install
 
@@ -787,7 +787,7 @@ apply -p1 -i /my/patch.diff
 exec ./configure "\$@"
 CONF
 
-  for i in {1..8}; do stub uname '-s : echo Linux'; done
+  for i in {1..9}; do stub uname '-s : echo Linux'; done
   stub apply 'echo apply "$@" >> build.log'
   stub_make_install
 

--- a/plugins/python-build/test/compiler.bats
+++ b/plugins/python-build/test/compiler.bats
@@ -69,7 +69,7 @@ DEF
   mkdir -p "$INSTALL_ROOT"
   cd "$INSTALL_ROOT"
 
-  for i in {1..9}; do stub uname '-s : echo Darwin'; done
+  for i in {1..10}; do stub uname '-s : echo Darwin'; done
   for i in {1..3}; do stub sw_vers '-productVersion : echo 10.10'; done
 
   stub cc 'false'

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -325,7 +325,7 @@ EOS
   cached_tarball "Python-3.6.2"
 
   for i in {1..4}; do stub brew false; done
-  for i in {1..7}; do stub uname '-s : echo Linux'; done
+  for i in {1..8}; do stub uname '-s : echo Linux'; done
   stub "$MAKE" \
     " : echo \"$MAKE \$@\" >> build.log" \
     " : echo \"$MAKE \$@\" >> build.log && cat build.log >> '$INSTALL_ROOT/build.log'"


### PR DESCRIPTION
XCode Command Line Tools 15.0 was recently released, and it contains a broken version of ncurses 6.0. Some uses of Python's `curses` module will segfault when compiled with it. The solution is to switch to using the version of ncurses from Homebrew, which is currently 6.4. Support for ncurses 6 was added to Python 3.7 and was backported to 3.6 and 2.7, so this change should not break any recently supported Python versions.

I tested this commit with Python 3.12, 3.11, and 2.7, and all tests in the `test.test_curses` module passed without issue.

See https://github.com/python/cpython/issues/109617 and https://github.com/python/cpython/issues/69906 for more information.

---

Feel free to edit the commit message as needed, but would you consider keeping more of it than in #2768? It's sometimes useful to grep the Git logs when developing.