### PR TITLE
Add sed and greadlink to shim exceptions

### DIFF
--- a/pyenv.d/rehash/conda.d/default.list
+++ b/pyenv.d/rehash/conda.d/default.list
@@ -64,6 +64,8 @@ redis-check-aof
 redis-check-dump
 redis-cli
 redis-server
+# sed
+sed
 # sqlite3
 sqlite3
 # xslt-config
@@ -190,3 +192,4 @@ who
 whoami
 yes
 # --- end exclusions from coreutils
+greadlink


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2971

### Description
- [x] Here are some details about my PR

Anaconda has packages that override at least sed
Greadlink is also a critical executable if present

### Tests
- [x] My PR adds the following unit tests (if any)
N/A