### PR TITLE
Use Homebrew in Linux if Pyenv is installled with Homebrew

### DIFF
--- a/plugins/python-build/README.md
+++ b/plugins/python-build/README.md
@@ -120,9 +120,11 @@ The exceptions -- non-default options that are set by default -- are listed belo
 
 ##### Homebrew
 
-In MacOS, Homebrew is used to find dependency packages if `brew` is found on `PATH`.
+Homebrew is used to find dependency packages if `brew` is found on `PATH`:
+* In MacOS, or
+* If the running Pyenv itself is installed with Homebrew
 
-Set `PYTHON_BUILD_SKIP_HOMEBREW` to avoid using it.
+Set `PYTHON_BUILD_USE_HOMEBREW` or `PYTHON_BUILD_SKIP_HOMEBREW` to override this default.
 
 When Homebrew is used, its `include` and `lib` paths are added to compiler search path (the latter is also set as `rpath`),
 and also Python dependencies that are typically keg-only are searched for in the Homebrew installation and added individually.
@@ -155,7 +157,8 @@ You can set certain environment variables to control the build process.
 * `PYTHON_BUILD_SKIP_MIRROR`, if set, forces python-build to download packages from
   their original source URLs instead of using a mirror.
 * `PYTHON_BUILD_HTTP_CLIENT`, explicitly specify the HTTP client type to use. `aria2`, `curl` and `wget` are the supported values and by default, are searched in that order.
-* `PYTHON_BUILD_SKIP_HOMEBREW`, if set, will not search for libraries installed by Homebrew in macOS.
+* `PYTHON_BUILD_SKIP_HOMEBREW`, if set, will not search for libraries installed by Homebrew when it would normally will.
+* `PYTHON_BUILD_USE_HOMEBREW`, if set, will search for libraries installed by Homebrew when it would normally not.
 * `PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA`, override the Homebrew OpenSSL formula to use.
 * `PYTHON_BUILD_ROOT` overrides the default location from where build definitions
   in `share/python-build/` are looked up.

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -118,8 +118,17 @@ is_mac() {
 }
 
 can_use_homebrew() {
-    [ -z "$PYTHON_BUILD_SKIP_HOMEBREW" ] || return 1
-    is_mac || return 1
+  [[ -n "$PYTHON_BUILD_USE_HOMEBREW" && -n "$PYTHON_BUILD_SKIP_HOMEBREW" ]] && {
+    echo "error: mutually exclusive environment variables PYTHON_BUILD_USE_HOMEBREW and PYTHON_BUILD_SKIP_HOMEBREW are set" >&3
+    exit 1
+  }
+  [[ -n "$PYTHON_BUILD_USE_HOMEBREW" ]] && return 0
+  [[ -n "$PYTHON_BUILD_SKIP_HOMEBREW" ]] && return 1
+  is_mac && return 0
+  # In Linux, if Pyenv itself is installed with Homebrew,
+  # we assume the user wants to take dependencies from there as well by default
+  command -v brew &>/dev/null && [[ $(abs_dirname "${BASH_SOURCE}") == "$(abs_dirname "$(brew --prefix 2>/dev/null ||true)")"/* ]] && return 0
+  return 1
 }
 
 #  9.1  -> 901

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -19,7 +19,10 @@ PYTHON_BUILD_VERSION="20180424"
 OLDIFS="$IFS"
 
 set -E
-[ -n "$PYENV_DEBUG" ] && set -x
+[ -n "$PYENV_DEBUG" ] && {
+  export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+  set -x
+}
 
 exec 3<&2 # preserve original stderr at fd 3
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2892
  - Closes https://github.com/pyenv/pyenv/issues/2881
  - Closes https://github.com/pyenv/pyenv/issues/2823

### Description
- [x] Here are some details about my PR

Practice has shown that users who install Pyenv via Homebrew in Linux want to use dependencies from there, too, despite the drawbacks.

### Tests
- [x] My PR adds the following unit tests (if any)

Tests for the new behavior and envvars