### PR TITLE
Fix tgz checksum for 3.9.20; fallback OpenSSL URLs and checksums

### DIFF
--- a/plugins/python-build/share/python-build/3.11.10
+++ b/plugins/python-build/share/python-build/3.11.10
@@ -1,7 +1,7 @@
 prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
-install_package "openssl-3.2.2" "https://www.openssl.org/source/openssl-3.2.2.tar.gz#2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.2.2" "https://openssl.org/source/old/3.2/openssl-3.2.2.tar.gz#197149c18d9e9f292c43f0400acaba12e5f52cacfe050f3d199277ea738ec2e7" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.11.10" "https://www.python.org/ftp/python/3.11.10/Python-3.11.10.tar.xz#07a4356e912900e61a15cb0949a06c4a05012e213ecd6b4e84d0f67aabbee372" standard verify_py311 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.12.6
+++ b/plugins/python-build/share/python-build/3.12.6
@@ -1,6 +1,6 @@
 prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-3.3.2" "https://www.openssl.org/source/openssl-3.3.2.tar.gz#2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.3.2" "https://openssl.org/source/old/3.2/openssl-3.2.2.tar.gz#197149c18d9e9f292c43f0400acaba12e5f52cacfe050f3d199277ea738ec2e7" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.12.6" "https://www.python.org/ftp/python/3.12.6/Python-3.12.6.tar.xz#1999658298cf2fb837dffed8ff3c033ef0c98ef20cf73c5d5f66bed5ab89697c" standard verify_py312 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.13.0rc2
+++ b/plugins/python-build/share/python-build/3.13.0rc2
@@ -1,6 +1,6 @@
 prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-3.3.2" "https://www.openssl.org/source/openssl-3.3.2.tar.gz#2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.3.2" "https://openssl.org/source/old/3.2/openssl-3.2.2.tar.gz#197149c18d9e9f292c43f0400acaba12e5f52cacfe050f3d199277ea738ec2e7" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.13.0rc2" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0rc2.tar.xz#d60e8b7c10de4f71d2dffaf7c7be8efa54dc1e532fe931dbb84e5f625709e237" standard verify_py313 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.9.20
+++ b/plugins/python-build/share/python-build/3.9.20
@@ -8,5 +8,5 @@ install_package "readline-8.1" "https://ftpmirror.gnu.org/readline/readline-8.1.
 if has_tar_xz_support; then
   install_package "Python-3.9.20" "https://www.python.org/ftp/python/3.9.20/Python-3.9.20.tar.xz#6b281279efd85294d2d6993e173983a57464c0133956fbbb5536ec9646beaf0c" standard verify_py39 copy_python_gdb ensurepip
 else
-  install_package "Python-3.9.20" "https://www.python.org/ftp/python/3.9.20/Python-3.9.20.tgz#9f2d5962c2583e67ef75924cd56d0c1af78bf45ec57035cf8a2cc09f74f4bf78" standard verify_py39 copy_python_gdb ensurepip
+  install_package "Python-3.9.20" "https://www.python.org/ftp/python/3.9.20/Python-3.9.20.tgz#1e71f006222666e0a39f5a47be8221415c22c4dd8f25334cc41aee260b3d379e" standard verify_py39 copy_python_gdb ensurepip
 fi


### PR DESCRIPTION
changed OpenSSL URLs to permalinks so that they keep working

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3057

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
