### PR TITLE
Move 3.11.5+ to OpenSSL 3 by default

### DIFF
--- a/plugins/python-build/share/python-build/3.11.5
+++ b/plugins/python-build/share/python-build/3.11.5
@@ -1,7 +1,7 @@
-prefer_openssl11
+prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
-install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.2.0" "https://www.openssl.org/source/openssl-3.2.0.tar.gz#14c826f07c7e433706fb5c69fa9e25dab95684844b4c962a2cf1bf183eb4690e" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.11.5" "https://www.python.org/ftp/python/3.11.5/Python-3.11.5.tar.xz#85cd12e9cf1d6d5a45f17f7afe1cebe7ee628d3282281c492e86adf636defa3f" standard verify_py311 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.11.6
+++ b/plugins/python-build/share/python-build/3.11.6
@@ -1,7 +1,7 @@
-prefer_openssl11
+prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
-install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.2.0" "https://www.openssl.org/source/openssl-3.2.0.tar.gz#14c826f07c7e433706fb5c69fa9e25dab95684844b4c962a2cf1bf183eb4690e" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.11.6" "https://www.python.org/ftp/python/3.11.6/Python-3.11.6.tar.xz#0fab78fa7f133f4f38210c6260d90d7c0d5c7198446419ce057ec7ac2e6f5f38" standard verify_py311 copy_python_gdb ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2856

### Description
- [x] Here are some details about my PR

As per https://docs.python.org/3.11/whatsnew/3.11.html#notable-changes-in-3-11-5, OpenSSL 3.0 support in CPython is finally official since 3.11.5.

This is also a workaround due to Arm64 Homebrew build of OpenSSL 1.1 being defective: linking to it fails with:
```
*** WARNING: renaming "_ssl" since importing it failed: dlopen(<...>/_ssl.cpython-311-darwin.so, 0x0002): symbol not found in flat namespace '_SSL_get_peer_certificate'
*** WARNING: renaming "_hashlib" since importing it failed: dlopen(<...>/_hashlib.cpython-311-darwin.so, 0x0002): symbol not found in flat namespace '_EVP_MD_block_size'
```

### Tests
- [x] My PR adds the following unit tests (if any)
N/A