### PR TITLE
Fix tests failing if plugins are installed

### DIFF
--- a/test/pyenv.bats
+++ b/test/pyenv.bats
@@ -46,12 +46,7 @@ load test_helper
   assert_output "pyenv: cannot change working directory to \`$dir'"
 }
 
-@test "adds its own libexec to PATH" {
-  run pyenv echo "PATH"
-  assert_success "${BATS_TEST_DIRNAME%/*}/libexec:${BATS_TEST_DIRNAME%/*}/plugins/python-build/bin:$PATH"
-}
-
-@test "adds plugin bin dirs to PATH" {
+@test "adds its own libexec and plugin bin dirs to PATH" {
   mkdir -p "$PYENV_ROOT"/plugins/python-build/bin
   mkdir -p "$PYENV_ROOT"/plugins/pyenv-each/bin
   run pyenv echo -F: "PATH"


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

Drop the failing test in favor of a better-written test that also tests the same



### Tests
- [x] My PR adds the following unit tests (if any)
N/A