### PR TITLE
minor grammar fix in libffi backport patch in 2.5.x

### DIFF
--- a/plugins/python-build/share/python-build/patches/2.5.0/Python-2.5/004_osx_libffi.patch
+++ b/plugins/python-build/share/python-build/patches/2.5.0/Python-2.5/004_osx_libffi.patch
@@ -197,7 +197,7 @@ index 0000000..1fc2747
 +Before making the call, the VALUES vector should be initialized 
 +with pointers to the appropriate argument values.
 +
-+To call the the function using the initialized ffi_cif, use the
++To call the function using the initialized ffi_cif, use the
 +ffi_call function:
 +
 +void ffi_call(ffi_cif *cif, void *fn, void *rvalue, void **avalues);

--- a/plugins/python-build/share/python-build/patches/2.5.1/Python-2.5.1/004_osx_libffi.patch
+++ b/plugins/python-build/share/python-build/patches/2.5.1/Python-2.5.1/004_osx_libffi.patch
@@ -197,7 +197,7 @@ index 0000000..1fc2747
 +Before making the call, the VALUES vector should be initialized 
 +with pointers to the appropriate argument values.
 +
-+To call the the function using the initialized ffi_cif, use the
++To call the function using the initialized ffi_cif, use the
 +ffi_call function:
 +
 +void ffi_call(ffi_cif *cif, void *fn, void *rvalue, void **avalues);

--- a/plugins/python-build/share/python-build/patches/2.5.2/Python-2.5.2/004_osx_libffi.patch
+++ b/plugins/python-build/share/python-build/patches/2.5.2/Python-2.5.2/004_osx_libffi.patch
@@ -197,7 +197,7 @@ index 0000000..1fc2747
 +Before making the call, the VALUES vector should be initialized 
 +with pointers to the appropriate argument values.
 +
-+To call the the function using the initialized ffi_cif, use the
++To call the function using the initialized ffi_cif, use the
 +ffi_call function:
 +
 +void ffi_call(ffi_cif *cif, void *fn, void *rvalue, void **avalues);

--- a/plugins/python-build/share/python-build/patches/2.5.3/Python-2.5.3/004_osx_libffi.patch
+++ b/plugins/python-build/share/python-build/patches/2.5.3/Python-2.5.3/004_osx_libffi.patch
@@ -197,7 +197,7 @@ index 0000000..1fc2747
 +Before making the call, the VALUES vector should be initialized 
 +with pointers to the appropriate argument values.
 +
-+To call the the function using the initialized ffi_cif, use the
++To call the function using the initialized ffi_cif, use the
 +ffi_call function:
 +
 +void ffi_call(ffi_cif *cif, void *fn, void *rvalue, void **avalues);

--- a/plugins/python-build/share/python-build/patches/2.5.4/Python-2.5.4/004_osx_libffi.patch
+++ b/plugins/python-build/share/python-build/patches/2.5.4/Python-2.5.4/004_osx_libffi.patch
@@ -197,7 +197,7 @@ index 0000000..1fc2747
 +Before making the call, the VALUES vector should be initialized 
 +with pointers to the appropriate argument values.
 +
-+To call the the function using the initialized ffi_cif, use the
++To call the function using the initialized ffi_cif, use the
 +ffi_call function:
 +
 +void ffi_call(ffi_cif *cif, void *fn, void *rvalue, void **avalues);

--- a/plugins/python-build/share/python-build/patches/2.5.5/Python-2.5.5/004_osx_libffi.patch
+++ b/plugins/python-build/share/python-build/patches/2.5.5/Python-2.5.5/004_osx_libffi.patch
@@ -197,7 +197,7 @@ index 0000000..1fc2747
 +Before making the call, the VALUES vector should be initialized 
 +with pointers to the appropriate argument values.
 +
-+To call the the function using the initialized ffi_cif, use the
++To call the function using the initialized ffi_cif, use the
 +ffi_call function:
 +
 +void ffi_call(ffi_cif *cif, void *fn, void *rvalue, void **avalues);

--- a/plugins/python-build/share/python-build/patches/2.5.6/Python-2.5.6/004_osx_libffi.patch
+++ b/plugins/python-build/share/python-build/patches/2.5.6/Python-2.5.6/004_osx_libffi.patch
@@ -197,7 +197,7 @@ index 0000000..1fc2747
 +Before making the call, the VALUES vector should be initialized 
 +with pointers to the appropriate argument values.
 +
-+To call the the function using the initialized ffi_cif, use the
++To call the function using the initialized ffi_cif, use the
 +ffi_call function:
 +
 +void ffi_call(ffi_cif *cif, void *fn, void *rvalue, void **avalues);


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR
remove repetitive words 

### Tests
- [x] My PR adds the following unit tests (if any)
