### PR TITLE
fix: silly docs mistake in `pyenv init`.

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -159,7 +159,7 @@ function help_() {
       echo
       echo 'export PYENV_ROOT="$HOME/.pyenv"'
       echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
-      echo 'eval "$(pyenv init -' $shell')"'
+      echo 'eval "$(pyenv init - '$shell')"'
       ;;
     esac
     echo

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -159,7 +159,7 @@ function help_() {
       echo
       echo 'export PYENV_ROOT="$HOME/.pyenv"'
       echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
-      echo 'eval "$(pyenv init -'$shell')"'
+      echo 'eval "$(pyenv init -' $shell')"'
       ;;
     esac
     echo

--- a/man/man1/pyenv.1
+++ b/man/man1/pyenv.1
@@ -14,7 +14,7 @@ pyenv lets you easily switch between multiple versions of Python\. It's simple, 
 .RS 15
 .nf
 if command -v pyenv 1>/dev/null 2>&1; then\n
-   eval "$(pyenv init -)" \n
+   eval "$(pyenv init - bash)" \n
 fi
 .fi
 .RE


### PR DESCRIPTION
### Description

A silly documentation mistake I made in my previously merged stuff.
Please don't shoot me 😘

-> Currently we get:
```zsh
pyenv init
# Load pyenv automatically by appending
# the following to
# ~/.zprofile (for login shells)
# and ~/.zshrc (for interactive shells) :

export PYENV_ROOT="$HOME/.pyenv"
[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
eval "$(pyenv init -zsh)"
```

But it should obviously be `pyenv init - zsh`.

### Tests
- [x] My PR adds the following unit tests (if any)

none