### PR TITLE
Add GraalPy 24.0.0

### DIFF
--- a/plugins/python-build/share/python-build/graalpy-24.0.0
+++ b/plugins/python-build/share/python-build/graalpy-24.0.0
@@ -1,0 +1,64 @@
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+VERSION='24.0.0'
+BUILD=''
+
+colorize 1 "GraalPy 23.1 and later installed by python-build use the faster Oracle GraalVM distribution" && echo
+colorize 1 "Oracle GraalVM uses the GFTC license, which is free for development and production use, see https://medium.com/graalvm/161527df3d76" && echo
+colorize 1 "The GraalVM Community Edition variant of GraalPy is also available, under the name graalpy-community-${VERSION}" && echo
+
+
+graalpy_arch="$(graalpy_architecture 2>/dev/null || true)"
+
+case "$graalpy_arch" in
+"linux-amd64" )
+  checksum="f0d194dea76da26093b9b01b78c0fcabbd8714640b08fcd2a9b05b9ded3e2039"
+  ;;
+"linux-aarch64" )
+  checksum="5bf0fd9d115c3ecd6bfb89a2fac7b9ba9343841c3928d14eac471b9b1ad1266e"
+  ;;
+"macos-amd64" )
+  checksum="1e2e51ea618bd6f6fe9a0248486b5962f6258193249c0657dc0480fd2b92d772"
+  ;;
+"macos-aarch64" )
+  checksum="d5597711839a41506beb129f9d8015f8997a1db1e0c79972636834d955d4ef61"
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": No binary distribution of GraalPy is available for $(uname -sm)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac
+
+if [ -n "${BUILD}" ]; then
+  { echo
+    colorize 1 "ERROR"
+    echo "Oracle GraalPy currently doesn't provide snapshot builds. Use graalpy-community if you need snapshots."
+    echo
+  } >&2
+  exit 1
+fi
+
+url="https://github.com/oracle/graalpython/releases/download/graal-${VERSION}/graalpy-${VERSION}-${graalpy_arch}.tar.gz#${checksum}"
+
+install_package "graalpy-${VERSION}" "${url}" "copy" ensurepip

--- a/plugins/python-build/share/python-build/graalpy-community-24.0.0
+++ b/plugins/python-build/share/python-build/graalpy-community-24.0.0
@@ -1,0 +1,54 @@
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+VERSION='24.0.0'
+BUILD=''
+
+graalpy_arch="$(graalpy_architecture 2>/dev/null || true)"
+
+case "$graalpy_arch" in
+"linux-amd64" )
+  checksum="a77892d8d6b897b70b4226aa1b6abc8c41e824ae98d727429542b0157ae6f8d9"
+  ;;
+"linux-aarch64" )
+  checksum="201e2bad0ed59efc89654a77ae1634302111b3ffb9af53f9ee63ab43b735e5c3"
+  ;;
+"macos-amd64" )
+  checksum="7c816beb8c8b46ee0de60861f739c274efbc744304aa9034bffbd0319f13701d"
+  ;;
+"macos-aarch64" )
+  checksum="7f5540a28cf5c2c628cd003c3eb86bfa0a07175dae7d9b6528b40c44c4927402"
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": No binary distribution of GraalPy is available for $(uname -sm)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac
+
+if [ -n "${BUILD}" ]; then
+  url="https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/${VERSION}-dev-${BUILD}/graalpy-community-dev-${graalpy_arch}.tar.gz"
+else
+  url="https://github.com/oracle/graalpython/releases/download/graal-${VERSION}/graalpy-community-${VERSION}-${graalpy_arch}.tar.gz#${checksum}"
+fi
+
+install_package "graalpy-community-${VERSION}${BUILD}" "${url}" "copy" ensurepip


### PR DESCRIPTION
Update GraalPy to the newly released version 24.0.0: https://github.com/oracle/graalpython/releases/tag/graal-24.0.0

CC @timfel 