### PR TITLE
Fix graalpy-community to use a separate package name

### DIFF
--- a/plugins/python-build/share/python-build/graalpy-community-23.1.0
+++ b/plugins/python-build/share/python-build/graalpy-community-23.1.0
@@ -51,4 +51,4 @@ else
   url="https://github.com/oracle/graalpython/releases/download/graal-${VERSION}/graalpy-community-${VERSION}-${graalpy_arch}.tar.gz#${checksum}"
 fi
 
-install_package "graalpy-${VERSION}${BUILD}" "${url}" "copy" ensurepip
+install_package "graalpy-community-${VERSION}${BUILD}" "${url}" "copy" ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2854

### Description
- [x] Here are some details about my PR

Using the same name as graalpy causes a cache clash.

So if a user
* has enabled cache
* and checksum checking is disabled/unavailable
* and they install graalpy-community and graalpy
=> graalpy-community will be installed instead of graalpy

### Tests
- [x] My PR adds the following unit tests (if any)
N/A