### PR TITLE
Add CPython 3.14.0a1

### DIFF
--- a/plugins/python-build/share/python-build/3.14.0a1
+++ b/plugins/python-build/share/python-build/3.14.0a1
@@ -1,0 +1,9 @@
+prefer_openssl3
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-3.3.2" "https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.3.2.tar.gz#2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+    install_package "Python-3.14.0a1" "https://www.python.org/ftp/python/3.14.0/Python-3.14.0a1.tar.xz#3e464b0cbb7535e2db34262fd19a0a393d0e62be0f43b1513ed98379b054ead4" standard verify_py313 copy_python_gdb ensurepip
+else
+    install_package "Python-3.14.0a1" "https://www.python.org/ftp/python/3.14.0/Python-3.14.0a1.tgz#6edf6c54c118daff03de81d60b227545de89732c2d131ed243ce5593fa9682b7" standard verify_py313 copy_python_gdb ensurepip
+fi

--- a/plugins/python-build/share/python-build/3.14.0a1t
+++ b/plugins/python-build/share/python-build/3.14.0a1t
@@ -1,0 +1,2 @@
+export PYTHON_BUILD_FREE_THREADING=1
+source "$(dirname "${BASH_SOURCE[0]}")"/3.14.0a1


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description

https://www.python.org/downloads/release/python-3140a1/

### Tests
- [ ] My PR adds the following unit tests (if any)
