### PR TITLE
Add 3.13.0b3t and exclude it from `pyenv latest`

### DIFF
--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -50,7 +50,7 @@ IFS=$'\n'
 
     DEFINITION_CANDIDATES=(\
         $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
-          sed -E -e '/-dev$/d' -e '/-src$/d' -e '/-latest$/d' -e '/(a|b|rc)[0-9]+$/d' -e '/t$/d'));
+          sed -E -e '/-dev$/d' -e '/-src$/d' -e '/-latest$/d' -e '/(a|b|rc)[0-9]+$/d' -e '/[0-9]+t$/d'));
 
     # Compose a sorting key, followed by | and original value
     DEFINITION_CANDIDATES=(\

--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -50,7 +50,7 @@ IFS=$'\n'
 
     DEFINITION_CANDIDATES=(\
         $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
-          sed -E -e '/-dev$/d' -e '/-src$/d' -e '/-latest$/d' -e '/(a|b|rc)[0-9]+$/d'));
+          sed -E -e '/-dev$/d' -e '/-src$/d' -e '/-latest$/d' -e '/(a|b|rc)[0-9]+$/d' -e '/t$/d'));
 
     # Compose a sorting key, followed by | and original value
     DEFINITION_CANDIDATES=(\

--- a/plugins/python-build/share/python-build/3.13.0b3t
+++ b/plugins/python-build/share/python-build/3.13.0b3t
@@ -1,0 +1,2 @@
+export PYTHON_BUILD_FREE_THREADING=1
+source "$(dirname "${BASH_SOURCE[0]}")"/3.13.0b3

--- a/pyenv.d/install/latest.bash
+++ b/pyenv.d/install/latest.bash
@@ -10,7 +10,7 @@ pyenv_install_resolve_latest() {
       $(python-build --definitions | \
         grep -F "${DEFINITION_PREFIX}" | \
         grep "^${DEFINITION_TYPE}" | \
-        sed -E -e '/-dev$/d' -e '/-src$/d' -e '/(b|rc)[0-9]+$/d' -e '/t$/d' | \
+        sed -E -e '/-dev$/d' -e '/-src$/d' -e '/(b|rc)[0-9]+$/d' -e '/[0-9]+t$/d' | \
         sort -t. -k1,1r -k 2,2nr -k 3,3nr \
       || true))
     DEFINITION="${DEFINITION_CANDIDATES}"

--- a/pyenv.d/install/latest.bash
+++ b/pyenv.d/install/latest.bash
@@ -10,7 +10,7 @@ pyenv_install_resolve_latest() {
       $(python-build --definitions | \
         grep -F "${DEFINITION_PREFIX}" | \
         grep "^${DEFINITION_TYPE}" | \
-        sed -E -e '/-dev$/d' -e '/-src$/d' -e '/(b|rc)[0-9]+$/d' | \
+        sed -E -e '/-dev$/d' -e '/-src$/d' -e '/(b|rc)[0-9]+$/d' -e '/t$/d' | \
         sort -t. -k1,1r -k 2,2nr -k 3,3nr \
       || true))
     DEFINITION="${DEFINITION_CANDIDATES}"

--- a/test/latest.bats
+++ b/test/latest.bats
@@ -103,6 +103,9 @@ echo 3.8.5-latest
 echo 3.8.5a2
 echo 3.8.5b3
 echo 3.8.5rc2
+echo 3.8.5t
+echo 3.8.5b3t
+echo 3.8.5rc2t
 echo 3.8.1
 echo 3.8.1/envs/foo
 !


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] This adds the free-threaded (without GIL) version of 3.13.0b3.

### Tests
- [x] My PR adds the following unit tests (if any) - N/A