### PR TITLE
Handle case where `pyenv-commands --sh` returns nothing

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -297,7 +297,7 @@ EOS
   fi
 
   case "\$command" in
-  ${commands[*]})
+  ${commands[*]:-/})
     eval "\$(pyenv "sh-\$command" "\$@")"
     ;;
   *)

--- a/test/init.bats
+++ b/test/init.bats
@@ -2,6 +2,18 @@
 
 load test_helper
 
+setup() {
+  export PATH="${PYENV_TEST_DIR}/bin:$PATH"
+}
+
+create_executable() {
+  local name="$1"
+  local bin="${PYENV_TEST_DIR}/bin"
+  mkdir -p "$bin"
+  sed -Ee '1s/^ +//' > "${bin}/$name"
+  chmod +x "${bin}/$name"
+}
+
 @test "creates shims and versions directories" {
   assert [ ! -d "${PYENV_ROOT}/shims" ]
   assert [ ! -d "${PYENV_ROOT}/versions" ]
@@ -165,6 +177,24 @@ echo "\$PATH"
   run pyenv-init - zsh
   assert_success
   assert_line '  case "$command" in'
+}
+
+@test "outputs sh-compatible case syntax" {
+  create_executable pyenv-commands <<!
+#!$BASH
+echo -e 'activate\ndeactivate\nrehash\nshell'
+!
+  run pyenv-init - bash
+  assert_success
+  assert_line '  activate|deactivate|rehash|shell)'
+
+  create_executable pyenv-commands <<!
+#!$BASH
+echo
+!
+  run pyenv-init - bash
+  assert_success
+  assert_line '  /)'
 }
 
 @test "outputs fish-specific syntax (fish)" {


### PR DESCRIPTION
When running `eval "$(pyenv init -)"` to initialize `pyenv`, the command generates a shell script to be executed. When not using the `fish` shell, this script contains a `case` statement where the first case matches against the output of `pyenv-commands --sh` and the second case handles everything else. However, if no commands are returned, then the matching expression will be only `)`, which is invalid Bash.

I have solved this by only including the first case if there are commands to match. The resulting `case` statement will have only a single, default case, which is somewhat silly, but I wanted to minimize the variation across runs of `pyenv init -`. To catch any regressions, I have added a test to catch unexpected changes in the generated `case` statement.

I do not know if `pyenv-commands --sh` can ever return nothing under normal conditions, but it happened to me due to completely unrelated problems in underlying Unix utilities called by `pyenv`. Although this bug will rarely occur, I feel that this increased robustness will be useful.

---

Feel free to edit the commit message as needed, but I would appreciate if you kept most of it. I sometimes find it useful to grep the Git logs when developing.

This bug might also exist in the generated `fish` script, but I know nothing about the `fish` shell. [`case`](https://fishshell.com/docs/current/cmds/case.html) doesn't explain what happens when no pattern is provided.