### PR TITLE
fix: do NOT execute conda specific code if conda not installed

### DIFF
--- a/pyenv.d/rehash/conda.bash
+++ b/pyenv.d/rehash/conda.bash
@@ -18,13 +18,11 @@ if conda_exists; then
   # `conda_shim` to skip creating shims for those binaries.
   build_conda_exclusion_list() {
     shims=()
-    shopt -s nullglob
-    for shim in $(cat "${BASH_SOURCE%/*}/conda.d/"*".list" | sort -u | sed -e 's/#.*$//' | sed -e '/^[[:space:]]*$/d'); do
+    for shim in $(sed 's/#.*$//; /^[[:space:]]*$/d' "${BASH_SOURCE%/*}/conda.d/default.list"); do
       if [ -n "${shim##*/}" ]; then
         shims[${#shims[*]}]="${shim})return 0;;"
       fi
     done
-    shopt -u nullglob
     eval \
 "conda_shim() {
   case \"\${1##*/}\" in

--- a/pyenv.d/rehash/conda.bash
+++ b/pyenv.d/rehash/conda.bash
@@ -11,48 +11,64 @@ conda_exists() {
   [ -n "${condas}" ]
 }
 
-shims=()
-shopt -s nullglob
-for shim in $(cat "${BASH_SOURCE%/*}/conda.d/"*".list" | sort | uniq | sed -e 's/#.*$//' | sed -e '/^[[:space:]]*$/d'); do
-  if [ -n "${shim##*/}" ]; then
-    shims[${#shims[*]}]="${shim})return 0;;"
-  fi
-done
-shopt -u nullglob
-eval "conda_shim(){ case \"\${1##*/}\" in ${shims[@]} *)return 1;;esac;}"
-
-# override `make_shims` to avoid conflict between pyenv-virtualenv's `envs.bash`
-# https://github.com/pyenv/pyenv-virtualenv/blob/v20160716/etc/pyenv.d/rehash/envs.bash
-make_shims() {
-  local file shim
-  for file do
-    shim="${file##*/}"
-    if ! conda_shim "${shim}" 1>&2; then
-      register_shim "$shim"
-    fi
-  done
-}
-
-deregister_conda_shims() {
-  # adapted for Bash 4.x's associative array (#1749)
-  if declare -p registered_shims 2> /dev/null | grep -Eq '^(declare|typeset) -A'; then
-    for shim in ${!registered_shims[*]}; do
-      if conda_shim "${shim}" 1>&2; then
-        unset registered_shims[${shim}]
-      fi
-    done
-  else
-    local shim
-    local shims=()
-    for shim in ${registered_shims}; do
-      if ! conda_shim "${shim}" 1>&2; then
-        shims[${#shims[*]}]="${shim}"
-      fi
-    done
-    registered_shims=" ${shims[@]} "
-  fi
-}
-
 if conda_exists; then
+
+  # Reads the list of `blacklisted` conda binaries
+  # from `conda.d/default.list` and creates a function
+  # `conda_shim` to skip creating shims for those binaries.
+  build_conda_exclusion_list() {
+    shims=()
+    shopt -s nullglob
+    for shim in $(cat "${BASH_SOURCE%/*}/conda.d/"*".list" | sort -u | sed -e 's/#.*$//' | sed -e '/^[[:space:]]*$/d'); do
+      if [ -n "${shim##*/}" ]; then
+        shims[${#shims[*]}]="${shim})return 0;;"
+      fi
+    done
+    shopt -u nullglob
+    eval \
+"conda_shim() {
+  case \"\${1##*/}\" in
+    ${shims[@]}
+    *) return 1;;
+  esac
+}"
+  }
+
+  # override `make_shims` to avoid conflict between pyenv-virtualenv's `envs.bash`
+  # https://github.com/pyenv/pyenv-virtualenv/blob/v20160716/etc/pyenv.d/rehash/envs.bash
+  # The only difference between this `make_shims` and the `make_shims` defined
+  # in `libexec/pyenv-rehash` is that this one calls `conda_shim` to check
+  # if shim is blacklisted. If blacklisted -> skip creating shim.
+  make_shims() {
+    local file shim
+    for file do
+      shim="${file##*/}"
+      if ! conda_shim "${shim}" 1>&2; then
+        register_shim "$shim"
+      fi
+    done
+  }
+
+  deregister_conda_shims() {
+    # adapted for Bash 4.x's associative array (#1749)
+    if declare -p registered_shims 2> /dev/null | grep -Eq '^(declare|typeset) -A'; then
+      for shim in ${!registered_shims[*]}; do
+        if conda_shim "${shim}" 1>&2; then
+          unset registered_shims[${shim}]
+        fi
+      done
+    else
+      local shim
+      local shims=()
+      for shim in ${registered_shims}; do
+        if ! conda_shim "${shim}" 1>&2; then
+          shims[${#shims[*]}]="${shim}"
+        fi
+      done
+      registered_shims=" ${shims[@]} "
+    fi
+  }
+
+  build_conda_exclusion_list
   deregister_conda_shims
 fi

--- a/pyenv.d/rehash/conda.d/default.list
+++ b/pyenv.d/rehash/conda.d/default.list
@@ -117,6 +117,7 @@ factor
 false
 fmt
 fold
+greadlink
 groups
 head
 hostid
@@ -192,4 +193,3 @@ who
 whoami
 yes
 # --- end exclusions from coreutils
-greadlink


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite

* [x] My PR addresses the following pyenv issue (if any)
  -  Addresses https://github.com/pyenv/pyenv/issues/2918

### Description
- [x] Here are some details about my PR

I was doing some debugging with PYENV_DEBUG=1 and noticed that a lot of
work was being done in conda.bash, even though I have not installed any
conda versions like `mambaforge`.

The solution is pretty simple, put all the code inside an if-block.
This aligns with what @varikin found in his pull request #3037

Additionally, I have refactored the code slightly for readability
(created function `build_conda_exclusion_list`), and added comments
which should make it easier to understand what's going on.

In a later commit, I also did some slight performance improvements to `pyenv.d/rehash/conda.bash`.
This PR simplifies debugging and should slightly reduce the execution time of

```bash
pyenv rehash
```

And by extension, the execution time of:

```bash
eval "$(pyenv init -)"
```

will be reduced slightly, especially if conda is not installed.

(NOTE: I am finding that it should be completely unnecessary to do a rehash upon init. I recommend using `pyenv init --no-rehash -` and would advocate for having --no-rehash as default option. Reason being that we have automatic rehash when installing/uninstalling python versions, and when doing `pip` install/uninstall, and thus it all goes automatically.)

### Tests
- [x] My PR adds the following unit tests (if any)

No tests added