### PR TITLE
chore: correct link to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The options from the [Linux section above](#linuxunix) also work but Homebrew is
       brew install pyenv --head
       ```
    3. Then follow the rest of the post-installation steps, starting with
-      [Set up your shell environment for Pyenv](#set-up-your-shell-environment-for-pyenv).
+      [Set up your shell environment for Pyenv](#b-set-up-your-shell-environment-for-pyenv).
 
    4. OPTIONAL. To fix `brew doctor`'s warning _""config" scripts exist outside your system or Homebrew directories"_
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description

The link to the setup steps in the MacOS instruction is incorrect, this PR fixes it.

### Tests
- [x] Click on the link in [the rendered README](https://github.com/shortcuts/pyenv/blob/8f3000bcd0adbb9593f214b1042796b8a728d1d4/README.md#homebrew-in-macos)
