### PR TITLE
Fix OpenSSL 3.3.2 download URLs

### DIFF
--- a/plugins/python-build/share/python-build/3.12.6
+++ b/plugins/python-build/share/python-build/3.12.6
@@ -1,6 +1,6 @@
 prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-3.3.2" "https://www.openssl.org/source/openssl-3.3.2.tar.gz#2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.3.2" "https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.3.2.tar.gz#2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.12.6" "https://www.python.org/ftp/python/3.12.6/Python-3.12.6.tar.xz#1999658298cf2fb837dffed8ff3c033ef0c98ef20cf73c5d5f66bed5ab89697c" standard verify_py312 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.13.0rc2
+++ b/plugins/python-build/share/python-build/3.13.0rc2
@@ -1,6 +1,6 @@
 prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-3.3.2" "https://www.openssl.org/source/openssl-3.3.2.tar.gz#2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.3.2" "https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.3.2.tar.gz#2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.13.0rc2" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0rc2.tar.xz#d60e8b7c10de4f71d2dffaf7c7be8efa54dc1e532fe931dbb84e5f625709e237" standard verify_py313 copy_python_gdb ensurepip


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description

See https://github.com/pyenv/pyenv/pull/3050#issuecomment-2342491510.

### Tests
- [ ] My PR adds the following unit tests (if any)
