### PR TITLE
Add PyPy v7.3.17.

### DIFF
--- a/plugins/python-build/share/python-build/pypy2.7-7.3.17
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.17
@@ -1,0 +1,77 @@
+VERSION='7.3.17'
+PYVER='2.7'
+
+# https://www.pypy.org/checksums.html
+aarch64_hash=a8df5ce1650f4756933f8780870c91a0a40e7c9870d74629bf241392bcb5c2e3
+linux32_hash=a3aa0867cc837a34941047ece0fbb6ca190410fae6ad35fae4999d03bf178750
+linux64_hash=9f3497f87b3372d17e447369e0016a4bec99a6b4d2a59aba774a25bfe4353474
+osarm64_hash=8573172db377ee0831bf20492cdee9bac4e0b194e3dfe8bf7c44ee257a824766
+osx64_hash=e3e1af1d6ad15e51d8d19ea36e1ac65c4c792314cc8b8dc5cf771ec4353b50f8
+
+### end of manual settings - following lines same for every download
+
+function err_no_binary {
+    local archmsg="${1}"
+    local ver="pypy${PYVER}-v${VERSION}-src"
+    local url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for ${archmsg}."
+      echo "try '${url}' to build from source."
+      echo
+    } >&2
+    exit 1
+}
+
+function pypy_pkg_data {
+    # pypy architecture tag
+    local ARCH="${1}"
+
+    # defaults
+    local cmd='install_package'  # use bz2
+    local pkg="${ARCH}" # assume matches
+    local ext='tar.bz2'
+    local hash='' # undefined
+
+    # select the hash, fix pkg if not match ARCH
+    case "${ARCH}" in
+    'linux-aarch64' )
+      hash="${aarch64_hash}"
+      pkg='aarch64'
+      ;;
+    'linux' )
+      hash="${linux32_hash}"
+      pkg='linux32'
+      ;;
+    'linux64' )
+      hash="${linux64_hash}"
+      ;;
+    'osarm64' )
+      hash="${osarm64_hash}"
+      pkg='macos_arm64'
+      ;;
+    'osx64' )
+      if require_osx_version "10.13"; then
+        hash="${osx64_hash}"
+        pkg='macos_x86_64'
+      else
+        err_no_binary "${ARCH}, OS X < 10.13"
+      fi
+      ;;
+    * )
+      err_no_binary "${ARCH}"
+      ;;
+    esac
+
+    local basever="pypy${PYVER}-v${VERSION}"
+    local baseurl="https://downloads.python.org/pypy/${basever}"
+
+    # result - command, package dir, url+hash
+    echo "${cmd}" "${basever}-${pkg}" "${baseurl}-${pkg}.${ext}#${hash}"
+}
+
+# determine command, package directory, url+hash
+declare -a pd="$(pypy_pkg_data "$(pypy_architecture 2>/dev/null || true)")"
+
+# install
+${pd[0]} "${pd[1]}" "${pd[2]}" 'pypy' "verify_py${PYVER//./}" 'ensurepip_lt21'

--- a/plugins/python-build/share/python-build/pypy2.7-7.3.17-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.17-src
@@ -1,0 +1,14 @@
+VERSION='7.3.17'
+PYVER='2.7'
+
+# https://www.pypy.org/checksums.html
+hash=50e06840f4bbde91448080a4118068a89b8fbcae25ff8da1e2bb1402dc9a0346
+
+### end of manual settings - following lines same for every download
+
+ver="pypy${PYVER}-v${VERSION}-src"
+url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+
+prefer_openssl11
+install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
+install_package "${ver}" "${url}#${hash}" 'pypy_builder' "verify_py${PYVER//./}" 'ensurepip_lt21'

--- a/plugins/python-build/share/python-build/pypy3.10-7.3.17
+++ b/plugins/python-build/share/python-build/pypy3.10-7.3.17
@@ -1,0 +1,77 @@
+VERSION='7.3.17'
+PYVER='3.10'
+
+# https://www.pypy.org/checksums.html
+aarch64_hash=53b6e5907df869c49e4eae7aca09fba16d150741097efb245892c1477d2395f2
+linux32_hash=e534110e1047da37c1d586c392f74de3424f871d906a2083de6d41f2a8cc9164
+linux64_hash=fdcdb9b24f1a7726003586503fdeb264fd68fc37fbfcea022dcfe825a7fee18b
+osarm64_hash=a050e25e8d686853dd5afc363e55625165825dacfb55f8753d8225ebe417cfd2
+osx64_hash=6c2c5f2300d7564e711421b4968abd63243cb96f76e363975dd648ebf4a362ee
+
+### end of manual settings - following lines same for every download
+
+function err_no_binary {
+    local archmsg="${1}"
+    local ver="pypy${PYVER}-v${VERSION}-src"
+    local url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for ${archmsg}."
+      echo "try '${url}' to build from source."
+      echo
+    } >&2
+    exit 1
+}
+
+function pypy_pkg_data {
+    # pypy architecture tag
+    local ARCH="${1}"
+
+    # defaults
+    local cmd='install_package'  # use bz2
+    local pkg="${ARCH}" # assume matches
+    local ext='tar.bz2'
+    local hash='' # undefined
+
+    # select the hash, fix pkg if not match ARCH
+    case "${ARCH}" in
+    'linux-aarch64' )
+      hash="${aarch64_hash}"
+      pkg='aarch64'
+      ;;
+    'linux' )
+      hash="${linux32_hash}"
+      pkg='linux32'
+      ;;
+    'linux64' )
+      hash="${linux64_hash}"
+      ;;
+    'osarm64' )
+      hash="${osarm64_hash}"
+      pkg='macos_arm64'
+      ;;
+    'osx64' )
+      if require_osx_version "10.13"; then
+        hash="${osx64_hash}"
+        pkg='macos_x86_64'
+      else
+        err_no_binary "${ARCH}, OS X < 10.13"
+      fi
+      ;;
+    * )
+      err_no_binary "${ARCH}"
+      ;;
+    esac
+
+    local basever="pypy${PYVER}-v${VERSION}"
+    local baseurl="https://downloads.python.org/pypy/${basever}"
+
+    # result - command, package dir, url+hash
+    echo "${cmd}" "${basever}-${pkg}" "${baseurl}-${pkg}.${ext}#${hash}"
+}
+
+# determine command, package directory, url+hash
+declare -a pd="$(pypy_pkg_data "$(pypy_architecture 2>/dev/null || true)")"
+
+# install
+${pd[0]} "${pd[1]}" "${pd[2]}" 'pypy' "verify_py${PYVER//./}" 'ensurepip'

--- a/plugins/python-build/share/python-build/pypy3.10-7.3.17-src
+++ b/plugins/python-build/share/python-build/pypy3.10-7.3.17-src
@@ -1,0 +1,14 @@
+VERSION='7.3.17'
+PYVER='3.10'
+
+# https://www.pypy.org/checksums.html
+hash=6ad74bc578e9c6d3a8a1c51503313058e3c58c35df86f7485453c4be6ab24bf7
+
+### end of manual settings - following lines same for every download
+
+ver="pypy${PYVER}-v${VERSION}-src"
+url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+
+prefer_openssl11
+install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
+install_package "${ver}" "${url}#${hash}" 'pypy_builder' "verify_py${PYVER//./}" 'ensurepip'


### PR DESCRIPTION
N.B.: 7.3.17 drops Python 3.9 support as well as s390x platform
releases. See: https://pypy.org/posts/2024/08/pypy-v7317-release.html

Make sure you have checked all steps below.

### Prerequisite
* [N/A] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [N/A] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [N/A] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR
As mentioned above, PyPy 7.3.17 drops Python 3.9 support as well as s390x platform
releases and so this PR does likewise.

### Tests
- [N/A] My PR adds the following unit tests (if any)
