### PR TITLE
Add support for miniconda3-3.11-23.10.0-1

### DIFF
--- a/plugins/python-build/share/python-build/miniconda3-3.11-23.10.0-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.11-23.10.0-1
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py311_23.10.0-1-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.10.0-1-Linux-aarch64.sh#a60e70ad7e8ac5bb44ad876b5782d7cdc66e10e1f45291b29f4f8d37cc4aa2c8" "miniconda" verify_py311
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py311_23.10.0-1-Linux-ppc64le.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.10.0-1-Linux-ppc64le.sh#1a2eda0a9a52a4bd058abbe9de5bb2bc751fcd7904c4755deffdf938d6f4436e" "miniconda" verify_py311
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py311_23.10.0-1-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.10.0-1-Linux-s390x.sh#ae212385c9d7f7473da7401d3f5f6cbbbc79a1fce730aa48531947e9c07e0808" "miniconda" verify_py311
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py311_23.10.0-1-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.10.0-1-Linux-x86_64.sh#d0643508fa49105552c94a523529f4474f91730d3e0d1f168f1700c43ae67595" "miniconda" verify_py311
+  ;;
+"MacOSX-arm64" )
+  install_script ""Miniconda3-py311_23.10.0-1-MacOSX-arm64.sh "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.10.0-1-MacOSX-arm64.sh#5043144d7eaea2286e30d091b62fcf50f7ed983b092230e56c370b592e7a57f2" "miniconda" verify_py311
+  ;;
+"MacOSX-x86_64" )
+  install_script ""Miniconda3-py311_23.10.0-1-MacOSX-x86_64.sh "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.10.0-1-MacOSX-x86_64.sh#8c50faa3880fdef96967477af09d41c52332998beeee7ef8116c79d4f5023d72" "miniconda" verify_py311
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Add support for miniconda3-3.11-23.10.0-1

### Tests
- [x] I have been tested locally and have passed the installation test
