### PR TITLE
Add miniconda3-24.1.2-0 support for py312、py311、py310、py39

### DIFF
--- a/plugins/python-build/share/python-build/miniconda3-3.10-24.1.2-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.10-24.1.2-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py310_24.1.2-0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_24.1.2-0-Linux-aarch64.sh#e560e737ac0e625dcc19ca2927457c2944434a61280daae2594632aca76d1422" "miniconda" verify_py310
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py310_24.1.2-0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py310_24.1.2-0-Linux-s390x.sh#014fd09da9f7ecae040d586a6ff4218e508bf0e5e0232be6383ff37973a337c7" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py310_24.1.2-0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_24.1.2-0-Linux-x86_64.sh#8eb5999c2f7ac6189690d95ae5ec911032fa6697ae4b34eb3235802086566d78" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py310_24.1.2-0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_24.1.2-0-MacOSX-arm64.sh#01110da80119c11078d2b39a499b6dc086c5fd4b413f4b333d32feb3b03cbe7b" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py310_24.1.2-0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_24.1.2-0-MacOSX-x86_64.sh#f078682fca26350717c1940650c227f9843fe9f3f0ecc87bf2665bccc5c64f9c" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.11-24.1.2-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.11-24.1.2-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py311_24.1.2-0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_24.1.2-0-Linux-aarch64.sh#1e046ef2d9d47289db2491f103c81b0b4baf943a9234ac59bd5bca076c881d98" "miniconda" verify_py311
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py311_24.1.2-0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py311_24.1.2-0-Linux-s390x.sh#0489909051fd9e2c9addfa5fbd531ccb7f8f2463ac47376b8854e5a09b1c4011" "miniconda" verify_py311
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py311_24.1.2-0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_24.1.2-0-Linux-x86_64.sh#3f2e5498e550a6437f15d9cc8020d52742d0ba70976ee8fce4f0daefa3992d2e" "miniconda" verify_py311
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py311_24.1.2-0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_24.1.2-0-MacOSX-arm64.sh#b5c4f646144fa4760bd5f6114ff2e6b49a3ef7c57b993f569adceea784f21a52" "miniconda" verify_py311
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py311_24.1.2-0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_24.1.2-0-MacOSX-x86_64.sh#3b26c0867561d0988040193c8efd9f53ca922026f735367436aa05b467b1f187" "miniconda" verify_py311
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.12-24.1.2-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.12-24.1.2-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py312_24.1.2-0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.1.2-0-Linux-aarch64.sh#942a057a52ec99f0fca4f413b87b332f6e61fad95c05fa7cabc003ae0b4471de" "miniconda" verify_py312
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py312_24.1.2-0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.1.2-0-Linux-s390x.sh#7ee6a3c41a825eca3b1c9e3c7155c67f7c26e31a75d7dc4f78f75a4c438e3009" "miniconda" verify_py312
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py312_24.1.2-0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.1.2-0-Linux-x86_64.sh#"b978856ec3c826eb495b60e3fffe621f670c101150ebcbdeede4f961f22dc438"miniconda" verify_py312
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py312_24.1.2-0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.1.2-0-MacOSX-arm64.sh#1c277b1ec046fd1b628390994e3fa3dbac0e364f44cd98b915daaa67a326c66a" "miniconda" verify_py312
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py312_24.1.2-0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.1.2-0-MacOSX-x86_64.sh#bc45a2ceea9341579532847cc9f29a9769d60f12e306bba7f0de6ad5acdd73e9" "miniconda" verify_py312
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.12-24.1.2-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.12-24.1.2-0
@@ -6,7 +6,7 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
   install_script "Miniconda3-py312_24.1.2-0-Linux-s390x" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.1.2-0-Linux-s390x.sh#7ee6a3c41a825eca3b1c9e3c7155c67f7c26e31a75d7dc4f78f75a4c438e3009" "miniconda" verify_py312
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-py312_24.1.2-0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.1.2-0-Linux-x86_64.sh#"b978856ec3c826eb495b60e3fffe621f670c101150ebcbdeede4f961f22dc438"miniconda" verify_py312
+  install_script "Miniconda3-py312_24.1.2-0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.1.2-0-Linux-x86_64.sh#b978856ec3c826eb495b60e3fffe621f670c101150ebcbdeede4f961f22dc438" "miniconda" verify_py312
   ;;
 "MacOSX-arm64" )
   install_script "Miniconda3-py312_24.1.2-0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.1.2-0-MacOSX-arm64.sh#1c277b1ec046fd1b628390994e3fa3dbac0e364f44cd98b915daaa67a326c66a" "miniconda" verify_py312

--- a/plugins/python-build/share/python-build/miniconda3-3.9-24.1.2-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-24.1.2-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py39_24.1.2-0-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_24.1.2-0-Linux-aarch64.sh#b3e7d8ad4a4c9106594b268ab1cd9494ce982eaf7734bb2cd13a47e14e92a43e" "miniconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py39_24.1.2-0-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_24.1.2-0-Linux-s390x.sh#c1e5b7cee62b465a919b88a9c5658c426c6633f1fbcb568d2cff36a13aef6b97" "miniconda" verify_py39
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py312_24.1.2-0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.1.2-0-Linux-x86_64.sh#2ec135e4ae2154bb41e8df9ecac7ef23a7d6ca59fc1c8071cfe5298505c19140" "miniconda" verify_py39
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py39_24.1.2-0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_24.1.2-0-MacOSX-arm64.sh#2a7e44373bdf47caae991ff8d7d275a2ded51ed0e8e457c7edc9ecd45e48cda4" "miniconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py39_24.1.2-0-MacOSX-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_24.1.2-0-MacOSX-x86_64.sh#d4e81df5beaa73dbbb9e1e91065e8f8222e9a9d44a2e7271aedd6e4a5054c541" "miniconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.9-24.1.2-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-24.1.2-0
@@ -6,7 +6,7 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
   install_script "Miniconda3-py39_24.1.2-0-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_24.1.2-0-Linux-s390x.sh#c1e5b7cee62b465a919b88a9c5658c426c6633f1fbcb568d2cff36a13aef6b97" "miniconda" verify_py39
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-py312_24.1.2-0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.1.2-0-Linux-x86_64.sh#2ec135e4ae2154bb41e8df9ecac7ef23a7d6ca59fc1c8071cfe5298505c19140" "miniconda" verify_py39
+  install_script "Miniconda3-py312_24.1.2-0-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.1.2-0-Linux-x86_64.sh#b978856ec3c826eb495b60e3fffe621f670c101150ebcbdeede4f961f22dc438" "miniconda" verify_py39
   ;;
 "MacOSX-arm64" )
   install_script "Miniconda3-py39_24.1.2-0-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py39_24.1.2-0-MacOSX-arm64.sh#2a7e44373bdf47caae991ff8d7d275a2ded51ed0e8e457c7edc9ecd45e48cda4" "miniconda" verify_py39


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
