### PR TITLE
Fix OpenSSL version parsing in python-build script

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1621,7 +1621,7 @@ build_package_mac_openssl() {
 openssl_version() {
   local -a ver
   IFS=- ver=( ${1:?} )
-  IFS=. ver=( ${ver[0]} )
+  IFS=. ver=( ${ver[1]} )
   [[ ${ver[2]} =~ '^([[:digit:]]+)[[:alpha:]]$' ]] && ver[2]="${BASH_REMATCH[1]}"
   echo $(( ${ver[0]}*10000 + ${ver[1]}*100 + ${ver[2]} ))
 }


### PR DESCRIPTION
### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * This is a bug fix in the core functionality of version parsing, not suitable for a plugin implementation.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * This is a Python-specific OpenSSL version parsing fix, not applicable to rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  * N/A - This is a standalone bug fix

### Description
- [x] Here are some details about my PR:
  * Fixes OpenSSL version parsing in the `openssl_version()` function
  * The function was incorrectly parsing the first element of the version array instead of the second element after splitting on '-'
  * Changed `ver[0]` to `ver[1]` to correctly extract the version number portion
  * This ensures proper version comparison for OpenSSL builds

### Tests
- [x] My PR adds the following unit tests:
  * No new tests added as this is a simple version parsing fix
  * The fix can be verified by building Python versions that depend on different OpenSSL versions