### PR TITLE
Add support for free-threaded Python

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -822,6 +822,7 @@ build_package_standard_build() {
       use_homebrew_zlib || true
     fi
     use_dsymutil || true
+    use_free_threading || true
   fi
 
   ( if [ "${CFLAGS+defined}" ] || [ "${!PACKAGE_CFLAGS+defined}" ]; then
@@ -1758,6 +1759,12 @@ use_tcltk() {
 use_dsymutil() {
   if [[ -n "$PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL" ]] && is_mac; then
     package_option python configure --with-dsymutil
+  fi
+}
+
+use_free_threading() {
+  if [[ -n "$PYTHON_BUILD_FREE_THREADING" ]]; then
+    package_option python configure --disable-gil
   fi
 }
 

--- a/plugins/python-build/share/python-build/3.13t-dev
+++ b/plugins/python-build/share/python-build/3.13t-dev
@@ -1,0 +1,8 @@
+prefer_openssl3
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
+export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
+export PYTHON_BUILD_FREE_THREADING=1
+install_package "openssl-3.3.0" "https://www.openssl.org/source/openssl-3.3.0.tar.gz#53e66b043322a606abf0087e7699a0e033a37fa13feb9742df35c3a33b18fb02" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+install_git "Python-3.13-dev" "https://github.com/python/cpython" 3.13 standard verify_py313 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.14t-dev
+++ b/plugins/python-build/share/python-build/3.14t-dev
@@ -1,0 +1,8 @@
+prefer_openssl3
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
+export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
+export PYTHON_BUILD_FREE_THREADING=1
+install_package "openssl-3.3.0" "https://www.openssl.org/source/openssl-3.3.0.tar.gz#53e66b043322a606abf0087e7699a0e033a37fa13feb9742df35c3a33b18fb02" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+install_git "Python-3.14-dev" "https://github.com/python/cpython" main standard verify_py314 copy_python_gdb ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2984

### Description
- [x] Here are some details about my PR

This adds support for free-threaded CPython (GIL disabled) with the "t" suffix. The naming is similar to what's used by [cibuildwheel](https://cibuildwheel.pypa.io/en/stable/options/#free-threaded-support) and the official macOS and Windows installers, which use, e.g. python3.13t.

For now, I've only added 3.13t-dev and 3.14t-dev. Once 3.13.0b3 is released, we can add that too. (I don't think we want to for 3.13.0b2 because pip didn't work right out of the box.)

### Tests
- [x] My PR adds the following unit tests (if any) 
N/A