### PR TITLE
README: Fix Markdown in "Notes about python releases"

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Running `pyenv install -l` gives the list of all available versions.
 ----
 
 <details> <summary> Notes about python releases </summary>
+  
 **NOTE:** Most Pyenv-provided Python releases are source releases and are built
 from source as part of installation (that's why you need Python build dependencies preinstalled).
 You can pass options to Python's `configure` and compiler flags to customize the build,


### PR DESCRIPTION
HTML and Markdown need to be separated by an empty line to co-exist, otherwise the Markdown isn't parsed correctly.

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.

### Description
- [x] Here are some details about my PR

