### PR TITLE
Add CPython 3.13.0b2

### DIFF
--- a/plugins/python-build/share/python-build/3.13.0b1
+++ b/plugins/python-build/share/python-build/3.13.0b1
@@ -1,9 +1,0 @@
-prefer_openssl3
-export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-3.3.0" "https://www.openssl.org/source/openssl-3.3.0.tar.gz#53e66b043322a606abf0087e7699a0e033a37fa13feb9742df35c3a33b18fb02" mac_openssl --if has_broken_mac_openssl
-install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
-if has_tar_xz_support; then
-    install_package "Python-3.13.0b1" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0b1.tar.xz#ba716ac56b039b545ad4a90ce586a57aa97869364553746ef2445728ceec198e" standard verify_py313 copy_python_gdb ensurepip
-else
-    install_package "Python-3.13.0b1" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0b1.tgz#3ff81ce29574296976dc42edfed52d39faf7ae583721a428cfc537a70bbaae16" standard verify_py313 copy_python_gdb ensurepip
-fi

--- a/plugins/python-build/share/python-build/3.13.0b2
+++ b/plugins/python-build/share/python-build/3.13.0b2
@@ -1,0 +1,9 @@
+prefer_openssl3
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-3.3.1" "https://www.openssl.org/source/openssl-3.3.1.tar.gz#777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+    install_package "Python-3.13.0b2" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0b2.tar.xz#bf11be01b42a07a3659e4e233591e03da631b7112aa61ee1e030eeb8c5dfd869" standard verify_py313 copy_python_gdb ensurepip
+else
+    install_package "Python-3.13.0b2" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0b2.tgz#c87c42aa8137230a15a02ed90a6600610ba680cb5b54c0fbc57581a0d032e0c4" standard verify_py313 copy_python_gdb ensurepip
+fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
  
  **This is not a feature addition.**
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with 
rbenv.
  
  **This is not a fix.**
* [x] My PR addresses the following pyenv issue (if any):

  **N/A**

### Description
- [x] Here are some details about my PR:
  
  **Add latest 3.13 pre-release support (drop prior pre-release).**

### Tests
- [x] My PR adds the following unit tests (if any):

  **N/A**
