### PR TITLE
Add CPython 3.13.0a3

### DIFF
--- a/plugins/python-build/share/python-build/3.13.0a3
+++ b/plugins/python-build/share/python-build/3.13.0a3
@@ -3,7 +3,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-3.1.2" "https://www.openssl.org/source/openssl-3.1.2.tar.gz#a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.13.0a2" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0a2.tar.xz#b6d46b44190c4c02421eb69a042d16b0c55481bdda818c6c416dc244113a9c2d" standard verify_py313 copy_python_gdb ensurepip
+    install_package "Python-3.13.0a3" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0a3.tar.xz#20784c8304eb1c69c80f966ebdf0775be2e37e23df3b62461eec12a85dcf7ead" standard verify_py313 copy_python_gdb ensurepip
 else
-    install_package "Python-3.13.0a2" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0a2.tgz#9a3c363589ec882f2d1ff008f29f66231ccb552366dd9d8041a65c7e799cbafd" standard verify_py313 copy_python_gdb ensurepip
+    install_package "Python-3.13.0a3" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0a3.tgz#9c7c2b42a20127816f9403723bfc88d1566f47dac0c46f50492f7ff8db646d8f" standard verify_py313 copy_python_gdb ensurepip
 fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description

Adds CPython [3.13.0a3](https://www.python.org/downloads/release/python-3130a3/), released Jan. 17, 2024.

### Tests
- [ ] My PR adds the following unit tests (if any)
