### PR TITLE
Add support for miniconda3 24.4.0-0 with py3.12, py3.11, py3.10, py3.9

### DIFF
--- a/plugins/python-build/share/python-build/miniconda3-3.10-24.4.0-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.10-24.4.0-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py310_24.4.0-0-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_24.4.0-0-Linux-aarch64.sh#68f3a537bf2ba8031961c8be6b52236c75478c797e0333e055539f02147676b8" "miniconda" verify_py310
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py310_24.4.0-0-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_24.4.0-0-Linux-s390x.sh#d5d06f9aa66d9cc9a23d6278826cb09f44f8e005b8b8fcf2664bef02e61ca751" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py310_24.4.0-0-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_24.4.0-0-Linux-x86_64.sh#fdaa5afdea8c07b6f2203b8f95abe0e4e8c4d3fd3c10d19fe590311446591ffa" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py310_24.4.0-0-MacOSX-arm64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_24.4.0-0-MacOSX-arm64.sh#21f0b7c653518a6eb6135593c509cefc78fdff839bb2e887d36bc03eda607faf" "miniconda" verify_py310
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py310_24.4.0-0-MacOSX-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py310_24.4.0-0-MacOSX-x86_64.sh#c2eed72ff97b4eb81bc1171616b0ff48a440a2e1ad5638e1899b80286767c568" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.11-24.4.0-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.11-24.4.0-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py311_24.4.0-0-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_24.4.0-0-Linux-aarch64.sh#d3ed9ff565c7341a4e4c957443ccb4f12f3dd5a087549099e7f199c36469e55c" "miniconda" verify_py311
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py311_24.4.0-0-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_24.4.0-0-Linux-s390x.sh#f2bea598cb72ed838a6e62b7dd8fbf1c3941a92783ba686822f70108c8c2e543" "miniconda" verify_py311
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py311_24.4.0-0-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_24.4.0-0-Linux-x86_64.sh#7cb030a12d1da35e1c548344a895b108e0d2fbdc4f6b67d5180b2ac8539cc473" "miniconda" verify_py311
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py311_24.4.0-0-MacOSX-arm64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_24.4.0-0-MacOSX-arm64.sh#a396cf4ca0088cf2d78517b28732b61697cdcb698528300946ef6409353eca86" "miniconda" verify_py311
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py311_24.4.0-0-MacOSX-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py311_24.4.0-0-MacOSX-x86_64.sh#b7f3adebd2b25dbefdc85e16f5ee130ac0d1167f416078f961e90f277476b115" "miniconda" verify_py311
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.12-24.4.0-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.12-24.4.0-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py312_24.4.0-0-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.4.0-0-Linux-aarch64.sh#832d48e11e444c1a25f320fccdd0f0fabefec63c1cd801e606836e1c9c76ad51" "miniconda" verify_py312
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py312_24.4.0-0-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.4.0-0-Linux-s390x.sh#e973f1b6352d58b1ab35f30424f1565d7ffa469dcde2d52c86ec1c117db11aad" "miniconda" verify_py312
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py312_24.4.0-0-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.4.0-0-Linux-x86_64.sh#b6597785e6b071f1ca69cf7be6d0161015b96340b9a9e132215d5713408c3a7c" "miniconda" verify_py312
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py312_24.4.0-0-MacOSX-arm64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.4.0-0-MacOSX-arm64.sh#f4925c0150d232d95de798a64c696f4b2df2745bb997b793506bdfd27bf91e11" "miniconda" verify_py312
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py312_24.4.0-0-MacOSX-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.4.0-0-MacOSX-x86_64.sh#1413369470adb7cf52f8b961e81b3ceeb92f5931a451bef9cb0c42be0ce17ef3" "miniconda" verify_py312
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.9-24.4.0-0
+++ b/plugins/python-build/share/python-build/miniconda3-3.9-24.4.0-0
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py39_24.4.0-0-Linux-aarch64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_24.4.0-0-Linux-aarch64.sh#6f09fd08165a9fdccb2a2c64e9bbcf68ce58a9bfb571600306eb44d29718b13f" "miniconda" verify_py39
+  ;;
+"Linux-s390x" )
+  install_script "Miniconda3-py39_24.4.0-0-Linux-s390x.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_24.4.0-0-Linux-s390x.sh#8766e30b038087e7da2bb9a8bca4ca3f2ed621659f0ea8954ffab789f4a8f192" "miniconda" verify_py39
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py39_24.4.0-0-Linux-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_24.4.0-0-Linux-x86_64.sh#edd7610f2e2b25d15f6ffa81ca94de0748dd107096871459a7966dcf9a564ea9" "miniconda" verify_py39
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py39_24.4.0-0-MacOSX-arm64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_24.4.0-0-MacOSX-arm64.sh#74f3de552d93712cc7c531f690b78d6acad8e3812da43fc3a1acbc5c39243480" "miniconda" verify_py39
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-py39_24.4.0-0-MacOSX-x86_64.sh" "https://repo.anaconda.com/miniconda/Miniconda3-py39_24.4.0-0-MacOSX-x86_64.sh#d3ad5e0bf74aa1cb838df2f73e4be4e5d9a0f259a05b5223199ea1f6f6edf9f3" "miniconda" verify_py39
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
