### PR TITLE
Exclude broken 22.11.0-0, 22.11.0-1, 22.11.0-2 from generation

### DIFF
--- a/plugins/python-build/scripts/add_miniforge.py
+++ b/plugins/python-build/scripts/add_miniforge.py
@@ -13,6 +13,13 @@ logging.basicConfig(level=os.environ.get('LOGLEVEL', 'INFO'))
 MINIFORGE_REPO = 'conda-forge/miniforge'
 DISTRIBUTIONS = ['miniforge', 'mambaforge']
 
+SKIPPED_RELEASES = [
+    '4.13.0-0',     #has no Mambaforge. We already generated scripts for Miniforge
+    '22.11.1-0',    #MacOS packages are broken (have broken dep tarballs, downloading them fails with 403)
+    '22.11.1-1',    #MacOS packages are broken (have broken dep tarballs, downloading them fails with 403)
+    '22.11.1-2',    #MacOS packages are broken (have broken dep tarballs, downloading them fails with 403)
+]
+
 install_script_fmt = """
 case "$(anaconda_architecture 2>/dev/null || true)" in
 {install_lines}
@@ -119,7 +126,7 @@ for release in requests.get(f'https://api.github.com/repos/{MINIFORGE_REPO}/rele
     # Build scripts for miniforge3-4.13.0-0 have already been generated.
     # Assuming this was a fluke, we don't yet need to implement proactively checking all releases for contents
     # or ignoring a release if _any_ of the flavors is already present in Pyenv.
-    if version == '4.13.0-0':
+    if version in SKIPPED_RELEASES:
         continue
 
     if any(not list(out_dir.glob(f'{distribution}*-{version}')) for distribution in DISTRIBUTIONS):


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

MacOS packages are broken
Have some invalid dep tarballs, downloading them fails with 403.

Could leave Linux packages or produce a warning but since these are effectively broken releases,
they can be considered revoked for the purpose of usage.
We can revisit this and do smth else if there's ever user demand.

### Tests
- [x] My PR adds the following unit tests (if any)
N/A