### PR TITLE
Add CPython 3.14-dev, update 3.13-dev

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2021,6 +2021,11 @@ build_package_verify_py313() {
   build_package_verify_py312 "$1" "${2:-3.13}"
 }
 
+# Post-install check for Python 3.14.x
+build_package_verify_py314() {
+  build_package_verify_py313 "$1" "${2:-3.13}"
+}
+
 # Post-install check for Python 3.x rolling release scripts
 # XXX: Will need splitting into project-specific ones if there emerge
 # multiple rolling-release scripts with different checks needed

--- a/plugins/python-build/share/python-build/3.13-dev
+++ b/plugins/python-build/share/python-build/3.13-dev
@@ -2,6 +2,6 @@ prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
 export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
-install_package "openssl-3.1.2" "https://www.openssl.org/source/openssl-3.1.2.tar.gz#a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.3.0" "https://www.openssl.org/source/openssl-3.3.0.tar.gz#53e66b043322a606abf0087e7699a0e033a37fa13feb9742df35c3a33b18fb02" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_git "Python-3.13-dev" "https://github.com/python/cpython" 3.13 standard verify_py313 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.13-dev
+++ b/plugins/python-build/share/python-build/3.13-dev
@@ -4,4 +4,4 @@ export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
 export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
 install_package "openssl-3.1.2" "https://www.openssl.org/source/openssl-3.1.2.tar.gz#a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_git "Python-3.13-dev" "https://github.com/python/cpython" main standard verify_py313 copy_python_gdb ensurepip
+install_git "Python-3.13-dev" "https://github.com/python/cpython" 3.13 standard verify_py313 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.14-dev
+++ b/plugins/python-build/share/python-build/3.14-dev
@@ -2,6 +2,6 @@ prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
 export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
-install_package "openssl-3.1.2" "https://www.openssl.org/source/openssl-3.1.2.tar.gz#a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.3.0" "https://www.openssl.org/source/openssl-3.3.0.tar.gz#53e66b043322a606abf0087e7699a0e033a37fa13feb9742df35c3a33b18fb02" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_git "Python-3.14-dev" "https://github.com/python/cpython" main standard verify_py314 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.14-dev
+++ b/plugins/python-build/share/python-build/3.14-dev
@@ -1,0 +1,7 @@
+prefer_openssl3
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
+export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
+install_package "openssl-3.1.2" "https://www.openssl.org/source/openssl-3.1.2.tar.gz#a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+install_git "Python-3.14-dev" "https://github.com/python/cpython" main standard verify_py314 copy_python_gdb ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
