### PR TITLE
Support nonexistent versions being present and set in a local .python-version

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -91,6 +91,10 @@ or, if you prefer 3.3.3 over 2.7.6,
     Python 3.3.3
 
 
+You can use the `-f/--force` flag to force setting versions even if some aren't installed.
+This is mainly useful in special cases like provisioning scripts.
+
+
 ## `pyenv global`
 
 Sets the global version of Python to be used in all shells by writing

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -29,9 +29,9 @@ if [ -z "$PYENV_COMMAND" ]; then
   exit 1
 fi
 
-export PYENV_VERSION
 PYENV_COMMAND_PATH="$(pyenv-which "$PYENV_COMMAND")"
 PYENV_BIN_PATH="${PYENV_COMMAND_PATH%/*}"
+export PYENV_VERSION
 
 OLDIFS="$IFS"
 IFS=$'\n' scripts=(`pyenv-hooks exec`)

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -21,7 +21,7 @@ if [ "$1" = "--complete" ]; then
   exec pyenv-shims --short
 fi
 
-PYENV_VERSION="$(pyenv-version-name)"
+PYENV_VERSION="$(pyenv-version-name -f)"
 PYENV_COMMAND="$1"
 
 if [ -z "$PYENV_COMMAND" ]; then

--- a/libexec/pyenv-local
+++ b/libexec/pyenv-local
@@ -2,8 +2,10 @@
 #
 # Summary: Set or show the local application-specific Python version(s)
 #
-# Usage: pyenv local <version> <version2> <..>
+# Usage: pyenv local [-f|--force] [<version> [...]]
 #        pyenv local --unset
+#
+#   -f/--force    Do not verify that the versions being set exist
 #
 # Sets the local application-specific Python version(s) by writing the
 # version name to a file named `.python-version'.
@@ -36,12 +38,25 @@ if [ "$1" = "--complete" ]; then
   exec pyenv-versions --bare
 fi
 
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        -f|--force)
+            FORCE=1
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
 versions=("$@")
 
 if [ "$versions" = "--unset" ]; then
   rm -f .python-version
 elif [ -n "$versions" ]; then
-  pyenv-version-file-write .python-version "${versions[@]}"
+  pyenv-version-file-write ${FORCE:+-f }.python-version "${versions[@]}"
 else
   if version_file="$(pyenv-version-file "$PWD")"; then
     IFS=: versions=($(pyenv-version-file-read "$version_file"))

--- a/libexec/pyenv-version-file-write
+++ b/libexec/pyenv-version-file-write
@@ -1,8 +1,22 @@
 #!/usr/bin/env bash
-# Usage: pyenv version-file-write <file> <version>
+# Usage: pyenv version-file-write [-f|--force] <file> <version>
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
+
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        -f|--force)
+            FORCE=1
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
 
 PYENV_VERSION_FILE="$1"
 shift || true
@@ -14,7 +28,7 @@ if [ -z "$versions" ] || [ -z "$PYENV_VERSION_FILE" ]; then
 fi
 
 # Make sure the specified version is installed.
-pyenv-prefix "${versions[@]}" >/dev/null
+[[ -z $FORCE ]] && pyenv-prefix "${versions[@]}" >/dev/null
 
 # Write the version out to disk.
 # Create an empty file. Using "rm" might cause a permission error.

--- a/libexec/pyenv-version-file-write
+++ b/libexec/pyenv-version-file-write
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Usage: pyenv version-file-write [-f|--force] <file> <version>
+# Usage: pyenv version-file-write [-f|--force] <file> <version> [...]
+#
+#   -f/--force    Don't verify that the versions exist
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x

--- a/libexec/pyenv-version-name
+++ b/libexec/pyenv-version-name
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Summary: Show the current Python version
 #
-#   -f/--force    If a version doesn't exist, print it as is rather than produce an error
+#   -f/--force    (Internal) If a version doesn't exist, print it as is rather than produce an error
 
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x

--- a/libexec/pyenv-version-name
+++ b/libexec/pyenv-version-name
@@ -1,7 +1,24 @@
 #!/usr/bin/env bash
 # Summary: Show the current Python version
+#
+#   -f/--force    If a version doesn't exist, print it as is rather than produce an error
+
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
+
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        -f|--force)
+            FORCE=1
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
 
 if [ -z "$PYENV_VERSION" ]; then
   PYENV_VERSION_FILE="$(pyenv-version-file)"
@@ -33,16 +50,20 @@ OLDIFS="$IFS"
     # Remove the explicit 'python-' prefix from versions like 'python-3.12'.
     normalised_version="${version#python-}"
     if version_exists "${version}" || [ "$version" = "system" ]; then
-      versions=("${versions[@]}" "${version}")
+      versions+=("${version}")
     elif version_exists "${normalised_version}"; then
-      versions=("${versions[@]}" "${normalised_version}")
+      versions+=("${normalised_version}")
     elif resolved_version="$(pyenv-latest -b "${version}")"; then
-      versions=("${versions[@]}" "${resolved_version}")
+      versions+=("${resolved_version}")
     elif resolved_version="$(pyenv-latest -b "${normalised_version}")"; then
-      versions=("${versions[@]}" "${resolved_version}")
+      versions+=("${resolved_version}")
     else
-      echo "pyenv: version \`$version' is not installed (set by $(pyenv-version-origin))" >&2
-      any_not_installed=1
+      if [[ -n $FORCE ]]; then
+        versions+=("${normalised_version}")
+      else
+        echo "pyenv: version \`$version' is not installed (set by $(pyenv-version-origin))" >&2
+        any_not_installed=1
+      fi
     fi
   done
 }

--- a/libexec/pyenv-which
+++ b/libexec/pyenv-which
@@ -96,7 +96,6 @@ else
     for version in "${nonexistent_versions[@]}"; do
       echo "pyenv: version \`$version' is not installed (set by $(pyenv-version-origin))" >&2
     done
-    exit 1
   fi
 
   echo "pyenv: $PYENV_COMMAND: command not found" >&2

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -16,10 +16,10 @@ create_executable() {
 
 @test "fails with invalid version" {
   export PYENV_VERSION="3.4"
-  run pyenv-exec python -V
+  run pyenv-exec nonexistent
   assert_failure <<EOF
 pyenv: version \`3.4' is not installed (set by PYENV_VERSION environment variable)
-pyenv: python: command not found
+pyenv: nonexistent: command not found
 EOF
 }
 
@@ -27,10 +27,10 @@ EOF
   mkdir -p "$PYENV_TEST_DIR"
   cd "$PYENV_TEST_DIR"
   echo 2.7 > .python-version
-  run pyenv-exec rspec
+  run pyenv-exec nonexistent
   assert_failure <<EOF
 pyenv: version \`2.7' is not installed (set by $PWD/.python-version)
-pyenv: rspec: command not found
+pyenv: nonexistent: command not found
 EOF
 }
 

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -17,7 +17,10 @@ create_executable() {
 @test "fails with invalid version" {
   export PYENV_VERSION="3.4"
   run pyenv-exec python -V
-  assert_failure "pyenv: version \`3.4' is not installed (set by PYENV_VERSION environment variable)"
+  assert_failure <<EOF
+pyenv: version \`3.4' is not installed (set by PYENV_VERSION environment variable)
+pyenv: python: command not found
+EOF
 }
 
 @test "fails with invalid version set from file" {
@@ -25,7 +28,10 @@ create_executable() {
   cd "$PYENV_TEST_DIR"
   echo 2.7 > .python-version
   run pyenv-exec rspec
-  assert_failure "pyenv: version \`2.7' is not installed (set by $PWD/.python-version)"
+  assert_failure <<EOF
+pyenv: version \`2.7' is not installed (set by $PWD/.python-version)
+pyenv: rspec: command not found
+EOF
 }
 
 @test "completes with names of executables" {

--- a/test/local.bats
+++ b/test/local.bats
@@ -41,6 +41,18 @@ setup() {
   assert [ "$(cat .python-version)" = "1.2.3" ]
 }
 
+@test "fails to set a nonexistent local version" {
+  run pyenv-local 1.2.3
+  assert_failure "pyenv: version \`1.2.3' not installed"
+  assert [ ! -e .python-version ]
+}
+
+@test "sets a nonexistent local version with --force" {
+  run pyenv-local -f 1.2.3
+  assert_success ""
+  assert [ "$(cat .python-version)" = "1.2.3" ]
+}
+
 @test "changes local version" {
   echo "1.0-pre" > .python-version
   mkdir -p "${PYENV_ROOT}/versions/1.2.3"

--- a/test/version-file-write.bats
+++ b/test/version-file-write.bats
@@ -21,6 +21,13 @@ setup() {
   assert [ ! -e ".python-version" ]
 }
 
+@test "setting nonexistent version succeeds with force" {
+  assert [ ! -e ".python-version" ]
+  run pyenv-version-file-write --force ".python-version" "2.7.6"
+  assert_success
+  assert [ -e ".python-version" ]
+}
+
 @test "writes value to arbitrary file" {
   mkdir -p "${PYENV_ROOT}/versions/2.7.6"
   assert [ ! -e "my-version" ]

--- a/test/version-file-write.bats
+++ b/test/version-file-write.bats
@@ -9,7 +9,7 @@ setup() {
 
 @test "invocation without 2 arguments prints usage" {
   run pyenv-version-file-write
-  assert_failure "Usage: pyenv version-file-write <file> <version>"
+  assert_failure "Usage: pyenv version-file-write [-f|--force] <file> <version> [...]"
   run pyenv-version-file-write "one" ""
   assert_failure
 }

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -73,6 +73,11 @@ SH
   assert_failure "pyenv: version \`1.2' is not installed (set by PYENV_VERSION environment variable)"
 }
 
+@test "missing version with --force" {
+  PYENV_VERSION=1.2 run pyenv-version-name -f
+  assert_success "1.2"
+}
+
 @test "one missing version (second missing)" {
   create_version "3.5.1"
   PYENV_VERSION="3.5.1:1.2" run pyenv-version-name

--- a/test/which.bats
+++ b/test/which.bats
@@ -80,6 +80,13 @@ create_executable() {
   assert_failure <<OUT
 pyenv: version \`2.7' is not installed (set by PYENV_VERSION environment variable)
 pyenv: version \`3.3' is not installed (set by PYENV_VERSION environment variable)
+pyenv: py.test: command not found
+   
+The \`py.test' command exists in these Python versions:
+  3.4
+
+ Note: See 'pyenv help global' for tips on allowing both
+       python2 and python3 to be found.
 OUT
 }
 

--- a/test/which.bats
+++ b/test/which.bats
@@ -71,7 +71,16 @@ create_executable() {
 @test "version not installed" {
   create_executable "3.4" "py.test"
   PYENV_VERSION=3.3 run pyenv-which py.test
-  assert_failure "pyenv: version \`3.3' is not installed (set by PYENV_VERSION environment variable)"
+  assert_failure <<OUT
+pyenv: version \`3.3' is not installed (set by PYENV_VERSION environment variable)
+pyenv: py.test: command not found
+   
+The \`py.test' command exists in these Python versions:
+  3.4
+
+ Note: See 'pyenv help global' for tips on allowing both
+       python2 and python3 to be found.
+OUT
 }
 
 @test "versions not installed" {


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2680

### Description
- [x] Here are some details about my PR

* If some of the set versions do not exist, executable resolution works without errors if an executable is found
  * as this corresponds to the current logic of selecting the first version that has the requested executable
* `pyenv local` supports `-f` to skip existence check

Supports deployments with a version-controlled `.python-version` that support any of a number of Python versions


### Tests
- [x] My PR adds the following unit tests (if any)
Tests for added switches for `pyenv local` and (internal) `pyenv version-name` and `pyenv version-file-write`