### PR TITLE
Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [n/a] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [n/a] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [n/a] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description

While browsing action runs in the repo I noticed that some of the action versions are out-of-date (for example, `actions/checkout@v3`, used in `macos_build.yml`, is now at `v4`).

This PR introduces a Dependabot config that will submit PRs (if needed) to keep action versions up-to-date. If this change is accepted and merges, you can expect Dependabot to immediately submit a PR to update `actions/checkout` to `v4`, together with any other actions that can be updated to new versions.

> ## Note: 
>
> `lee-dohm/no-response` is throwing Node version deprecation warnings ([example](https://github.com/pyenv/pyenv/actions/runs/7174017131)); the action appears to be unmaintained.
>
> It may be that `actions/stale` could be used as a replacement.

Thanks for your work on pyenv! :heart: 

### Tests
- [n/a] My PR adds the following unit tests (if any)
