### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,12 +367,6 @@ See [Advanced configuration](#advanced-configuration) for details and more confi
 
    **Proxy note**: If you use a proxy, export `http_proxy` and `https_proxy`, too.
 
-   In MacOS, you might also want to install [Fig](https://fig.io/) which
-provides alternative shell completions for many command line tools with an
-IDE-like popup interface in the terminal window.
-(Note that their completions are independent from Pyenv's codebase
-so they might be slightly out of sync for bleeding-edge interface changes.)
-
 ### Restart your shell
 
   for the `PATH` changes to take effect.


### PR DESCRIPTION
> Effective September 1, 2024 we will be ending access to Fig.

### Description
- Removed reference to [Fig](https://fig.io) as this has been sunlit for new users, with access being removed in September. Their recommendation is to switch to [Amazon Q for command line](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-getting-started-installing.html).


