### PR TITLE
[WIP] fix: add `python -m pip` command to pip hook-script.

### DIFF
--- a/pyenv.d/exec/pip-rehash.bash
+++ b/pyenv.d/exec/pip-rehash.bash
@@ -6,9 +6,13 @@ if [[ $PYENV_REHASH_COMMAND =~ ^(pip|easy_install)[23](\.\d)?$ ]]; then
   PYENV_REHASH_COMMAND="${BASH_REMATCH[1]}"
 fi
 
-if [[ $1 == "python" && $2 == "-m" && $3 == "pip" ]]; then
-  PYENV_REHASH_COMMAND="pip"
-fi
+for (( i=1; i<$#; i++ )); do
+  next=$((i+1))
+  if [[ ${!i} == "-m" && ${!next} == "pip" ]]; then
+    PYENV_REHASH_COMMAND="pip"
+    break
+  fi
+done
 
 if [ -x "${PYENV_PIP_REHASH_ROOT}/${PYENV_REHASH_COMMAND}" ]; then
   PYENV_COMMAND_PATH="${PYENV_PIP_REHASH_ROOT}/${PYENV_REHASH_COMMAND##*/}"

--- a/pyenv.d/exec/pip-rehash.bash
+++ b/pyenv.d/exec/pip-rehash.bash
@@ -6,6 +6,10 @@ if [[ $PYENV_REHASH_COMMAND =~ ^(pip|easy_install)[23](\.\d)?$ ]]; then
   PYENV_REHASH_COMMAND="${BASH_REMATCH[1]}"
 fi
 
+if [[ $1 == "python" && $2 == "-m" && $3 == "pip" ]]; then
+  PYENV_REHASH_COMMAND="pip"
+fi
+
 if [ -x "${PYENV_PIP_REHASH_ROOT}/${PYENV_REHASH_COMMAND}" ]; then
   PYENV_COMMAND_PATH="${PYENV_PIP_REHASH_ROOT}/${PYENV_REHASH_COMMAND##*/}"
   PYENV_BIN_PATH="${PYENV_PIP_REHASH_ROOT}"


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3031

### Description
- [x] Here are some details about my PR

Currently, `pyenv` does NOT do an automatic `rehash` after doing `python -m pip install ...` which is different from the behavior you get when doing `pip install ...`

As was mentioned in #3031, if you do:

`pip install black`
Then you can immediately do:
`black --version`

But if you do:
`python -m pip install black` 

You get something like **command not found**, if you do `black --version`. The following PR will fix this issue.

DETAILED:

When doing `pip install ...`, the command is redirected to
`pyenv.d/exec/pip-rehash/pip`, which does a `pyenv rehash` after
installation. A simple fix to issue #3031 is to make `python -m pip`
commands go through the same special hook script.

If you do `python -m pip install black`, then the main scripts which are read are:

$PYENV_ROOT/shims/python ->
./libexec/pyenv ->
./libexec/pyenv-exec ->
./pyenv.d/exec/pip-rehash/pip

NEEDS TO BE DONE:

Will need to make this work with edge cases like: `python3.12 -m pip install ...` and so forth.

One possible solution, as mentioned by @native-api is to simply check for `-m pip` in the command which is being executed.

The solution should not be too heavy, as the `pyenv.d/exec/pip-rehash.bash` script is sourced every time a python related command is being run (e.g. `python main.py`), and on my computer it already takes ~180ms to run `python --version` :O

### Tests
- [x] My PR adds the following unit tests (if any)

No tests have been added, but we should DEFINITELY add some tests which check that a rehash is performed when doing `python -m pip install ...` and when doing `pip install ...`, as such tests are not present in the `test` folder.