### PR TITLE
Describe --no-rehash option

### DIFF
--- a/man/man1/pyenv.1
+++ b/man/man1/pyenv.1
@@ -234,6 +234,7 @@ Skip this section unless you must know what every line in your shell profile is 
 \fBSets up your shims path\.\fR This is the only requirement for pyenv to function properly\. You can do this by hand by prepending \fB$(pyenv root)/shims\fR to your \fB$PATH\fR\.
 .IP "2." 4
 \fBRehashes shims\.\fR From time to time you'll need to rebuild your shim files\. Doing this on init makes sure everything is up to date\. You can always run \fBpyenv rehash\fR manually\.
+You can disable this functionality by adding \fB--no-rehash\fR to the end of your \fBpyenv init\fR command line.
 .IP "3." 4
 \fBInstalls the sh dispatcher\.\fR This bit is also optional, but allows pyenv and plugins to change variables in your current shell, making commands like \fBpyenv shell\fR possible\. The sh dispatcher doesn't do anything crazy like override \fBcd\fR or hack your shell prompt, but if for some reason you need \fBpyenv\fR to be a real script rather than a shell function, you can safely skip it\.
 .IP "" 0


### PR DESCRIPTION
(Closes: #2831)

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [X] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2831

### Description
- [X] Here are some details about my PR

I looked into describing more of the undocumented options in `libexec/pyenv-init` but my conclusions were speculative. If you would like for me to put those speculations into a separate PR, let me know and I'll go ahead.

### Tests
- [ ] My PR adds the following unit tests (if any)
