### PR TITLE
WIP: Add version aliases

### DIFF
--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -123,6 +123,36 @@ DEFINITIONS=("${ARGUMENTS[@]}")
 [[ "${#DEFINITIONS[*]}" -eq 0 ]] && DEFINITIONS=($(pyenv-local 2>/dev/null || true))
 [[ "${#DEFINITIONS[*]}" -eq 0 ]] && usage 1 >&2
 
+is_array() {
+    # no argument passed
+    [[ $# -ne 1 ]] && echo 'Supply a variable name as an argument'>&2 && return 2
+    local var=$1
+    # use a variable to avoid having to escape spaces
+    local regex="^declare -[aA] ${var}(=|$)"
+    [[ $(declare -p "$var" 2> /dev/null) =~ $regex ]] && return 0
+}
+
+# If VERSION_ALIAS exists, create a 1-element array, VERSION_ALIASES, from VERSION_ALIAS
+if [ -n "${VERSION_ALIAS}" ]; then
+  # Make sure VERSION_ALIASES doesn't already exist
+  # If it does, print an error about defining only one of VERSION_ALIAS or VERSION_ALIASES
+  if is_array VERSION_ALIASES; then
+    echo "Define only one of VERSION_ALIAS or VERSION_ALIASES" >&2
+    exit 1
+  fi
+
+  VERSION_ALIASES=("${VERSION_ALIAS}")
+fi
+
+# If VERSION_ALIASES exists, make sure it has the same number of elements as DEFINITIONS
+
+if is_array VERSION_ALIASES; then
+  if [[ "${#VERSION_ALIASES[@]}" -ne "${#DEFINITIONS[@]}" ]]; then
+    echo "VERSION_ALIASES must have the same number of elements as DEFINITIONS" >&2
+    exit 1
+  fi
+fi
+
 # Define `before_install` and `after_install` functions that allow
 # plugin hooks to register a string of code for execution before or
 # after the installation process.
@@ -152,7 +182,12 @@ IFS="$OLDIFS"
 for script in "${scripts[@]}"; do source "$script"; done
 
 COMBINED_STATUS=0
-for DEFINITION in "${DEFINITIONS[@]}"; do
+for i in "${!DEFINITIONS[@]}"; do
+  DEFINITION="${DEFINITIONS[$i]}"
+  if is_array VERSION_ALIASES; then
+    VERSION_ALIAS="${VERSION_ALIASES[$i]}"
+  fi
+
   STATUS=0
 
   # Try to resolve a prefix if user indeed gave a prefix.
@@ -160,8 +195,9 @@ for DEFINITION in "${DEFINITIONS[@]}"; do
   # and hooks also see the resolved name
   DEFINITION="$(pyenv-latest -q -k "$DEFINITION" || echo "$DEFINITION")"
 
-  # Set VERSION_NAME from $DEFINITION. Then compute the installation prefix.
-  VERSION_NAME="${DEFINITION##*/}"
+  # Set VERSION_NAME from $VERSION_ALIAS if it is defined, else $DEFINITION. 
+  # Then compute the installation prefix.
+  VERSION_NAME="${VERSION_ALIAS:-$DEFINITION##*/}"
   [ -n "$DEBUG" ] && VERSION_NAME="${VERSION_NAME}-debug"
   PREFIX="${PYENV_ROOT}/versions/${VERSION_NAME}"
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
    * **This is a modification of an existing plugin (pyenv-build)**
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
    * **Not applicable; this modification happens in the pyenv-build plugin, which does not exist upstream**
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/218
 
### Description
- [x] Here are some details about my PR

An older plugin, pyenv-alias, allowed naming the desired python version with an alias, which allowed installing multiple versions of the same python version.  This is particularly useful on Apple silicon if you want to install both arm and x86_64 versions of python.

Unfortunately, this plugin broke when the code was modified to allow multiple versions to be specified at once on the command line, and the updated code does not allow non-invasive modification of the version number.


### Tests
- [x] My PR adds the following unit tests (if any)

    * None