### PR TITLE
Add support for miniconda3 23.10.0-1 with py3.10、py3.9、py3.8

### DIFF
--- a/plugins/python-build/share/python-build/miniconda3-3.10-23.10.0-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.10-23.10.0-1
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py310_23.10.0-1-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.10.0-1-Linux-aarch64.sh#3b8698e433dd9e8f948f94939b176b7819807bedb86020b81e2fca674d3df3b4" "miniconda" verify_py310
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py310_23.10.0-1-Linux-ppc64le.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.10.0-1-Linux-ppc64le.sh#8ba2b32ee15be9e43c3712d9235e8c6f1350de733e72f67ef035c878eee134e5" "miniconda" verify_py310
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py310_23.10.0-1-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.10.0-1-Linux-s390x.sh#ab037a5df6414fe48979285769a61bf99e46d1efd1c98bd3b0a9ab767862f86b" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py310_23.10.0-1-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.10.0-1-Linux-x86_64.sh#c7a34df472feb69805b64df6e8db58363c5ccab41cd3b40b07e3e6dfb924359a" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py310_23.10.0-1-MacOSX-arm64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.10.0-1-MacOSX-arm64.sh#a1477dfb4edfe922c2d1ed8dce90c16e6c57b3008f9503fae804acfda67736ae" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py310_23.10.0-1-MacOSX-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.10.0-1-MacOSX-x86_64.sh#bea320962dce404ecc1f6f4b0c0462cd3300df8ab165e5cb5bcee372c498535f" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.8-23.10.0-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.8-23.10.0-1
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py38_23.10.0-1-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.10.0-1-Linux-aarch64.sh#aee297bdefb15cfee9e2cb4c0881f811ce18c1a066ac75b811b21967ccd41acd" "miniconda" verify_py38
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py38_23.10.0-1-Linux-ppc64le.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.10.0-1-Linux-ppc64le.sh#1d7ccb2fa31042116b38ec518a63428d9cf87adba8771ffa9f0e3241f6b5a72a" "miniconda" verify_py38
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py38_23.10.0-1-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.10.0-1-Linux-s390x.sh#095bfb828b3155e6a345b7e821010451dfd291e8373b618a3b72a050a1c7a909" "miniconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py38_23.10.0-1-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.10.0-1-Linux-x86_64.sh#6842afb93a64fd4f04daa0f49f4618857d2327ead1366851eb0e49f1ae460f00" "miniconda" verify_py38
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py38_23.10.0-1-MacOSX-arm64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.10.0-1-MacOSX-arm64.sh#c5ece9fce0a2f3c68600476e4256146f03511f82f76d05324eedbdc9eb06bed7" "miniconda" verify_py38
+  ;;
+"MacOSX-x86_64" )
+  install_script ""Miniconda3-py38_23.10.0-1-MacOSX-x86_64.sh "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.10.0-1-MacOSX-x86_64.sh#0e6921f44b4278aa178969f59da57ca4ced2a55ef7730c774296f1de1801c561" "miniconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.9-23.10.0-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-23.10.0-1
@@ -1,0 +1,28 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py39_23.10.0-1-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.10.0-1-Linux-aarch64.sh#e7558e2a628ce2f40e8ea792763b942ba587b01b33a677d2d22e7372ec50dbb7" "miniconda" verify_py39
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniconda3-py39_23.10.0-1-Linux-ppc64le.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.10.0-1-Linux-ppc64le.sh#cd92b3272d85c94ef54b685d49fbbd9d36c6680e6b518f1806c039ddb34fc754" "miniconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py39_23.10.0-1-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.10.0-1-Linux-s390x.sh#1aa4b984316faa9917c0dce8656bf3b32941def86397815adbe124185b7d3cdb" "miniconda" verify_py39
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py39_23.10.0-1-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.10.0-1-Linux-x86_64.sh#3dbb87a74f80c84ae166a380bf51da8ef75699ce97c234e3e196afa20d1a9319" "miniconda" verify_py39
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py39_23.10.0-1-MacOSX-arm64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.10.0-1-MacOSX-arm64.sh#adfac9e92405a6fdb60cc3b39018cb5084d096799be8f82fa88d26dadbe719b6" "miniconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py39_23.10.0-1-MacOSX-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.10.0-1-MacOSX-x86_64.sh#6d26cbe11e964bf573c459420154139d922ffa2e5c690c9c1e9bdb84f17f83af" "miniconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
…niconda3-3.8-23.10.0-1

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Add support for miniconda3 23.10.0-1 with py3.10、py3.9、py3.8

### Tests
- [x] I have been tested locally and have passed the installation test.
