### PR TITLE
Support compiler sanitizer options in python-build

### DIFF
--- a/plugins/python-build/README.md
+++ b/plugins/python-build/README.md
@@ -164,6 +164,12 @@ You can set certain environment variables to control the build process.
 * `PYTHON_BUILD_SKIP_HOMEBREW`, if set, will not search for libraries installed by Homebrew when it would normally will.
 * `PYTHON_BUILD_USE_HOMEBREW`, if set, will search for libraries installed by Homebrew when it would normally not.
 * `PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA`, override the Homebrew OpenSSL formula to use.
+* `PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL`, add DWARF debug information on MacOS. Available on Python 3.12 and newer.
+* `PYTHON_BUILD_FREE_THREADING`, build an interpreter with the free-threaded (GIL-disabled) ABI. Available on Python 3.13 and newer.
+* `PYTHON_BUILD_ADDRESS_SANITIZER`, build an interpreter with address sanitizer.
+* `PYTHON_BUILD_MEMORY_SANITIZER`, build an interpreter with memory sanitizer.
+* `PYTHON_BUILD_UNDEFINED_BEHAVIOR_SANITIZER`, build an interpreter with undefined behavior sanitizer.
+* `PYTHON_BUILD_THREAD_SANITIZER`, build an interpreter with thread sanitizer. Available on Python 3.13 and newer.
 * `PYTHON_BUILD_ROOT` overrides the default location from where build definitions
   in `share/python-build/` are looked up.
 * `PYTHON_BUILD_DEFINITIONS` can be a list of colon-separated paths that get

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -826,6 +826,10 @@ build_package_standard_build() {
     fi
     use_dsymutil || true
     use_free_threading || true
+    use_address_sanitizer || true
+    use_memory_sanitizer || true
+    use_undefined_behavior_sanitizer || true
+    use_thread_sanitizer || true
   fi
 
   ( if [[ -n "${!PACKAGE_CFLAGS}" ]]; then
@@ -1767,6 +1771,30 @@ use_dsymutil() {
 use_free_threading() {
   if [[ -n "$PYTHON_BUILD_FREE_THREADING" ]]; then
     package_option python configure --disable-gil
+  fi
+}
+
+use_address_sanitizer() {
+  if [[ -n "$PYTHON_BUILD_ADDRESS_SANITIZER" ]]; then
+    package_option python configure --with-address-sanitizer
+  fi
+}
+
+use_memory_sanitizer() {
+  if [[ -n "$PYTHON_BUILD_MEMORY_SANITIZER" ]]; then
+    package_option python configure --with-memory-sanitizer
+  fi
+}
+
+use_undefined_behavior_sanitizer() {
+  if [[ -n "$PYTHON_BUILD_UNDEFINED_BEHAVIOR_SANITIZER" ]]; then
+    package_option python configure --with-undefined-behavior-sanitizer
+  fi
+}
+
+use_thread_sanitizer() {
+  if [[ -n "$PYTHON_BUILD_THREAD_SANITIZER" ]]; then
+    package_option python configure --with-thread-sanitizer
   fi
 }
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.


### Description
- [x] Here are some details about my PR

Adds a way to enable compiler sanitizers at build time via environment variables in a script, similar to other options.

Also add docs as well as docs for variables that are already in the plugin but aren't documented yet.

### Tests

I tested this locally - it's not clear to me how to add a formal test for this.