### PR TITLE
Make "Automatic installer" command a copy-able code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,9 @@ As far as Pyenv is concerned, version names are simply directories under
 
 ##### Automatic installer
 
-`curl https://pyenv.run | bash`
+```bash
+curl https://pyenv.run | bash
+```
 
 For more details visit our other project:
 https://github.com/pyenv/pyenv-installer


### PR DESCRIPTION
This code block was missing the nice "copy" icon that proper code-blocks get:

![pyenv readme screenshot](https://github.com/pyenv/pyenv/assets/465045/0612a2fc-625d-498a-9f15-660b97d72690)
