### PR TITLE
Make `pyenv init` output insertable to startup files

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -160,8 +160,8 @@ function help_() {
         echo "$profile :"
       else
         echo
-        echo "${profile_explain:-$profile} (for login shells)"
-        echo "and $rc (for interactive shells) :"
+        echo "# ${profile_explain:-$profile} (for login shells)"
+        echo "# and $rc (for interactive shells) :"
       fi
       echo
       echo 'export PYENV_ROOT="$HOME/.pyenv"'


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  N/A

### Description
- [x] Here are some details about my PR

Allows to pipe `pyenv init` output direcly into starup scripts

### Tests
- [x] My PR adds the following unit tests (if any)
N/A