### PR TITLE
docs: Use `--verbose` with performance CPython build instructions

### DIFF
--- a/plugins/python-build/README.md
+++ b/plugins/python-build/README.md
@@ -208,7 +208,7 @@ enables PGO (profile guided optimization). While your mileage may vary, it is
 common for performance improvement from this to be in the ballpark of 30%.
 
 ```sh
-env PYTHON_CONFIGURE_OPTS='--enable-optimizations --with-lto' PYTHON_CFLAGS='-march=native -mtune=native' pyenv install 3.6.0
+env PYTHON_CONFIGURE_OPTS='--enable-optimizations --with-lto' PYTHON_CFLAGS='-march=native -mtune=native' pyenv install --verbose 3.6.0
 ```
 
 You can also customize the task used for profile guided optimization by setting


### PR DESCRIPTION
### Prerequisite
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3052

### Description

This is a tiny change to the docs for building CPython with performance optimizations; without the `--verbose` option, the commands runs for ~13 minutes and produces ~4 lines of output. It's nice to see the command is still running on an additional monitor while switching focus. 

### Tests

* I ran the modified command in my shell to check that the change works as expected
* I ran with and without the `--verbose` flag to make sure both still run in the same amount of time
