### PR TITLE
Add /usr/etc/pyenv.d to hooks path

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -94,7 +94,7 @@ if [ "${bin_path%/*}" != "$PYENV_ROOT" ]; then
   # Add pyenv's own `pyenv.d` unless pyenv was cloned to PYENV_ROOT
   PYENV_HOOK_PATH="${PYENV_HOOK_PATH}:${bin_path%/*}/pyenv.d"
 fi
-PYENV_HOOK_PATH="${PYENV_HOOK_PATH}:/usr/local/etc/pyenv.d:/etc/pyenv.d:/usr/lib/pyenv/hooks"
+PYENV_HOOK_PATH="${PYENV_HOOK_PATH}:/usr/etc/pyenv.d:/usr/local/etc/pyenv.d:/etc/pyenv.d:/usr/lib/pyenv/hooks"
 for plugin_hook in "${PYENV_ROOT}/plugins/"*/etc/pyenv.d; do
   PYENV_HOOK_PATH="${PYENV_HOOK_PATH}:${plugin_hook}"
 done

--- a/test/pyenv.bats
+++ b/test/pyenv.bats
@@ -68,5 +68,5 @@ load test_helper
 @test "PYENV_HOOK_PATH includes pyenv built-in plugins" {
   unset PYENV_HOOK_PATH
   run pyenv echo "PYENV_HOOK_PATH"
-  assert_success "${PYENV_ROOT}/pyenv.d:${BATS_TEST_DIRNAME%/*}/pyenv.d:/usr/local/etc/pyenv.d:/etc/pyenv.d:/usr/lib/pyenv/hooks"
+  assert_success "${PYENV_ROOT}/pyenv.d:${BATS_TEST_DIRNAME%/*}/pyenv.d:/usr/etc/pyenv.d:/usr/local/etc/pyenv.d:/etc/pyenv.d:/usr/lib/pyenv/hooks"
 }


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3036

I'm not sure about the first items in the above lists. Are they applicable to this issue? :thinking: 

### Description
The directory `/usr/etc` is an optional directory and used by Fedora, RHEL 9, and openSUSE. The purpose of `/usr/etc` is to store distribution-provided configuration files that can be overridden by user-modified files in /etc.

`/usr/etc` is not in FHS. However, as Torsten stated in [his comment](https://github.com/thkukuk/atomic-updates_and_etc/issues/2#issuecomment-524848666) "[FHS] is currently nearly as dead as LSB, we can only ignore it if we don't want to stop and kill all innovation."

### Tests
- [x] My PR adds the following unit tests (if any): 
   Modified `test/pyenv.bats`