### PR TITLE
pyenv-latest: replace -q with -b and -f, document as internal

### DIFF
--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # Summary: Print the latest installed or known version with the given prefix
-# Usage: pyenv latest [-k|--known] [-q|--quiet] <prefix>
+# Usage: pyenv latest [-k|--known] <prefix>
 #
 #   -k/--known      Select from all known versions instead of installed
-#   -q/--quiet      Do not print an error message on resolution failure
+#   -b/--bypass     (internal) On a resolution failure, do not print an error message
+#                   but rather print the argument unchanged
+#   -f/--force      (internal) Same as -b but also do not return a failure exit code
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
@@ -15,8 +17,13 @@ do
             FROM_KNOWN=1
             shift
             ;;
-        -q|--quiet)
-            QUIET=1
+        -b|--bypass)
+            BYPASS=1
+            shift
+            ;;
+        -f|--force)
+            FORCE=1
+            BYPASS=1
             shift
             ;;
         *)
@@ -71,10 +78,14 @@ IFS=$'\n'
     if [[ -n "$DEFINITION" ]]; then
         echo "$DEFINITION"
     else
-        if [[ -z $QUIET ]]; then
+        if [[ -z $BYPASS ]]; then
             echo "pyenv: no $([[ -z $FROM_KNOWN ]] && echo installed || echo known) versions match the prefix \`$prefix'" >&2
+        else
+            echo "$prefix"
         fi
-        exitcode=1
+        if [[ -z $FORCE ]]; then
+            exitcode=1
+        fi
     fi
 
 exit $exitcode

--- a/libexec/pyenv-prefix
+++ b/libexec/pyenv-prefix
@@ -42,7 +42,7 @@ OLDIFS="$IFS"
         exit 1
       fi
     else
-      version="$(pyenv-latest -q "$version" || echo "$version")"
+      version="$(pyenv-latest -f "$version")"
       PYENV_PREFIX_PATH="${PYENV_ROOT}/versions/${version}"
     fi
     if [ -d "$PYENV_PREFIX_PATH" ]; then

--- a/libexec/pyenv-version-name
+++ b/libexec/pyenv-version-name
@@ -34,7 +34,7 @@ OLDIFS="$IFS"
       versions=("${versions[@]}" "${version}")
     elif version_exists "${version#python-}"; then
       versions=("${versions[@]}" "${version#python-}")
-    elif resolved_version="$(pyenv-latest -q "$version")"; then
+    elif resolved_version="$(pyenv-latest -b "$version")"; then
       versions=("${versions[@]}" "${resolved_version}")
     else
       echo "pyenv: version \`$version' is not installed (set by $(pyenv-version-origin))" >&2

--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -158,7 +158,7 @@ for DEFINITION in "${DEFINITIONS[@]}"; do
   # Try to resolve a prefix if user indeed gave a prefix.
   # We install the version under the resolved name
   # and hooks also see the resolved name
-  DEFINITION="$(pyenv-latest -q -k "$DEFINITION" || echo "$DEFINITION")"
+  DEFINITION="$(pyenv-latest -f -k "$DEFINITION")"
 
   # Set VERSION_NAME from $DEFINITION. Then compute the installation prefix.
   VERSION_NAME="${DEFINITION##*/}"

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -888,54 +888,6 @@ OUT
   assert_success "hello world"
 }
 
-@test "mruby strategy overwrites non-writable files" {
-  # nop
-}
-
-@test "mruby strategy fetches rake if missing" {
-  # nop
-}
-
-@test "rbx uses bundle then rake" {
-  # nop
-}
-
-@test "fixes rbx binstubs" {
-  # nop
-}
-
-@test "JRuby build" {
-  # nop
-}
-
-@test "JRuby+Graal does not install launchers" {
-  # nop
-}
-
-@test "JRuby Java 7 missing" {
-  # nop
-}
-
-@test "JRuby Java is outdated" {
-  # nop
-}
-
-@test "JRuby Java 7 up-to-date" {
-  # nop
-}
-
-@test "Java version string not on first line" {
-  # nop
-}
-
-@test "Java version string on OpenJDK" {
-  # nop
-}
-
-@test "JRuby Java 9 version string" {
-  # nop
-}
-
 @test "non-writable TMPDIR aborts build" {
   export TMPDIR="${TMP}/build"
   mkdir -p "$TMPDIR"

--- a/plugins/python-build/test/hooks.bats
+++ b/plugins/python-build/test/hooks.bats
@@ -15,9 +15,10 @@ after_install 'echo after: \$STATUS'
 OUT
   stub pyenv-hooks "install : echo '$HOOK_PATH'/install.bash"
   stub pyenv-rehash "echo rehashed"
-  stub pyenv-latest false
 
   definition="${TMP}/3.6.2"
+  stub pyenv-latest "echo $definition"
+
   cat > "$definition" <<<"echo python-build"
   run pyenv-install "$definition"
 

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -18,7 +18,7 @@ stub_python_build_no_latest() {
   
 stub_python_build() {
   stub_python_build_no_latest "$@"
-  stub pyenv-latest false
+  stub pyenv-latest '-f -k * : shift 2; echo "$@"'
 }
 
 @test "install a single version" {
@@ -65,9 +65,9 @@ OUT
   stub_python_build_lib
   for i in {1..3}; do stub_python_build_no_latest; done
   stub pyenv-latest \
-      '-q -k 3.4 : echo 3.4.2' \
-      '-q -k 3.5.1 : false' \
-      '-q -k 3.5 : echo 3.5.2'
+      '-r -k 3.4 : echo 3.4.2' \
+      '-r -k 3.5.1 : false' \
+      '-r -k 3.5 : echo 3.5.2'
 
   run pyenv-install 3.4 3.5.1 3.5
   assert_success <<OUT

--- a/test/latest.bats
+++ b/test/latest.bats
@@ -115,3 +115,25 @@ echo 3.8.1/envs/foo
 3.8.1
 !
 }
+
+@test "falls back to argument with -b" {
+  create_executable pyenv-versions <<!
+#!$BASH
+!
+  run pyenv-latest -b nonexistent
+  assert_failure
+  assert_output <<!
+nonexistent
+!
+}
+
+@test "falls back to argument and succeeds with -f" {
+  create_executable pyenv-versions <<!
+#!$BASH
+!
+  run pyenv-latest -f nonexistent
+  assert_success
+  assert_output <<!
+nonexistent
+!
+}


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Addresses https://github.com/pyenv/pyenv/pull/3005#issuecomment-2207625549 cc @Erotemic 
  - Closes https://github.com/pyenv/pyenv/pull/3012

### Description
- [x] Here are some details about my PR
More tailored for the emergent internal use cases

### Tests
- [x] My PR adds the following unit tests (if any)
For the new options