### PR TITLE
Add standard curl arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The Homebrew option from the [MacOS section below](#macos) would also work if yo
 ##### 1. Automatic installer (Recommended)
 
 ```bash
-curl https://pyenv.run | bash
+curl -fsSL https://pyenv.run | bash
 ```
 
 For more details visit our other project:


### PR DESCRIPTION
Most importantly, `-f` instructs curl to fail if the request fails. The other arguments are not strictly necessary, but `-fsSL` is standard boilerplate that many users of curl will recognize.

More details here; https://explainshell.com/explain?cmd=curl+-fsSL+example.org
