### PR TITLE
CI: replace set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -21,8 +21,7 @@ jobs:
           echo "$EOF" >> $GITHUB_ENV;
       - id: modified-versions
         run: |
-          echo -n "::set-output name=versions::"
-          echo "${{ env.versions }}" | jq -R . | jq -sc .
+          echo "versions=`echo "${{ env.versions }}" | jq -R . | jq -sc .`" >> $GITHUB_OUTPUT
   macos_build:
     needs: discover_modified_scripts
     if: needs.discover_modified_scripts.outputs.versions != '[""]'


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)

---
`::set-output` will be deprecated in the future.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

demo test [here](https://github.com/tuzi3040/pyenv/actions/runs/11133272712/job/30938986102)

Didn't squash to previous step for better debug output (seems that env will be printed to log when set in context).