### PR TITLE
Support free-threaded CPython flavor in prefix resolution

### DIFF
--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -48,16 +48,25 @@ IFS=$'\n'
         exit $exitcode;
     fi
     
+    suffix=""
+    if [[ $prefix =~ ^(.*[0-9])t$ ]]; then
+        suffix="t"
+        prefix="${BASH_REMATCH[1]}"
+    fi
+    
     # https://stackoverflow.com/questions/11856054/is-there-an-easy-way-to-pass-a-raw-string-to-grep/63483807#63483807 
     prefix_re="$(sed 's/[^\^]/[&]/g;s/[\^]/\\&/g' <<< "$prefix")"
+    suffix_re="$(sed 's/[^\^]/[&]/g;s/[\^]/\\&/g' <<< "$suffix")"
     # FIXME: more reliable and readable would probably be to loop over them and transform in pure Bash
     DEFINITION_CANDIDATES=(\
       $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
-      grep -Ee "^$prefix_re[-.]" || true))
+      grep -Ee "^$prefix_re[-.].*$suffix_re\$" || true))
 
     DEFINITION_CANDIDATES=(\
         $(printf '%s\n' "${DEFINITION_CANDIDATES[@]}" | \
-          sed -E -e '/-dev$/d' -e '/-src$/d' -e '/-latest$/d' -e '/(a|b|rc)[0-9]+$/d' -e '/[0-9]+t$/d'));
+          sed -E -e '/-dev$/d' -e '/-src$/d' -e '/-latest$/d' -e '/(a|b|rc)[0-9]+$/d' \
+            $(if [[ -z $suffix ]]; then echo "-e /[0-9]t\$/d"; fi)
+        ));
 
     # Compose a sorting key, followed by | and original value
     DEFINITION_CANDIDATES=(\

--- a/test/latest.bats
+++ b/test/latest.bats
@@ -94,7 +94,7 @@ echo 3.10.6
 !
 }
 
-@test "ignores rolling releases, branch tips, alternative srcs, prereleases and virtualenvs" {
+@test "ignores rolling releases, branch tips, alternative srcs, prereleases, virtualenvs; 't' versions if prefix without 't'" {
   create_executable pyenv-versions <<!
 #!$BASH
 echo 3.8.5-dev
@@ -113,6 +113,21 @@ echo 3.8.1/envs/foo
   assert_success
   assert_output <<!
 3.8.1
+!
+}
+
+@test "resolves to a 't' version if prefix has 't'" {
+  create_executable pyenv-versions <<!
+#!$BASH
+echo 3.13.2t
+echo 3.13.5
+echo 3.13.5t
+echo 3.14.6
+!
+  run pyenv-latest 3t
+  assert_success
+  assert_output <<!
+3.13.5t
 !
 }
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Addresses

### Description
- [x] Here are some details about my PR

Since 3.13, CPython is provided in 2 flavors: regular and free-threaded, with the 't' suffix.

An incomplete prefix ending with '[0-9]t'
resolves only among versions that also end with '[0-9]t'

### Tests
- [x] My PR adds the following unit tests (if any)

* test resolution with 't'
* existing test 'ignores branch tips etc' renamed as it now also tests ignoring 't' versions without 't' in prefix