### PR TITLE
Add CPython 3.13.0rc3

### DIFF
--- a/plugins/python-build/share/python-build/3.13.0rc2t
+++ b/plugins/python-build/share/python-build/3.13.0rc2t
@@ -1,2 +1,0 @@
-export PYTHON_BUILD_FREE_THREADING=1
-source "$(dirname "${BASH_SOURCE[0]}")"/3.13.0rc2

--- a/plugins/python-build/share/python-build/3.13.0rc3
+++ b/plugins/python-build/share/python-build/3.13.0rc3
@@ -3,7 +3,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-3.3.2" "https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.3.2.tar.gz#2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.13.0rc2" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0rc2.tar.xz#d60e8b7c10de4f71d2dffaf7c7be8efa54dc1e532fe931dbb84e5f625709e237" standard verify_py313 copy_python_gdb ensurepip
+    install_package "Python-3.13.0rc3" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0rc3.tar.xz#c8bc790185af1cb77b75c01cbc1aa642dfdcf97a370d2d10090bc7baa70da57e" standard verify_py313 copy_python_gdb ensurepip
 else
-    install_package "Python-3.13.0rc2" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0rc2.tgz#d08965c543f21d9949b2715b50d7e4619a5c13984a2ba6d2efcabf413d41479a" standard verify_py313 copy_python_gdb ensurepip
+    install_package "Python-3.13.0rc3" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0rc3.tgz#e5e8611d1bfbfda4accf8fab868712252a9c5f6aa5f13f6a5093878a9ef38412" standard verify_py313 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/3.13.0rc3t
+++ b/plugins/python-build/share/python-build/3.13.0rc3t
@@ -1,0 +1,2 @@
+export PYTHON_BUILD_FREE_THREADING=1
+source "$(dirname "${BASH_SOURCE[0]}")"/3.13.0rc3


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description

The final CPython 3.13.0 release was pushed a week and folks decided to publish a new RC instead:

https://discuss.python.org/t/incremental-gc-and-pushing-back-the-3-13-0-release/65285

### Tests
- [ ] My PR adds the following unit tests (if any)
