### PR TITLE
Prefer tcl-tk@8 from Homebrew due to release of Tcl/Tk 9 with which only 3.12+ are compatible

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1671,25 +1671,32 @@ use_xcode_sdk_zlib() {
 
 use_homebrew_tcltk() {
   can_use_homebrew || return 1
-  # get the version from the folder that homebrew versions
-  local tcltk_libdir="$(brew --prefix tcl-tk 2>/dev/null || true)"
-  if [ -d "$tcltk_libdir" ]; then
-    echo "python-build: use tcl-tk from homebrew"
-    if [[ -z "$PYTHON_BUILD_TCLTK_USE_PKGCONFIG" ]]; then
-      local tcltk_version="$(sh -c '. '"$tcltk_libdir"'/lib/tclConfig.sh; echo $TCL_VERSION')"
-      package_option python configure --with-tcltk-libs="-L$tcltk_libdir/lib -ltcl$tcltk_version -ltk$tcltk_version"
-      # In Homebrew Tcl/Tk 8.6.13, headers have been moved to the 'tcl-tk' subdir.
-      # We're not using tclConfig.sh here 'cuz it produces the version-specific path to <brew prefix>/Cellar
-      # and we'd rather have rpath set to <brew prefix>/opt/<...> to allow micro release upgrades without rebuilding
-      # XXX: do use tclConfig.sh and translate the paths if more path shenanigans appear in later releases
-      if [ -d "$tcltk_libdir/include/tcl-tk" ]; then
-        package_option python configure --with-tcltk-includes="-I$tcltk_libdir/include/tcl-tk"
-      else
-        package_option python configure --with-tcltk-includes="-I$tcltk_libdir/include"
+  # Since https://github.com/Homebrew/homebrew-core/commit/f10e88617b41555193c22fdcba6109fe82155ee2 (10.11.2024),
+  # tcl-tk is 9.0 which is not compatible with CPython as of this writing
+  # but we'll keep it as backup for cases like non-updated Homebrew
+  local tcltk
+  for tcltk in "tcl-tk@8" "tcl-tk"; do
+    local tcltk_libdir="$(brew --prefix "${tcltk}" 2>/dev/null || true)"
+    if [ -d "$tcltk_libdir" ]; then
+      echo "python-build: use tcl-tk from homebrew"
+      if [[ -z "$PYTHON_BUILD_TCLTK_USE_PKGCONFIG" ]]; then
+        local tcltk_version="$(sh -c '. '"$tcltk_libdir"'/lib/tclConfig.sh; echo $TCL_VERSION')"
+        package_option python configure --with-tcltk-libs="-L$tcltk_libdir/lib -ltcl$tcltk_version -ltk$tcltk_version"
+        # In Homebrew Tcl/Tk 8.6.13, headers have been moved to the 'tcl-tk' subdir.
+        # We're not using tclConfig.sh here 'cuz it produces the version-specific path to <brew prefix>/Cellar
+        # and we'd rather have rpath set to <brew prefix>/opt/<...> to allow micro release upgrades without rebuilding
+        # XXX: do use tclConfig.sh and translate the paths if more path shenanigans appear in later releases
+        if [ -d "$tcltk_libdir/include/tcl-tk" ]; then
+          package_option python configure --with-tcltk-includes="-I$tcltk_libdir/include/tcl-tk"
+        else
+          package_option python configure --with-tcltk-includes="-I$tcltk_libdir/include"
+        fi
       fi
+      export PKG_CONFIG_PATH="${tcltk_libdir}/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+      return
     fi
-    export PKG_CONFIG_PATH="${tcltk_libdir}/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
-  fi
+  done
+  return 1
 }
 
 # FIXME: this function is a workaround for #1125

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1703,9 +1703,9 @@ use_homebrew_tcltk() {
 # once fixed, it should be removed.
 # if tcltk_ops_flag is in PYTHON_CONFIGURE_OPTS, use user provided tcltk
 use_custom_tcltk() {
-  local tcl_tk_ops="$(get_tcltk_flag_from "$PYTHON_CONFIGURE_OPTS")"
+  local tcltk_ops="$(get_tcltk_flag_from "$PYTHON_CONFIGURE_OPTS")"
 
-  if [[ -z "$tcl_tk_ops" ]]; then
+  if [[ -z "$tcltk_ops" ]]; then
     return 1
   fi
   local tcltk_ops_flag="--with-tcltk-libs="

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -814,7 +814,7 @@ build_package_standard_build() {
 
   if [ "$package_var_name" = "PYTHON" ]; then
     use_homebrew || true
-    use_tcltk || true
+    use_custom_tcltk || use_homebrew_tcltk || true
     use_homebrew_readline || use_freebsd_pkg || true
     use_homebrew_ncurses || true
     if is_mac -ge 1014; then
@@ -1693,7 +1693,7 @@ use_homebrew_tcltk() {
         fi
       fi
       export PKG_CONFIG_PATH="${tcltk_libdir}/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
-      return
+      return 0
     fi
   done
   return 1
@@ -1701,8 +1701,13 @@ use_homebrew_tcltk() {
 
 # FIXME: this function is a workaround for #1125
 # once fixed, it should be removed.
+# if tcltk_ops_flag is in PYTHON_CONFIGURE_OPTS, use user provided tcltk
 use_custom_tcltk() {
-  local tcltk_ops="$1"
+  local tcl_tk_ops="$(get_tcltk_flag_from "$PYTHON_CONFIGURE_OPTS")"
+
+  if [[ -z "$tcl_tk_ops" ]]; then
+    return 1
+  fi
   local tcltk_ops_flag="--with-tcltk-libs="
   # get tcltk libs
   local tcltk_libs="${tcltk_ops//$tcltk_ops_flag/}"
@@ -1743,21 +1748,6 @@ get_tcltk_flag_from() {
   done
 
   IFS="$OLDIFS"
-}
-
-use_tcltk() {
-  if can_use_homebrew; then
-    local tcltk_libdir="$(brew --prefix tcl-tk 2>/dev/null || true)"
-  fi
-  local tcl_tk_libs="$(get_tcltk_flag_from "$PYTHON_CONFIGURE_OPTS")"
-
-  # if tcltk_ops_flag is in PYTHON_CONFIGURE_OPTS, use user provided tcltk
-  # otherwise default to homebrew-installed tcl-tk, if installed
-  if [[ -n "$tcl_tk_libs" ]]; then
-    use_custom_tcltk "$tcl_tk_libs"
-  elif [ -d "$tcltk_libdir" ]; then
-    use_homebrew_tcltk
-  fi
 }
 
 # Since 3.12, CPython can add DWARF debug information in MacOS

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -739,7 +739,7 @@ OUT
 
   for i in {1..10}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
-  for i in {1..5}; do stub brew false; done
+  for i in {1..6}; do stub brew false; done
   stub_make_install
 
   run_inline_definition <<DEF

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -182,7 +182,7 @@ OUT
   for i in {1..10}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
   stub brew "--prefix libyaml : echo '$brew_libdir'"
-  for i in {1..5}; do stub brew false; done
+  for i in {1..6}; do stub brew false; done
   stub_make_install
 
   install_fixture definitions/needs-yaml
@@ -208,7 +208,7 @@ OUT
   mkdir -p "$readline_libdir"
   for i in {1..8}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
-  for i in {1..2}; do stub brew false; done
+  for i in {1..3}; do stub brew false; done
   stub brew "--prefix readline : echo '$readline_libdir'"
   for i in {1..2}; do stub brew false; done
   stub_make_install
@@ -238,7 +238,7 @@ OUT
   mkdir -p "$ncurses_libdir"
   for i in {1..9}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
-  for i in {1..3}; do stub brew false; done
+  for i in {1..4}; do stub brew false; done
   stub brew "--prefix ncurses : echo '$ncurses_libdir'"
   stub brew false
   stub_make_install
@@ -364,7 +364,7 @@ OUT
 
   for i in {1..4}; do stub uname '-s : echo Linux'; done
   stub brew "--prefix : echo '$BREW_PREFIX'"
-  for i in {1..4}; do stub brew false; done
+  for i in {1..5}; do stub brew false; done
   stub_make_install
   export PYTHON_BUILD_USE_HOMEBREW=1
 
@@ -394,7 +394,7 @@ OUT
 
   for i in {1..4}; do stub uname '-s : echo Linux'; done
   stub brew "--prefix : echo '$BREW_PREFIX'"
-  for i in {1..4}; do stub brew false; done
+  for i in {1..5}; do stub brew false; done
   stub_make_install
   export PYTHON_BUILD_USE_HOMEBREW=1
 
@@ -453,7 +453,7 @@ OUT
   for i in {1..8}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
 
-  for i in {1..4}; do stub brew false; done
+  for i in {1..5}; do stub brew false; done
   stub_make_install
 
   export PYTHON_CONFIGURE_OPTS="CPPFLAGS=-I$readline_libdir/include LDFLAGS=-L$readline_libdir/lib"
@@ -482,11 +482,11 @@ OUT
   mkdir -p "$tcl_tk_libdir/lib"
   echo "TCL_VERSION='$tcl_tk_version'" >>"$tcl_tk_libdir/lib/tclConfig.sh"
 
-  for i in {1..10}; do stub uname '-s : echo Darwin'; done
+  for i in {1..9}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
 
   stub brew false
-  for i in {1..2}; do stub brew "--prefix tcl-tk : echo '$tcl_tk_libdir'"; done
+  stub brew "--prefix tcl-tk@8 : echo '$tcl_tk_libdir'"
   for i in {1..3}; do stub brew false; done
 
   stub_make_install
@@ -516,10 +516,10 @@ OUT
   tcl_tk_version_long="8.6.10"
   tcl_tk_version="${tcl_tk_version_long%.*}"
 
-  for i in {1..9}; do stub uname '-s : echo Darwin'; done
+  for i in {1..8}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
 
-  for i in {1..5}; do stub brew false; done
+  for i in {1..4}; do stub brew false; done
   stub_make_install
 
   export PYTHON_CONFIGURE_OPTS="--with-tcltk-libs='-L${TMP}/custom-tcl-tk/lib -ltcl$tcl_tk_version -ltk$tcl_tk_version'"
@@ -544,14 +544,14 @@ OUT
 @test "tcl-tk is linked from Homebrew via pkgconfig only when envvar is set" {
   cached_tarball "Python-3.6.2"
 
-  for i in {1..10}; do stub uname '-s : echo Darwin'; done
+  for i in {1..9}; do stub uname '-s : echo Darwin'; done
   for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
 
   tcl_tk_libdir="$TMP/homebrew-tcl-tk"
   mkdir -p "$tcl_tk_libdir/lib"
 
   stub brew false
-  for i in {1..2}; do stub brew "--prefix tcl-tk : echo '${tcl_tk_libdir}'"; done
+  stub brew "--prefix tcl-tk@8 : echo '${tcl_tk_libdir}'"
   for i in {1..3}; do stub brew false; done
 
   stub_make_install


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3116

### Description
- [x] Here are some details about my PR

Since 10.11.2024, Homebrew upgraded tck-tk to 9.0
which CPython is not compatible with yet

### Tests
- [x] My PR adds the following unit tests (if any)
N/A