### PR TITLE
Add CPython 3.13.0rc2

### DIFF
--- a/plugins/python-build/share/python-build/3.13.0rc1
+++ b/plugins/python-build/share/python-build/3.13.0rc1
@@ -1,9 +1,0 @@
-prefer_openssl3
-export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-3.3.1" "https://www.openssl.org/source/openssl-3.3.1.tar.gz#777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e" mac_openssl --if has_broken_mac_openssl
-install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
-if has_tar_xz_support; then
-    install_package "Python-3.13.0rc1" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0rc1.tar.xz#678b884775eec0224d5159fa900879020baca2a36ce942fd95febfa1adb4a6bd" standard verify_py313 copy_python_gdb ensurepip
-else
-    install_package "Python-3.13.0rc1" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0rc1.tgz#53f1ed4920b82fa65cd32a56fa80fd18b475bf1b757597a5a104d2a4dfa5ffff" standard verify_py313 copy_python_gdb ensurepip
-fi

--- a/plugins/python-build/share/python-build/3.13.0rc1t
+++ b/plugins/python-build/share/python-build/3.13.0rc1t
@@ -1,2 +1,0 @@
-export PYTHON_BUILD_FREE_THREADING=1
-source "$(dirname "${BASH_SOURCE[0]}")"/3.13.0rc1

--- a/plugins/python-build/share/python-build/3.13.0rc2
+++ b/plugins/python-build/share/python-build/3.13.0rc2
@@ -1,0 +1,9 @@
+prefer_openssl3
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-3.3.2" "https://www.openssl.org/source/openssl-3.3.2.tar.gz#2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+    install_package "Python-3.13.0rc2" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0rc2.tar.xz#bf11be01b42a07a3659e4e233591e03da631b7112aa61ee1e030eeb8c5dfd869" standard verify_py313 copy_python_gdb ensurepip
+else
+    install_package "Python-3.13.0rc2" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0rc2.tgz#c87c42aa8137230a15a02ed90a6600610ba680cb5b54c0fbc57581a0d032e0c4" standard verify_py313 copy_python_gdb ensurepip
+fi

--- a/plugins/python-build/share/python-build/3.13.0rc2t
+++ b/plugins/python-build/share/python-build/3.13.0rc2t
@@ -1,0 +1,2 @@
+export PYTHON_BUILD_FREE_THREADING=1
+source "$(dirname "${BASH_SOURCE[0]}")"/3.13.0rc2


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [N/A] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [N/A] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [N/A] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR
This PR also bumps OpenSSL from 3.3.1 to 3.3.2
### Tests
- [N/A] My PR adds the following unit tests (if any)
