### PR TITLE
Add support for miniconda3 23.11.0-1、23.11.0-2 with py3.11、py3.10、py3…

### DIFF
--- a/plugins/python-build/share/python-build/miniconda3-3.10-23.11.0-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.10-23.11.0-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py310_23.11.0-1-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-1-Linux-aarch64.sh#30b3f26fee441c5d70bd50ec06ea1acaa0e373ad30771165eada3f6bdf27766a" "miniconda" verify_py310
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py310_23.11.0-1-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-1-Linux-s390x.sh#54bfe6a47e24ddaa74b02c88d64596c1234fdf6c3789740471dea2bf3c685392" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py310_23.11.0-1-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-1-Linux-x86_64.sh#6581658486be8e700d77e24eccafba586a0fbafafadcf73d35ab13eaee4b80b1" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py310_23.11.0-1-MacOSX-arm64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-1-MacOSX-arm64.sh#570f66f7264d8ba3195fc0755baed35320842b36fb34ef16bdc142f1dc616cae" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py310_23.11.0-1-MacOSX-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-1-MacOSX-x86_64.sh#6517332e5af2088a0413dd9f536f258814efb6d5b9f78011a6f2ea53e2874484" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.10-23.11.0-2
+++ b/plugins/python-build/share/python-build/miniconda3-3.10-23.11.0-2
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py310_23.11.0-2-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-aarch64.sh#85bb96bca04b75f2081b4c0f7f10476fd67fba1637c18b07272aa3a518df5596" "miniconda" verify_py310
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py310_23.11.0-2-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-s390x.sh#fd506291eb51641e8cd3164c09fec31826f26dc446c3da9bb4c88fe35c95dfe7" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py310_23.11.0-2-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-x86_64.sh#35a58b8961e1187e7311b979968662c6223e86e1451191bed2e67a72b6bd0658" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py310_23.11.0-2-MacOSX-arm64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-MacOSX-arm64.sh#958a8d6e14d9eb843b24ba4019a1b62e0dedd819d844247485fd0c0ea4acbc61" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py310_23.11.0-2-MacOSX-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-MacOSX-x86_64.sh#07a6f46146993510d5d839ee014fc2229f7870d92aa73a52f11dd240833f08fb" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.11-23.11.0-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.11-23.11.0-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py311_23.11.0-1-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-1-Linux-aarch64.sh#63c06a1974695e50bbe767a030903d169e637e42d5b7b6d30876b19a01fbbad8" "miniconda" verify_py311
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py311_23.11.0-1-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-1-Linux-s390x.sh#04586c734987a39114b81384014c2cfa89360c518371b6fa249d3062efca27fe" "miniconda" verify_py311
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py311_23.11.0-1-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-1-Linux-x86_64.sh#5b3cefe534e23541f5f703f40d4818e361c3615dbf14651a0f29554c3fc3d0fd" "miniconda" verify_py311
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py311_23.11.0-1-MacOSX-arm64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-1-MacOSX-arm64.sh#7901f8f272478657bd023cfd6d832b53213053897efd23c1061bcc35c68c0637" "miniconda" verify_py311
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py311_23.11.0-1-MacOSX-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-1-MacOSX-x86_64.sh#7ee24fb01fbe1081d6dd600805f5f9c6a3a12714670ecad65a6dfcf870c8a74d" "miniconda" verify_py311
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.11-23.11.0-2
+++ b/plugins/python-build/share/python-build/miniconda3-3.11-23.11.0-2
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py311_23.11.0-2-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-2-Linux-aarch64.sh#decd447fb99dbd0fc5004481ec9bf8c04f9ba28b35a9292afe49ecefe400237f" "miniconda" verify_py311
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py311_23.11.0-2-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-2-Linux-s390x.sh#53a9e9eb97cd6e318f4f184add069436e1a46124cf864bf2d7bd67043e50e471" "miniconda" verify_py311
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py311_23.11.0-2-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-2-Linux-x86_64.sh#c9ae82568e9665b1105117b4b1e499607d2a920f0aea6f94410e417a0eff1b9c" "miniconda" verify_py311
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py311_23.11.0-2-MacOSX-arm64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-2-MacOSX-arm64.sh#5694c382e6056d62ed874f22692224c4f53bca22e8135b6f069111e081be07aa" "miniconda" verify_py311
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py311_23.11.0-2-MacOSX-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-2-MacOSX-x86_64.sh#2b7f9e46308c28c26dd83abad3e72121ef63916eaf17b63723b5a1f728dc3032" "miniconda" verify_py311
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.8-23.11.0-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.8-23.11.0-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py38_23.11.0-1-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.11.0-1-Linux-aarch64.sh#3b28bce7689d42c85190e86738f152efc88a7d17cbcd90b4eb8cb92be42e3bff" "miniconda" verify_py38
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py38_23.11.0-1-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.11.0-1-Linux-s390x.sh#38e4050d6b73814071c065d36c41c6fea553fbf973e72e6375b958fcff747b69" "miniconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py38_23.11.0-1-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.11.0-1-Linux-x86_64.sh#ad3cb53ddfbadd190172b864337572206733ae75515fcfb17157cc8f2cb907a5" "miniconda" verify_py38
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py38_23.11.0-1-MacOSX-arm64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.11.0-1-MacOSX-arm64.sh#89b1b0428e68fea63af15193237f2efed9a3c80cffa2fc221cca0af2465d3fd2" "miniconda" verify_py38
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py38_23.11.0-1-MacOSX-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.11.0-1-MacOSX-x86_64.sh#5056bea02062a198991a09c8c9c02c39735ad2d26cdbf21863eaa799bcacd8ab" "miniconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.8-23.11.0-2
+++ b/plugins/python-build/share/python-build/miniconda3-3.8-23.11.0-2
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py38_23.11.0-2-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.11.0-2-Linux-aarch64.sh#6e439ae5373d35b78a3f45775fa69f0afddd0c0a9e5e545cd2f75f913a6d143b" "miniconda" verify_py38
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py38_23.11.0-2-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.11.0-2-Linux-s390x.sh#4d53356e80b3be7e90dbcf021d40cd3d7f889cf4d19574c9957ba22f5a9d98f2" "miniconda" verify_py38
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py38_23.11.0-2-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.11.0-2-Linux-x86_64.sh#cb908ddbd603d789d94076ea4dd3f8517b15866719e007725dca778a8dfab823" "miniconda" verify_py38
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py38_23.11.0-2-MacOSX-arm64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.11.0-2-MacOSX-arm64.sh#5b0258717b9c53c90fc9255ef739d766325fc284761b637837e3d378bb12d3e3" "miniconda" verify_py38
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py38_23.11.0-2-MacOSX-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.11.0-2-MacOSX-x86_64.sh#143d79c7018c66ef452a27711090367dc36e0046ae765f514bc2b1c2b4f76746" "miniconda" verify_py38
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.9-23.11.0-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-23.11.0-1
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py39_23.11.0-1-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.11.0-1-Linux-aarch64.sh#a8a9c37882209680d9258e57ce5d5ca0e186f0159e703736b9f5122e94864083" "miniconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py39_23.11.0-1-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.11.0-1-Linux-s390x.sh#719c653d7e4b724566c2a9fa365f7b6dbb830d279513ae62e02e11144722c1c9" "miniconda" verify_py39
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py39_23.11.0-1-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.11.0-1-Linux-x86_64.sh#d36c0f778b6b164223a174acafbe8556b841b67e53cb84b3eb24f1956b62121a" "miniconda" verify_py39
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py39_23.11.0-1-MacOSX-arm64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.11.0-1-MacOSX-arm64.sh#1f345d26837e505713aa7b9332cc740c7f2319c7208dc6bd7b95b6a251a9b665" "miniconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py39_23.11.0-1-MacOSX-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.11.0-1-MacOSX-x86_64.sh#7b05aff168e441ec500e038bb3e252e5b01f3059a74f92fb7f3a7630eb6a6b13" "miniconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.9-23.11.0-2
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-23.11.0-2
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py39_23.11.0-2-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.11.0-2-Linux-aarch64.sh#465f30688bae46f73b8497bb601face6b652092ace0e515c898e2a64f8c0f15f" "miniconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py39_23.11.0-2-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.11.0-2-Linux-s390x.sh#ff1de437a3f9110d8d7665c1f6d178bb797150689264bec5d0d8b36604e3823a" "miniconda" verify_py39
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py39_23.11.0-2-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.11.0-2-Linux-x86_64.sh#b911ff745c55db982078ac51ed4d848da0170f16ba642822a3bc7dd3fc8c61ba" "miniconda" verify_py39
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py39_23.11.0-2-MacOSX-arm64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.11.0-2-MacOSX-arm64.sh#0234becafc167a475fbbcd9a59dda0eec288343695ff6b9645b34fcb9f124bb5" "miniconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py39_23.11.0-2-MacOSX-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.11.0-2-MacOSX-x86_64.sh#cc22270c81080d50e518f74d36a151fd3727e2cd6fccc4b1fd345f9a852d5762" "miniconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
….9、py3.8

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
