### PR TITLE
Fix latest version resolution when using `python-` prefix

### DIFF
--- a/libexec/pyenv-version-name
+++ b/libexec/pyenv-version-name
@@ -30,11 +30,11 @@ OLDIFS="$IFS"
 { IFS=:
   any_not_installed=0
   for version in ${PYENV_VERSION}; do
-    if version_exists "$version" || [ "$version" = "system" ]; then
-      versions=("${versions[@]}" "${version}")
-    elif version_exists "${version#python-}"; then
-      versions=("${versions[@]}" "${version#python-}")
-    elif resolved_version="$(pyenv-latest -b "$version")"; then
+    # Remove the explicit 'python-' prefix from versions like 'python-3.12'.
+    normalised_version="${version#python-}"
+    if version_exists "${normalised_version}" || [ "$version" = "system" ]; then
+      versions=("${versions[@]}" "${normalised_version}")
+    elif resolved_version="$(pyenv-latest -b "${normalised_version}")"; then
       versions=("${versions[@]}" "${resolved_version}")
     else
       echo "pyenv: version \`$version' is not installed (set by $(pyenv-version-origin))" >&2

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -120,3 +120,10 @@ OUT
   assert_success
   assert_output "2.7.11"
 }
+
+@test "pyenv-latest fallback with prefix in name" {
+  create_version "3.12.6"
+  PYENV_VERSION="python-3.12" run pyenv-version-name
+  assert_success
+  assert_output "3.12.6"
+}


### PR DESCRIPTION
### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3054

### Description

Fixes use of version specifiers like `python-3.12`, which:
- have an explicit `python-` prefix
- are using a major version alias that has to be resolved to an exact version.

As part of fixing this, I've also simplified the conditional for the already working case, since it had two branches that were virtually identical.

Fixes #3054.

### Tests
- [x] My PR adds the following unit tests: `"pyenv-latest fallback with prefix in name"`
