### PR TITLE
Fix debug build for X.Yt-dev

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -19,6 +19,7 @@ PYTHON_BUILD_VERSION="20180424"
 OLDIFS="$IFS"
 
 set -E
+shopt -s extglob
 [ -n "$PYENV_DEBUG" ] && {
   export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
   set -x
@@ -1784,20 +1785,14 @@ build_package_auto_tcltk() {
   fi
 }
 
-# extglob must be set at both parse time and runtime
-# https://stackoverflow.com/questions/49283740/bash-script-throws-syntax-errors-when-the-extglob-option-is-set-inside-a-subsh
-shopt -s extglob
 package_is_python() {
-  shopt -s extglob
   case "$1" in
     Python-* | jython-* | pypy-* | pypy[0-9].+([0-9])-* | stackless-* )
       return 0
       ;;
   esac
   return 1
-  shopt -u extglob
 }
-shopt -u extglob
 
 apply_patch() {
   local package_name="$1"
@@ -2308,7 +2303,6 @@ if [[ "$PYPY_OPTS" == *"--shared"* ]]; then
 fi
 
 # Add support for framework installation (`--enable-framework`) of CPython (#55, #99)
-shopt -s extglob
 if [[ "$CONFIGURE_OPTS $PYTHON_CONFIGURE_OPTS" == *"--enable-framework"* ]]; then
   if ! is_mac; then
     echo "python-build: framework installation is not supported outside of MacOS." >&2
@@ -2334,10 +2328,8 @@ if [[ "$CONFIGURE_OPTS $PYTHON_CONFIGURE_OPTS" == *"--enable-framework"* ]]; the
   PYTHON_CONFIGURE_OPTS="${PYTHON_CONFIGURE_OPTS//--enable-framework?(=*([^ ]))?( )/}";
   PYTHON_CONFIGURE_OPTS="${PYTHON_CONFIGURE_OPTS% }"
 fi
-shopt -u extglob
 
 # Build against universal SDK
-shopt -s extglob
 if [[ "$CONFIGURE_OPTS $PYTHON_CONFIGURE_OPTS" == *"--enable-universalsdk"* ]]; then
   if ! is_mac; then
     echo "python-build: universal installation is not supported outside of MacOS." >&2
@@ -2359,7 +2351,6 @@ if [[ "$CONFIGURE_OPTS $PYTHON_CONFIGURE_OPTS" == *"--enable-universalsdk"* ]]; 
     fi
   fi
 fi
-shopt -u extglob
 
 # Compile with `--enable-unicode=ucs4` by default (#257)
 if [[ "$PYTHON_CONFIGURE_OPTS" != *"--enable-unicode="* ]]; then
@@ -2454,6 +2445,7 @@ python_bin_suffix() {
     version_name="${version_name%-dev}"
     version_name="${version_name%-rc*}"
     version_name="${version_name%rc*}"
+    version_name="${version_name%%*([^0-9])}"
     version_info=(${version_name//./ })
     echo "${version_info[0]}.${version_info[1]}"
     ;;


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3010

### Description
- [x] Here are some details about my PR

There's a routine that infers resulting executable name "`pythonX.Y`" from version name for a check.
It wasn't handling "X.Yt-dev" properly, which only manifested itself for a debug build.

### Tests
- [x] My PR adds the following unit tests (if any)
N/A