### PR TITLE
Add script to install graalpy development builds

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -397,7 +397,7 @@ http_get_aria2c() {
   fi
 
   if aria2c --allow-overwrite=true --no-conf=true -d "${dir_out}" -o "${out}" ${ARIA2_OPTS} "$1" >&4; then
-    [ -n "$2" ] || cat "${out}"
+    [ -n "$2" ] || cat "${dir_out:-.}/${out}"
   else
     false
   fi

--- a/plugins/python-build/share/python-build/graalpy-dev
+++ b/plugins/python-build/share/python-build/graalpy-dev
@@ -1,0 +1,54 @@
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+JSON_URL=https://raw.githubusercontent.com/graalvm/graal-languages-ea-builds/main/graalpy/versions/latest-ea.json
+
+colorize 1 "GraalPy 23.1 and later installed by python-build use the faster Oracle GraalVM distribution" && echo
+colorize 1 "Oracle GraalVM uses the GFTC license, which is free for development and production use, see https://medium.com/graalvm/161527df3d76" && echo
+colorize 1 "Release builds of the GraalVM Community Edition variant of GraalPy are available, with names starting with graalpy-community-" && echo
+
+json=`http get "$JSON_URL"`
+version=`expr "$json" : '{.*"version":[^"]*"\([^"]*\)'`
+base_url=`expr "$json" : '{.*"download_base_url":[^"]*"\([^"]*\)'`
+
+graalpy_arch="$(graalpy_architecture 2>/dev/null || true)"
+
+case "$graalpy_arch" in
+"linux-amd64" )
+  ;;
+"linux-aarch64" )
+  ;;
+"macos-amd64" )
+  ;;
+"macos-aarch64" )
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": No binary distribution of GraalPy is available for $(uname -sm)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac
+
+url="${base_url}/graalpy-${version}-${graalpy_arch}.tar.gz"
+
+install_package "graalpy-${version}" "${url}" "copy" ensurepip


### PR DESCRIPTION
GraalPy now publishes regular early access builds at https://github.com/graalvm/graal-languages-ea-builds. It'd be nice to be able to easily install the latest one for users to try bugfixes that are not in a release, yet.