### PR TITLE
Fix intermittent "broken pipe" in tests

### DIFF
--- a/test/versions.bats
+++ b/test/versions.bats
@@ -201,6 +201,7 @@ OUT
   create_version "1.218.0"
   create_executable sort <<SH
 #!$BASH
+cat >/dev/null
 if [ "\$1" == "--version-sort" ]; then
   echo "${PYENV_ROOT}/versions/1.9.0"
   echo "${PYENV_ROOT}/versions/1.53.0"


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Addresses https://github.com/pyenv/pyenv/actions/runs/6427697835/job/17453756085

### Description
- [x] Here are some details about my PR

Read all stdin in the `sort` stub.
In other places, use the newly-discovered way to fix "broken pipe" with `head`.

### Tests
- [ ] My PR adds the following unit tests (if any)
