### PR TITLE
Add new anaconda and miniconda definitions

### DIFF
--- a/plugins/python-build/scripts/add_miniconda.py
+++ b/plugins/python-build/scripts/add_miniconda.py
@@ -193,7 +193,11 @@ class CondaVersion(NamedTuple):
             else:
                 return PyVersion.PY37
         if self.flavor == "anaconda":
-            # https://docs.anaconda.com/anaconda/reference/release-notes/
+            # https://docs.anaconda.com/free/anaconda/reference/release-notes/
+            if v >= (2023,7):
+                return PyVersion.PY311
+            if v >= (2023,3):
+                return PyVersion.PY310
             if v >= (2021,11):
                 return PyVersion.PY39
             if v >= (2020,7):

--- a/plugins/python-build/share/python-build/anaconda3-2023.09-0
+++ b/plugins/python-build/share/python-build/anaconda3-2023.09-0
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Anaconda3-2023.09-0-Linux-aarch64" "https://repo.anaconda.com/archive/Anaconda3-2023.09-0-Linux-aarch64.sh#69ee26361c1ec974199bce5c0369e3e9a71541de7979d2b9cfa4af556d1ae0ea" "anaconda" verify_py311
+  ;;
+"Linux-ppc64le" )
+  install_script "Anaconda3-2023.09-0-Linux-ppc64le" "https://repo.anaconda.com/archive/Anaconda3-2023.09-0-Linux-ppc64le.sh#5ea1ed9808af95eb2655fe6a4ffdb66bea66ecd1d053fc2ee69eacc7685ef665" "anaconda" verify_py311
+  ;;
+"Linux-s390x" )
+  install_script "Anaconda3-2023.09-0-Linux-s390x" "https://repo.anaconda.com/archive/Anaconda3-2023.09-0-Linux-s390x.sh#ee817071a2ad94e044fb48061a721bc86606b2f4906b705e4f42177eeb3ca7c5" "anaconda" verify_py311
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda3-2023.09-0-Linux-x86_64" "https://repo.anaconda.com/archive/Anaconda3-2023.09-0-Linux-x86_64.sh#6c8a4abb36fbb711dc055b7049a23bbfd61d356de9468b41c5140f8a11abd851" "anaconda" verify_py311
+  ;;
+"MacOSX-arm64" )
+  install_script "Anaconda3-2023.09-0-MacOSX-arm64" "https://repo.anaconda.com/archive/Anaconda3-2023.09-0-MacOSX-arm64.sh#34121775d9e30a6ea12af0a462e1881670b0c175b426e06fd7b1581625ebd69b" "anaconda" verify_py311
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda3-2023.09-0-MacOSX-x86_64" "https://repo.anaconda.com/archive/Anaconda3-2023.09-0-MacOSX-x86_64.sh#0c64a2c634fe31335079d97340c277c81b3f0c9dfe862a06599570640ac897a4" "anaconda" verify_py311
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.10-23.9.0-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.10-23.9.0-0
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py310_23.9.0-0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.9.0-0-Linux-aarch64.sh#bc0f7f0a1c83cdf1330726168518b55454d092c64593f82872a50c4b5742b958" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py310_23.9.0-0-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.9.0-0-Linux-ppc64le.sh#fa9d79e1df278dc72e5935fec3c87c6897a9388895a2a47b0ed49935d71c92e7" "miniconda" verify_py310
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py310_23.9.0-0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.9.0-0-Linux-s390x.sh#e10a160a44b0356f2ce59ce562855461499202976197ca7e1bf25ccb51dabb57" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py310_23.9.0-0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.9.0-0-Linux-x86_64.sh#b272a5f843762f0a18f6b70a162cd554a43a06adcd6f5a2102840e41907fffe5" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py310_23.9.0-0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.9.0-0-MacOSX-arm64.sh#3178aad8c75b30830e97d9a232433df1dfbe6cd34f55e0d7769cfaa17aa49e84" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py310_23.9.0-0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.9.0-0-MacOSX-x86_64.sh#88266dda3e812bf6789fceeb9cfcfbbcada860aa4050ae2a781812fbd077ed35" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.11-23.9.0-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.11-23.9.0-0
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py311_23.9.0-0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.9.0-0-Linux-aarch64.sh#1242847b34b23353d429fcbcfb6586f0c373e63070ad7d6371c23ddbb577778a" "miniconda" verify_py311
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py311_23.9.0-0-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.9.0-0-Linux-ppc64le.sh#07b53e411c2e4423bd34c3526d6644b916c4b2143daa8fbcb36b8ead412239b9" "miniconda" verify_py311
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py311_23.9.0-0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.9.0-0-Linux-s390x.sh#707c68e25c643c84036a16acdf836a3835ea75ffd2341c05ec2da6db1f3e9963" "miniconda" verify_py311
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py311_23.9.0-0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.9.0-0-Linux-x86_64.sh#43651393236cb8bb4219dcd429b3803a60f318e5507d8d84ca00dafa0c69f1bb" "miniconda" verify_py311
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py311_23.9.0-0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.9.0-0-MacOSX-arm64.sh#4215f6fc572207f73a8f64692b4936b1952051f4cd620eec2ebd1f946e98b886" "miniconda" verify_py311
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py311_23.9.0-0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.9.0-0-MacOSX-x86_64.sh#4b60eb49cf8fea6272bd2060878ab02cbab187dffd2fd732685c3c92a60b62ed" "miniconda" verify_py311
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.8-23.9.0-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.8-23.9.0-0
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py38_23.9.0-0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.9.0-0-Linux-aarch64.sh#c59fbb2565812573f39b88425ef48607de70d1feadc522204811555e58bb972c" "miniconda" verify_py38
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py38_23.9.0-0-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.9.0-0-Linux-ppc64le.sh#4d1903b396de1c3473a81b2794f0d9792b30b4e9d98ae1c9dcfeef3aba15435b" "miniconda" verify_py38
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py38_23.9.0-0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.9.0-0-Linux-s390x.sh#57cf786d2c30aed186a14e9319c596579750ef75d1c8c039734492b5e6d6762c" "miniconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py38_23.9.0-0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.9.0-0-Linux-x86_64.sh#3c684c1c22d3a0e6bd5ab28186fd7b068b5c552f0937ee927ad117f35a5573fc" "miniconda" verify_py38
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py38_23.9.0-0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.9.0-0-MacOSX-arm64.sh#694facc3601da8a93592d6f947818c2064d6854ca1f2a7e5b40b3e2e91e65baa" "miniconda" verify_py38
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py38_23.9.0-0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.9.0-0-MacOSX-x86_64.sh#6fab242ca8200a1d59e54c5cc1abb89f7519a136da234e2ab77a30fb87c4ce7d" "miniconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.9-23.9.0-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-23.9.0-0
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py39_23.9.0-0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.9.0-0-Linux-aarch64.sh#b3ae7a36e3adbe9f9ab152b645d8d20b09bd25b4f0a9be15bfb4d36aafdedd98" "miniconda" verify_py39
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py39_23.9.0-0-Linux-ppc64le" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.9.0-0-Linux-ppc64le.sh#f7699ab404cbcba918e1977cc54ee8573902835d3272e3d80b5a107f8c5b5b38" "miniconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py39_23.9.0-0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.9.0-0-Linux-s390x.sh#eab9add06fe3b0beb9b54b3ab3fc57b944dc370a3c9342216082f7747d6c74a7" "miniconda" verify_py39
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py39_23.9.0-0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.9.0-0-Linux-x86_64.sh#9200a10c762186391c35709382ed7cfa6578a051c9c76ea58f998df62c5afab0" "miniconda" verify_py39
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py39_23.9.0-0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.9.0-0-MacOSX-arm64.sh#3143f830fdff011a3d389fdb53b8021e90b662615a1ed62a0bcad099cef35c26" "miniconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py39_23.9.0-0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.9.0-0-MacOSX-x86_64.sh#763c08ad5bdf159d32e406bd3b03394e1fba6923f1936271ca27c8073f744ac2" "miniconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
I used `add_miniconda.py` to generate definitions files for anaconda `2023.09` and miniconda `23.9.0`.

In addition, I realized that `add_miniconda.py` was not properly determining the Python versions properly for recent releases of Anaconda, so I adjusted the code accordingly.