### PR TITLE
Fix 404 for openssl-3.4.0 release in build 3.13.1

### DIFF
--- a/plugins/python-build/share/python-build/3.13.1
+++ b/plugins/python-build/share/python-build/3.13.1
@@ -1,6 +1,6 @@
 prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-3.4.0" "https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.4.0.tar.gz#e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.4.0" "https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz#e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.13.1" "https://www.python.org/ftp/python/3.13.1/Python-3.13.1.tar.xz#9cf9427bee9e2242e3877dd0f6b641c1853ca461f39d6503ce260a59c80bf0d9" standard verify_py313 copy_python_gdb ensurepip


### PR DESCRIPTION
The path before this change was wrong and resulted in the following message, provided here so others may search for the error message:
```
% pyenv install 3.13.1
Downloading openssl-3.4.0.tar.gz...
-> https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.4.0.tar.gz
error: failed to download openssl-3.4.0.tar.gz

BUILD FAILED (OS X 14.6.1 using python-build 2.4.21)

Results logged to /var/folders/yt/6fv7ccy95ql3cz6_8z00_hx80000gn/T/python-build.20241206115436.6774.log

Last 10 log lines:
via: 1.1 varnish
x-served-by: cache-ewr-kewr1740040-EWR
x-cache: HIT
x-cache-hits: 0
x-timer: S1733504077.891231,VS0,VE1
vary: Accept-Encoding
x-fastly-request-id: cb5cb260b1733a73c78f7fd58d09f1701d334a6a
content-length: 9379

curl: (56) The requested URL returned error: 404
```

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3121

### Description

The URL contains an old semver in the path for 3.2.2 where the file's semver is 3.4.0. This leads to a 404 from github.com. The patch corrects this to use the right path to openssl-3.4.0's release tar gz file.

### Tests

I manually tested that the fix proceeds to get and build all parts of python 3.13.3 including openssl-3.4.0. If you're not using brew but just a plain macbook's macOS, you'll need this fix.