### PR TITLE
Speed up `pyenv prefix` by not constructing advice text when it would be discarded

### DIFF
--- a/libexec/pyenv-prefix
+++ b/libexec/pyenv-prefix
@@ -30,9 +30,9 @@ OLDIFS="$IFS"
 { IFS=:
   for version in ${PYENV_VERSION}; do
     if [ "$version" = "system" ]; then
-      if PYTHON_PATH="$(PYENV_VERSION="${version}" pyenv-which python 2>/dev/null)" || \
-          PYTHON_PATH="$(PYENV_VERSION="${version}" pyenv-which python3 2>/dev/null)" || \
-          PYTHON_PATH="$(PYENV_VERSION="${version}" pyenv-which python2 2>/dev/null)"; then
+      if PYTHON_PATH="$(PYENV_VERSION="${version}" pyenv-which python --skip-advice 2>/dev/null)" || \
+          PYTHON_PATH="$(PYENV_VERSION="${version}" pyenv-which python3 --skip-advice 2>/dev/null)" || \
+          PYTHON_PATH="$(PYENV_VERSION="${version}" pyenv-which python2 --skip-advice 2>/dev/null)"; then
         shopt -s extglob
         # In some distros (Arch), Python can be found in sbin as well as bin
         PYENV_PREFIX_PATH="${PYTHON_PATH%/?(s)bin/*}"

--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -128,9 +128,9 @@ print_version() {
 
 # Include "system" in the non-bare output, if it exists
 if [ -n "$include_system" ] && \
-    (PYENV_VERSION=system pyenv-which python >/dev/null 2>&1 || \
-     PYENV_VERSION=system pyenv-which python3 >/dev/null 2>&1 || \
-     PYENV_VERSION=system pyenv-which python2 >/dev/null 2>&1) ; then
+    (PYENV_VERSION=system pyenv-which python --skip-advice >/dev/null 2>&1 || \
+     PYENV_VERSION=system pyenv-which python3 --skip-advice >/dev/null 2>&1 || \
+     PYENV_VERSION=system pyenv-which python2 --skip-advice >/dev/null 2>&1) ; then
   print_version system "/"
 fi
 

--- a/libexec/pyenv-which
+++ b/libexec/pyenv-which
@@ -2,13 +2,14 @@
 #
 # Summary: Display the full path to an executable
 #
-# Usage: pyenv which <command> [--nosystem]
+# Usage: pyenv which <command> [--nosystem] [--skip-advice]
 #
 # Displays the full path to the executable that pyenv will invoke when
 # you run the given command.
 # Use --nosystem argument in case when you don't need to search command in the 
 # system environment.
-#
+# Internal switch --skip-advice used to skip printing an error message on a
+# failed search.
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
@@ -18,11 +19,27 @@ if [ "$1" = "--complete" ]; then
   exec pyenv-shims --short
 fi
 
-if [ "$2" = "--nosystem" ]; then
-  system=""
-else
-  system="system"
-fi
+system="system"
+SKIP_ADVICE=""
+PYENV_COMMAND="$1"
+
+while [[ $# -gt 0 ]]
+do
+  case "$1" in
+    --skip-advice)
+      SKIP_ADVICE=1
+      shift
+      ;;
+    --nosystem)
+      system=""
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
 
 remove_from_path() {
   local path_to_remove="$1"
@@ -35,8 +52,6 @@ remove_from_path() {
   result="${result%:}"
   echo "${result#:}"
 }
-
-PYENV_COMMAND="$1"
 
 if [ -z "$PYENV_COMMAND" ]; then
   pyenv-help --usage which >&2
@@ -85,16 +100,17 @@ else
   fi
 
   echo "pyenv: $PYENV_COMMAND: command not found" >&2
-
-  versions="$(pyenv-whence "$PYENV_COMMAND" || true)"
-  if [ -n "$versions" ]; then
-    { echo
-      echo "The \`$1' command exists in these Python versions:"
-      echo "$versions" | sed 's/^/  /g'
-      echo
-      echo "Note: See 'pyenv help global' for tips on allowing both"
-      echo "      python2 and python3 to be found."
-    } >&2
+  if [ -z "$SKIP_ADVICE" ]; then
+    versions="$(pyenv-whence "$PYENV_COMMAND" || true)"
+    if [ -n "$versions" ]; then
+      { echo
+        echo "The \`$PYENV_COMMAND' command exists in these Python versions:"
+        echo "$versions" | sed 's/^/  /g'
+        echo
+        echo "Note: See 'pyenv help global' for tips on allowing both"
+        echo "      python2 and python3 to be found."
+      } >&2
+    fi
   fi
 
   exit 127

--- a/test/which.bats
+++ b/test/which.bats
@@ -155,3 +155,15 @@ exit
   PYENV_VERSION=3.4 run pyenv-which python
   assert_success "version=3.4.2"
 }
+
+@test "skip advice supresses error messages" {
+  create_executable "2.7" "python"
+  create_executable "3.3" "py.test"
+  create_executable "3.4" "py.test"
+
+  PYENV_VERSION=2.7 run pyenv-which py.test --skip-advice
+  assert_failure
+  assert_output <<OUT
+pyenv: py.test: command not found
+OUT
+}


### PR DESCRIPTION

### Prerequisite
I don't believe this makes sense as a hook

I don't believe this makes sense to submit to rbenv, I don't see corresponding issues there. 

Closes https://github.com/pyenv/pyenv/issues/3004

### Description

This speeds up the call of `pyenv prefix` by skipping the construction of an error message that is ultimately discarded by being piped to `/dev/null`. The construction of the error message is slow when there are many (in my case 20) different Python environments. Notably, the slowness seems to only happen on the first call, but this patch eliminates it completely. 

The mechanism I used is a sneaky "_"-prefixed environment variable, which works, but I'm not sure if it is the best way to accomplish the task. However, it seemed simpler to do it this way than adding more CLI parsing, and this only needs to be handled when called by other internal code anyway.

I'm not sure if it is possible to detect if stderr for a script is being piped to /dev/null, but if there is a quick way to check for that, then that would probably make even more sense than my existing implementation, and it wouldn't require ugly local environs that I added to `pyenv-prefix`.

### Tests

I don't think this requires a test.
