### PR TITLE
Add CPython 3.12.9 and 3.13.2

### DIFF
--- a/plugins/python-build/share/python-build/3.12.9
+++ b/plugins/python-build/share/python-build/3.12.9
@@ -1,0 +1,9 @@
+prefer_openssl3
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-3.3.2" "https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.3.2.tar.gz#2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+    install_package "Python-3.12.9" "https://www.python.org/ftp/python/3.12.9/Python-3.12.9.tar.xz#7220835d9f90b37c006e9842a8dff4580aaca4318674f947302b8d28f3f81112" standard verify_py312 copy_python_gdb ensurepip
+else
+    install_package "Python-3.12.9" "https://www.python.org/ftp/python/3.12.9/Python-3.12.9.tgz#45313e4c5f0e8acdec9580161d565cf5fea578e3eabf25df7cc6355bf4afa1ee" standard verify_py312 copy_python_gdb ensurepip
+fi

--- a/plugins/python-build/share/python-build/3.13.2
+++ b/plugins/python-build/share/python-build/3.13.2
@@ -1,0 +1,9 @@
+prefer_openssl3
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-3.4.0" "https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz#e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+    install_package "Python-3.13.2" "https://www.python.org/ftp/python/3.13.2/Python-3.13.2.tar.xz#d984bcc57cd67caab26f7def42e523b1c015bbc5dc07836cf4f0b63fa159eb56" standard verify_py313 copy_python_gdb ensurepip
+else
+    install_package "Python-3.13.2" "https://www.python.org/ftp/python/3.13.2/Python-3.13.2.tgz#b8d79530e3b7c96a5cb2d40d431ddb512af4a563e863728d8713039aa50203f9" standard verify_py313 copy_python_gdb ensurepip
+fi

--- a/plugins/python-build/share/python-build/3.13.2t
+++ b/plugins/python-build/share/python-build/3.13.2t
@@ -1,0 +1,2 @@
+export PYTHON_BUILD_FREE_THREADING=1
+source "$(dirname "${BASH_SOURCE[0]}")"/3.13.2


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
