### PR TITLE
CI: add building modified scripts with bundled MacOS dependencies

### DIFF
--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -82,6 +82,67 @@ jobs:
           pyenv global system
           rm -f "$(pyenv root)"/shims/*
 
+  macos_build_bundled_dependencies:
+    needs: discover_modified_scripts
+    if: needs.discover_modified_scripts.outputs.versions != '[""]'
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{fromJson(needs.discover_modified_scripts.outputs.versions)}}
+        os: ["macos-13", "macos-14"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          #envvars
+          export PYENV_ROOT="$GITHUB_WORKSPACE"
+          echo "PYENV_ROOT=$PYENV_ROOT" >> $GITHUB_ENV
+          echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
+      - run: |
+          #prerequisites
+          brew install sqlite3 xz zlib
+          "$GITHUB_WORKSPACE/.github/workflows/scripts/brew-uninstall-cascade.sh" openssl@3 openssl@1.1 readline
+          if [[ "${{ matrix.python-version }}" =~ pypy.*-(src|dev) ]]; then
+            export PYENV_BOOTSTRAP_VERSION=pypy2.7-7
+            echo "PYENV_BOOTSTRAP_VERSION=$PYENV_BOOTSTRAP_VERSION" >> $GITHUB_ENV
+            pyenv install $PYENV_BOOTSTRAP_VERSION
+          fi
+      - run: |
+          #build
+          pyenv --debug install ${{ matrix.python-version }}
+          pyenv global ${{ matrix.python-version }}
+      # Micropython doesn't support --version
+      - run: |
+          #print version
+          if [[ "${{ matrix.python-version }}" == "micropython-"* ]]; then
+            python -c 'import sys; print(sys.version)'
+          else
+            python --version
+            python -m pip --version
+          fi
+      # Micropython doesn't support sys.executable, os.path, older versions even os
+      - env:
+          EXPECTED_PYTHON: ${{ matrix.python-version }}
+        run: |
+          #check
+          if [[ "${{ matrix.python-version }}" == "micropython-"* ]]; then
+            [[ $(pyenv which python) == "${{ env.PYENV_ROOT }}/versions/${{ matrix.python-version }}/bin/python" ]] || exit 1
+            python -c 'import sys; assert sys.implementation.name == "micropython"'
+          else
+            python -c 'if True:
+            import os, sys, os.path
+            correct_dir = os.path.join(
+              os.environ["PYENV_ROOT"],
+              "versions",
+              os.environ["EXPECTED_PYTHON"],
+              "bin")
+            assert os.path.dirname(sys.executable) == correct_dir'
+          fi
+      # bundled executables in some Anaconda releases cause the post-run step to hang in MacOS
+      - run: |
+          pyenv global system
+          rm -f "$(pyenv root)"/shims/*
+
   ubuntu_build:
     needs: discover_modified_scripts
     if: needs.discover_modified_scripts.outputs.versions != '[""]'

--- a/.github/workflows/scripts/brew-uninstall-cascade.sh
+++ b/.github/workflows/scripts/brew-uninstall-cascade.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+declare -a packages rdepends
+packages=("$@")
+
+# have to try one by one, otherwise `brew uses` would only print
+# packages that require them all rather than any of them
+for package in "${packages[@]}"; do
+  rdepends+=($(brew uses --installed --include-build --include-test --include-optional --recursive "$package"))
+done
+brew uninstall "${packages[@]}" "${rdepends[@]}"


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - None

### Description
- [x] Here are some details about my PR
Building bundled OpenSSL and Readline is not currently tested which has caused breakages multiple times

### Tests
- [x] My PR adds the following unit tests (if any)
N/A