### PR TITLE
Avoid shadowing of virtualenvs with name starting by "python-"

### DIFF
--- a/libexec/pyenv-version-name
+++ b/libexec/pyenv-version-name
@@ -32,8 +32,12 @@ OLDIFS="$IFS"
   for version in ${PYENV_VERSION}; do
     # Remove the explicit 'python-' prefix from versions like 'python-3.12'.
     normalised_version="${version#python-}"
-    if version_exists "${normalised_version}" || [ "$version" = "system" ]; then
+    if version_exists "${version}" || [ "$version" = "system" ]; then
+      versions=("${versions[@]}" "${version}")
+    elif version_exists "${normalised_version}"; then
       versions=("${versions[@]}" "${normalised_version}")
+    elif resolved_version="$(pyenv-latest -b "${version}")"; then
+      versions=("${versions[@]}" "${resolved_version}")
     elif resolved_version="$(pyenv-latest -b "${normalised_version}")"; then
       versions=("${versions[@]}" "${resolved_version}")
     else

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -127,3 +127,10 @@ OUT
   assert_success
   assert_output "3.12.6"
 }
+
+@test "pyenv version started by python-" {
+  create_version "python-3.12.6"
+  PYENV_VERSION="python-3.12.6" run pyenv-version-name
+  assert_success
+  assert_output "python-3.12.6"
+}


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.

### Description
- [x] Here are some details about my PR

I had a virtualenv named python-api which worked correctly. Until pyenv upgrade, which results in `pyenv: version 'python-api' is not installed` error message when I tried to use any python binary.

I am not familiar with bash so I don't know if this can be fixed in pyenv-virtualenv plugin (which is probably a better place to handle this special case).

### Tests
- [x] My PR adds the following unit tests

"pyenv version started by python-"
