### PR TITLE
pyenv-init | performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,23 +656,25 @@ for the environment variables that control Pyenv's behavior.
 extra commands into your shell. Coming from RVM, some of you might be
 opposed to this idea. Here's what `eval "$(pyenv init -)"` actually does:
 
+1. **Finds current shell.**
+   `pyenv init` figures out what shell you are using, as the exact commands of `eval "$(pyenv init -)"` vary depending on shell. Specifying which shell you are using (e.g. `eval "$(pyenv init - bash)"`) is preferred, because it reduces launch time significantly.
 
-1. **Sets up the shims path.** This is what allows Pyenv to intercept
+2. **Sets up the shims path.** This is what allows Pyenv to intercept
    and redirect invocations of `python`, `pip` etc. transparently.
    It prepends `$(pyenv root)/shims` to your `$PATH`.
    It also deletes any other instances of `$(pyenv root)/shims` on `PATH`
    which allows to invoke `eval "$(pyenv init -)"` multiple times without
    getting duplicate `PATH` entries.
 
-2. **Installs autocompletion.** This is entirely optional but pretty
+3. **Installs autocompletion.** This is entirely optional but pretty
    useful. Sourcing `$(pyenv root)/completions/pyenv.bash` will set that
    up. There are also completions for Zsh and Fish.
 
-3. **Rehashes shims.** From time to time you'll need to rebuild your
+4. **Rehashes shims.** From time to time you'll need to rebuild your
    shim files. Doing this on init makes sure everything is up to
    date. You can always run `pyenv rehash` manually.
 
-4. **Installs `pyenv` into the current shell as a shell function.**
+5. **Installs `pyenv` into the current shell as a shell function.**
    This bit is also optional, but allows
    pyenv and plugins to change variables in your current shell.
    This is required for some commands like `pyenv shell` to work.
@@ -681,7 +683,7 @@ opposed to this idea. Here's what `eval "$(pyenv init -)"` actually does:
    for some reason you need `pyenv` to be a real script rather than a
    shell function, you can safely skip it.
 
-`eval "$(pyenv init --path)"` only does items 1 and 3.
+`eval "$(pyenv init --path)"` only does items 2 and 4.
 
 To see exactly what happens under the hood for yourself, run `pyenv init -`
 or `pyenv init --path`.

--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ opposed to this idea. Here's what `eval "$(pyenv init -)"` actually does:
    getting duplicate `PATH` entries.
 
 3. **Installs autocompletion.** This is entirely optional but pretty
-   useful. Sourcing `$(pyenv root)/completions/pyenv.bash` will set that
+   useful. Sourcing `<pyenv installation prefix>/completions/pyenv.bash` will set that
    up. There are also completions for Zsh and Fish.
 
 4. **Rehashes shims.** From time to time you'll need to rebuild your

--- a/README.md
+++ b/README.md
@@ -191,27 +191,27 @@ See [Advanced configuration](#advanced-configuration) for details and more confi
       ```bash
       echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
       echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-      echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+      echo 'eval "$(pyenv init - bash)"' >> ~/.bashrc
       ```
-  3. Then, if you have `~/.profile`, `~/.bash_profile` or `~/.bash_login`, add the commands there as well.
+  2. Then, if you have `~/.profile`, `~/.bash_profile` or `~/.bash_login`, add the commands there as well.
      If you have none of these, create a `~/.profile` and add the commands there.
 
      * to add to `~/.profile`:
        ``` bash
        echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.profile
        echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.profile
-       echo 'eval "$(pyenv init -)"' >> ~/.profile
+       echo 'eval "$(pyenv init - bash)"' >> ~/.profile
        ```
      * to add to `~/.bash_profile`:
        ```bash
        echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
        echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
-       echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
+       echo 'eval "$(pyenv init - bash)"' >> ~/.bash_profile
        ```
 
    **Bash warning**: There are some systems where the `BASH_ENV` variable is configured
    to point to `.bashrc`. On such systems, you should almost certainly put the
-   `eval "$(pyenv init -)"` line into `.bash_profile`, and **not** into `.bashrc`. Otherwise, you
+   `eval "$(pyenv init - bash)"` line into `.bash_profile`, and **not** into `.bashrc`. Otherwise, you
    may observe strange behaviour, such as `pyenv` getting into an infinite loop.
    See [#264](https://github.com/pyenv/pyenv/issues/264) for details.
    
@@ -224,7 +224,7 @@ See [Advanced configuration](#advanced-configuration) for details and more confi
   ```zsh
     echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
     echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
-    echo 'eval "$(pyenv init -)"' >> ~/.zshrc
+    echo 'eval "$(pyenv init - zsh)"' >> ~/.zshrc
   ```
   
   If you wish to get Pyenv in noninteractive login shells as well, also add the commands to `~/.zprofile` or `~/.zlogin`.
@@ -248,7 +248,7 @@ See [Advanced configuration](#advanced-configuration) for details and more confi
 
   3. Now, add this to `~/.config/fish/config.fish`:
      ~~~ fish
-       pyenv init - | source
+       pyenv init - fish | source
      ~~~
   </details>
 

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -253,52 +253,40 @@ function print_shell_function() {
   commands=(`pyenv-commands --sh`)
   case "$shell" in
   fish )
-    cat <<EOS
-function pyenv
+    echo "function pyenv
   set command \$argv[1]
   set -e argv[1]
 
-  switch "\$command"
+  switch \"\$command\"
   case ${commands[*]}
-    source (pyenv "sh-\$command" \$argv|psub)
+    source (pyenv \"sh-\$command\" \$argv|psub)
   case '*'
-    command pyenv "\$command" \$argv
+    command pyenv \"\$command\" \$argv
   end
-end
-EOS
+end"
     ;;
   ksh | ksh93 | mksh )
-    cat <<EOS
-function pyenv {
-  typeset command
-EOS
+    echo "function pyenv {
+  typeset command=\$1"
     ;;
   * )
-    cat <<EOS
-pyenv() {
-  local command
-EOS
+    echo "pyenv() {
+  local command=\$1"
     ;;
   esac
 
   if [ "$shell" != "fish" ]; then
     IFS="|"
-    cat <<EOS
-  command="\${1:-}"
-  if [ "\$#" -gt 0 ]; then
-    shift
-  fi
-
-  case "\$command" in
+    echo "  [ \"\$#\" -gt 0 ] && shift
+  case \"\$command\" in
   ${commands[*]:-/})
-    eval "\$(pyenv "sh-\$command" "\$@")"
+    eval \"\$(pyenv \"sh-\$command\" \"\$@\")\"
     ;;
   *)
-    command pyenv "\$command" "\$@"
+    command pyenv \"\$command\" \"\$@\"
     ;;
   esac
-}
-EOS
+}"
   fi
 }
 

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -60,8 +60,6 @@ if [ -z "$shell" ]; then
   shell="${shell%%-*}"
 fi
 
-root="${0%/*}/.."
-
 function main() {
   case "$mode" in
   "help")
@@ -244,7 +242,7 @@ function print_env() {
 }
 
 function print_completion() {
-  completion="${root}/completions/pyenv.${shell}"
+  completion="${PYENV_ROOT}/completions/pyenv.${shell}"
   if [ -r "$completion" ]; then
     echo "source '$completion'"
   fi

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -237,7 +237,7 @@ function print_env() {
 }
 
 function print_completion() {
-  completion="${PYENV_ROOT}/completions/pyenv.${shell}"
+  completion="${0%/*/*}/completions/pyenv.${shell}"
   if [ -r "$completion" ]; then
     echo "source '$completion'"
   fi

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -22,35 +22,37 @@ fi
 mode="help"
 no_rehash=""
 no_push_path=""
-for args in "$@"
-do
-  if [ "$args" = "-" ]; then
-    mode="print"
-    shift
-  fi
+shell=""
 
-  if [ "$args" = "--path" ]; then
-    mode="path"
-    shift
-  fi
-
-  if [ "$args" = "--detect-shell" ]; then
-    mode="detect-shell"
-    shift
-  fi
-
-  if [ "$args" = "--no-push-path" ]; then
-    no_push_path=1
-    shift
-  fi
-  
-  if [ "$args" = "--no-rehash" ]; then
-    no_rehash=1
-    shift
-  fi
+for arg in "$@"; do
+  case "$arg" in
+    -)
+      mode="print"
+      ;;
+    zsh|bash|ksh|fish)
+      shell="$arg"
+      ;;
+    --path)
+      mode="path"
+      ;;
+    --detect-shell)
+      mode="detect-shell"
+      ;;
+    --no-push-path)
+      no_push_path=1
+      ;;
+    --no-rehash)
+      no_rehash=1
+      ;;
+    *)
+      echo "Warning: Unknown option '$arg'" >&2
+      echo "Run 'pyenv init --help' for usage." >&2
+      exit 1
+      ;;
+  esac
 done
 
-shell="$1"
+# If shell is not provided, detect it.
 if [ -z "$shell" ]; then
   shell="$(ps -p "$PPID" -o 'args=' 2>/dev/null || true)"
   shell="${shell%% *}"

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -24,13 +24,10 @@ no_rehash=""
 no_push_path=""
 shell=""
 
-for arg in "$@"; do
-  case "$arg" in
+while [ "$#" -gt 0 ]; do
+  case "$1" in
     -)
       mode="print"
-      ;;
-    zsh|bash|ksh|fish)
-      shell="$arg"
       ;;
     --path)
       mode="path"
@@ -45,11 +42,10 @@ for arg in "$@"; do
       no_rehash=1
       ;;
     *)
-      echo "Warning: Unknown option '$arg'" >&2
-      echo "Run 'pyenv init --help' for usage." >&2
-      exit 1
+      shell="$1"
       ;;
   esac
+  shift
 done
 
 # If shell is not provided, detect it.

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -159,7 +159,7 @@ function help_() {
       echo
       echo 'export PYENV_ROOT="$HOME/.pyenv"'
       echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
-      echo "eval \"\$(pyenv init - $shell)\""
+      echo 'eval "$(pyenv init -'$shell')"'
       ;;
     esac
     echo
@@ -253,40 +253,40 @@ function print_shell_function() {
   commands=(`pyenv-commands --sh`)
   case "$shell" in
   fish )
-    echo "function pyenv
-  set command \$argv[1]
+    echo 'function pyenv
+  set command $argv[1]
   set -e argv[1]
 
-  switch \"\$command\"
-  case ${commands[*]}
-    source (pyenv \"sh-\$command\" \$argv|psub)
-  case '*'
-    command pyenv \"\$command\" \$argv
+  switch "$command"
+  case '"${commands[*]}"'
+    source (pyenv "sh-$command" $argv|psub)
+  case "*"
+    command pyenv "$command" $argv
   end
-end"
+end'
     ;;
   ksh | ksh93 | mksh )
-    echo "function pyenv {
-  typeset command=\$1"
+    echo 'function pyenv {
+  typeset command=$1'
     ;;
   * )
-    echo "pyenv() {
-  local command=\$1"
+    echo 'pyenv() {
+  local command=$1'
     ;;
   esac
 
   if [ "$shell" != "fish" ]; then
     IFS="|"
-    echo "  [ \"\$#\" -gt 0 ] && shift
-  case \"\$command\" in
-  ${commands[*]:-/})
-    eval \"\$(pyenv \"sh-\$command\" \"\$@\")\"
+    echo '  [ "$#" -gt 0 ] && shift
+  case "$command" in
+  '"${commands[*]:-/}"')
+    eval "$(pyenv "sh-$command" "$@")"
     ;;
   *)
-    command pyenv \"\$command\" \"\$@\"
+    command pyenv "$command" "$@"
     ;;
   esac
-}"
+}'
   fi
 }
 

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -150,7 +150,7 @@ function help_() {
       echo "# Load pyenv automatically by appending"
       echo "# the following to ~/.config/fish/config.fish:"
       echo
-      echo 'pyenv init - | source'
+      echo 'pyenv init - fish | source'
       echo
       ;;
     * )
@@ -166,7 +166,7 @@ function help_() {
       echo
       echo 'export PYENV_ROOT="$HOME/.pyenv"'
       echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
-      echo 'eval "$(pyenv init -)"'
+      echo "eval \"\$(pyenv init - $shell)\""
       ;;
     esac
     echo

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -20,9 +20,6 @@ if [ "$1" = "--complete" ]; then
 fi
 
 mode="help"
-no_rehash=""
-no_push_path=""
-shell=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -253,7 +253,8 @@ function print_shell_function() {
   commands=(`pyenv-commands --sh`)
   case "$shell" in
   fish )
-    echo 'function pyenv
+    echo \
+'function pyenv
   set command $argv[1]
   set -e argv[1]
 
@@ -266,18 +267,21 @@ function print_shell_function() {
 end'
     ;;
   ksh | ksh93 | mksh )
-    echo 'function pyenv {
-  typeset command=$1'
+    echo \
+'function pyenv {
+  typeset command=${1:-}'
     ;;
   * )
-    echo 'pyenv() {
-  local command=$1'
+    echo \
+'pyenv() {
+  local command=${1:-}'
     ;;
   esac
 
   if [ "$shell" != "fish" ]; then
     IFS="|"
-    echo '  [ "$#" -gt 0 ] && shift
+    echo \
+'  [ "$#" -gt 0 ] && shift
   case "$command" in
   '"${commands[*]:-/}"')
     eval "$(pyenv "sh-$command" "$@")"

--- a/test/init.bats
+++ b/test/init.bats
@@ -36,11 +36,10 @@ create_executable() {
 }
 
 @test "setup shell completions" {
-  root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
-  export PYENV_ROOT=$root
+  exec_root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
   run pyenv-init - bash
   assert_success
-  assert_line "source '${root}/completions/pyenv.bash'"
+  assert_line "source '${exec_root}/completions/pyenv.bash'"
 }
 
 @test "detect parent shell" {
@@ -63,11 +62,10 @@ OUT
 }
 
 @test "setup shell completions (fish)" {
-  root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
-  export PYENV_ROOT=$root
+  exec_root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
   run pyenv-init - fish
   assert_success
-  assert_line "source '${root}/completions/pyenv.fish'"
+  assert_line "source '${exec_root}/completions/pyenv.fish'"
 }
 
 @test "fish instructions" {

--- a/test/init.bats
+++ b/test/init.bats
@@ -72,7 +72,7 @@ OUT
 @test "fish instructions" {
   run pyenv-init fish
   assert [ "$status" -eq 1 ]
-  assert_line 'pyenv init - | source'
+  assert_line 'pyenv init - fish | source'
 }
 
 @test "shell detection for installer" {

--- a/test/init.bats
+++ b/test/init.bats
@@ -35,12 +35,12 @@ create_executable() {
   assert_line "command pyenv rehash 2>/dev/null"
 }
 
-
 @test "setup shell completions" {
   root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
+  export PYENV_ROOT=$root
   run pyenv-init - bash
   assert_success
-  assert_line "source '${root}/test/../libexec/../completions/pyenv.bash'"
+  assert_line "source '${root}/completions/pyenv.bash'"
 }
 
 @test "detect parent shell" {
@@ -64,9 +64,10 @@ OUT
 
 @test "setup shell completions (fish)" {
   root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
+  export PYENV_ROOT=$root
   run pyenv-init - fish
   assert_success
-  assert_line "source '${root}/test/../libexec/../completions/pyenv.fish'"
+  assert_line "source '${root}/completions/pyenv.fish'"
 }
 
 @test "fish instructions" {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -21,7 +21,7 @@ if [ -z "$PYENV_TEST_DIR" ]; then
 
   PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
   PATH="${PYENV_TEST_DIR}/bin:$PATH"
-  PATH="${BATS_TEST_DIRNAME}/../libexec:$PATH"
+  PATH="${BATS_TEST_DIRNAME%/*}/libexec:$PATH"
   PATH="${BATS_TEST_DIRNAME}/libexec:$PATH"
   PATH="${PYENV_ROOT}/shims:$PATH"
   export PATH


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Addresses https://github.com/pyenv/pyenv/issues/2918

### Description
- [x] Here are some details about my PR

1) Changed the local pyenv function generated by `pyenv init -`, and replaced calls to `cat` with calls to `echo`. 

Instead of having:

```
pyenv() {
  local command
  command="${1:-}"
  if [ "$#" -gt 0 ]; then
    shift
  fi

  case "$command" in
  activate|deactivate|rehash|shell)
    eval "$(pyenv "sh-$command" "$@")"
    ;;
  *)
    command pyenv "$command" "$@"
    ;;
  esac
}
```

We now get:

```
pyenv() {
  local command=$1
  [ "$#" -gt 0 ] && shift
  case "$command" in
  activate|deactivate|rehash|shell)
    eval "$(pyenv "sh-$command" "$@")"
    ;;
  *)
    command pyenv "$command" "$@"
    ;;
  esac
}
```

2) DOCUMENTATION: Update README.md to make people specify their shell when setting up `pyenv init` in their shell configuration file.

Example:

Under the section: Set up shell environment for zsh:

```
echo 'eval "$(pyenv init - zsh)"' >> ~/.zshrc
```

Instead of 

```
echo 'eval "$(pyenv init -)"' >> ~/.zshrc
```

My computer uses 50ms on `pyenv init -`, and 30ms on `pyenv init - zsh`. Simple speedup.

3) General code cleanup in `pyenv-init`
Removed unnecessary declarations of variables: (e. g. `no_rehash=""`), replaced a series of if-statements with a `case` block (code essentially imported from rbenv), and change `completions path` such that we get:

```
source '/home/christian/.pyenv/completions/pyenv.zsh'
```
(essentially `PYENV_ROOT/completions/pyenv.zsh`)

instead of:

```
source '/home/christian/.pyenv/libexec/../completions/pyenv.zsh'
```
(equal to something like: `$(dirname "$(realpath pyenv-init)")/../completions/pyenv.zsh`)

RESULTS:

The first command is run by `master` branch, second command is used with perf improvements.

![Bildschirmfoto vom 2024-12-19 16-50-47](https://github.com/user-attachments/assets/a864d16f-3137-46e5-9b64-c581487633dc)
![Bildschirmfoto vom 2024-12-19 16-52-16](https://github.com/user-attachments/assets/b9d3fd00-0cd6-4682-b8fa-075d9efd98ab)

Not much to speak of, but will hopefully come with more improvements later. Interestingly, the speedup seems to be more significant when `zsh` is specified.

### Tests
- [x] My PR adds the following unit tests (if any)

3 tests have been modified, all inside `test/init.bats`. 

* **fish instructions**: Now expects `pyenv init - fish | source`
* **setup shell completions** and **setup shell completions (fish)**:  `PYENV_ROOT` is exported before running `pyenv init - <shell>`. 

```
@test "setup shell completions" {
  root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
  export PYENV_ROOT=$root
  run pyenv-init - bash
  assert_success
  assert_line "source '${root}/completions/pyenv.bash'"
}
```

Assumes that `BATS_TEST_DIRNAME/..` is equal to `PYENV_ROOT`. Enables us to have a simpler path for sourcing of completions, as mentioned in point (3) above.