### PR TITLE
Fix pyenv-uninstall not having the debug tracing invocation

### DIFF
--- a/plugins/python-build/bin/pyenv-uninstall
+++ b/plugins/python-build/bin/pyenv-uninstall
@@ -11,6 +11,7 @@
 # See `pyenv versions` for a complete list of installed versions.
 #
 set -e
+[ -n "$PYENV_DEBUG" ] && set -x
 
 # Provide pyenv completions
 if [ "$1" = "--complete" ]; then


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Addresses https://github.com/pyenv/pyenv/issues/3017

### Description
- [x] Here are some details about my PR
https://github.com/pyenv/pyenv/issues/3017#issuecomment-2227098018

### Tests
- [x] My PR adds the following unit tests (if any)
N/A