### PR TITLE
Use `"` quotes for `$PYENV_ROOT` in `[[ -d ]]` check

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -165,7 +165,7 @@ function help_() {
       fi
       echo
       echo 'export PYENV_ROOT="$HOME/.pyenv"'
-      echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
+      echo '[[ -d "$PYENV_ROOT/bin" ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
       echo 'eval "$(pyenv init -)"'
       ;;
     esac


### PR DESCRIPTION

I don't think any of the checks really apply here, this is a simple typo-like change.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description

If a user sets `$PYENV_ROOT` to a path with ` ` (space) inside, the variable expansion might be not correct.

It is better to use explicit quoting.

### Tests

None.
