### PR TITLE
Add MacPorts support for python-build

### DIFF
--- a/plugins/python-build/README.md
+++ b/plugins/python-build/README.md
@@ -138,6 +138,17 @@ would break all Pyenv-managed installations that depend on it.
 You can use a [community plugin `fix-version`](https://github.com/pyenv/pyenv/wiki/Plugins#community-plugins)
 to fix installations in such a case.
 
+##### MacPorts
+
+MacPorts Homebrew is used to find dependency packages if `port` is found on `PATH` in MacOS.
+
+Set `PYTHON_BUILD_USE_MACPORTS` or `PYTHON_BUILD_SKIP_MACPORTS` to override this default.
+
+###### Interaction with Homebrew
+
+If both Homebrew and MacPorts are installed and allowed to be used, Homebrew takes preference.
+There first ecosystem where any of the required dependency packages is found is used.
+
 ##### Portage
 
 In FreeBSD, if `pkg` is on PATH, Ports are searched for some dependencies that Configure is known to not search for via `pkg-config`.
@@ -164,6 +175,8 @@ You can set certain environment variables to control the build process.
 * `PYTHON_BUILD_SKIP_HOMEBREW`, if set, will not search for libraries installed by Homebrew when it would normally will.
 * `PYTHON_BUILD_USE_HOMEBREW`, if set, will search for libraries installed by Homebrew when it would normally not.
 * `PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA`, override the Homebrew OpenSSL formula to use.
+* `PYTHON_BUILD_SKIP_MACPORTS`, if set, will not search for libraries installed by MacPorts when it would normally will.
+* `PYTHON_BUILD_USE_MACPORTS`, if set, will search for libraries installed by MacPorts when it would normally not.
 * `PYTHON_BUILD_ROOT` overrides the default location from where build definitions
   in `share/python-build/` are looked up.
 * `PYTHON_BUILD_DEFINITIONS` can be a list of colon-separated paths that get

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -128,10 +128,36 @@ can_use_homebrew() {
   }
   [[ -n "$PYTHON_BUILD_USE_HOMEBREW" ]] && return 0
   [[ -n "$PYTHON_BUILD_SKIP_HOMEBREW" ]] && return 1
-  is_mac && return 0
+  is_mac && command -v brew &>/dev/null && return 0
   # In Linux, if Pyenv itself is installed with Homebrew,
   # we assume the user wants to take dependencies from there as well by default
   command -v brew &>/dev/null && [[ $(abs_dirname "${BASH_SOURCE}") == "$(abs_dirname "$(brew --prefix 2>/dev/null ||true)")"/* ]] && return 0
+  return 1
+}
+
+can_use_macports() {
+  [[ -n "$PYTHON_BUILD_USE_MACPORTS" && -n "$PYTHON_BUILD_SKIP_MACPORTS" ]] && {
+    echo "error: mutually exclusive environment variables PYTHON_BUILD_USE_MACPORTS and PYTHON_BUILD_SKIP_MACPORTS are set" >&3
+    exit 1
+  }
+  [[ -n "$PYTHON_BUILD_USE_MACPORTS" ]] && return 0
+  [[ -n "$PYTHON_BUILD_SKIP_MACPORTS" ]] && return 1
+  command -v port &>/dev/null && return 0
+  return 1
+}
+
+is_homebrew_preferred() {
+  can_use_homebrew || return 1
+  [ -n "$PYTHON_BUILD_USE_HOMEBREW" ] && return 0
+  local brew_path port_path path paths
+  command -v port &>/dev/null && port_path=$(dirname "$(command -v port)")
+  [ -z "$port_path" ] && return 0
+  [ -n "$PYTHON_BUILD_USE_MACPORTS" ] && return 1
+  command -v brew &>/dev/null && brew_path=$(dirname "$(command -v brew)")
+  [ -z "$brew_path" ] && return 1
+  # Homebrew and MacPorts found in PATH
+  # find out what to use based on the PATH order
+  [[ $PATH == *$brew_path*":"*$port_path* ]] && return 0
   return 1
 }
 
@@ -815,14 +841,28 @@ build_package_standard_build() {
   local PACKAGE_LDFLAGS="${package_var_name}_LDFLAGS"
 
   if [ "$package_var_name" = "PYTHON" ]; then
-    use_homebrew || true
-    use_custom_tcltk || use_homebrew_tcltk || true
-    use_homebrew_readline || use_freebsd_pkg || true
-    use_homebrew_ncurses || true
-    if is_mac -ge 1014; then
-      use_xcode_sdk_zlib || use_homebrew_zlib || true
+    if is_homebrew_preferred; then
+      use_homebrew || true
+      use_custom_tcltk || use_homebrew_tcltk || true
+      use_homebrew_readline || true
+      use_homebrew_ncurses || true
+      if is_mac -ge 1014; then
+        use_xcode_sdk_zlib || use_homebrew_zlib || true
+      else
+        use_homebrew_zlib || true
+      fi
+    elif can_use_macports; then
+      use_macports || true
+      use_custom_tcltk || true
+      use_macports_readline || true
+      use_macports_ncurses || true
+      if is_mac -ge 1014; then
+        use_xcode_sdk_zlib || use_macports_zlib || true
+      else
+        use_macports_zlib || true
+      fi
     else
-      use_homebrew_zlib || true
+      use_freebsd_pkg || true
     fi
     use_dsymutil || true
     use_free_threading || true
@@ -1438,9 +1478,24 @@ use_homebrew() {
   fi
 }
 
+use_macports() {
+  can_use_macports || return 1
+  local port_location="$(command -v port)"
+  if [ -n "$port_location" ]; then
+    local prefix="${port_location%/bin/port}"
+    export CPPFLAGS="${CPPFLAGS:+$CPPFLAGS }-I${prefix}/include"
+    append_ldflags_libs "-L${prefix}/lib -Wl,-rpath,${prefix}/lib"
+  fi
+}
+
 needs_yaml() {
-  ! configured_with_package_dir "python" "yaml.h" &&
-  ! use_homebrew_yaml
+  if ! configured_with_package_dir "python" "yaml.h"; then
+    if is_homebrew_preferred; then
+      use_homebrew_yaml && return 1
+    elif can_use_macports; then
+      use_macports_yaml && return 1
+    fi
+  fi
 }
 
 use_homebrew_yaml() {
@@ -1450,6 +1505,21 @@ use_homebrew_yaml() {
     echo "python-build: use libyaml from homebrew"
     export CPPFLAGS="-I$libdir/include${CPPFLAGS:+ $CPPFLAGS}"
     export LDFLAGS="-L$libdir/lib${LDFLAGS:+ ${LDFLAGS% }}"
+  else
+    return 1
+  fi
+}
+
+use_macports_yaml() {
+  can_use_macports || return 1
+  local prefix="$(port -q location libyaml 2>/dev/null || true)"
+  if [ -n "$prefix" ]; then
+    local libdir="$prefix/opt/local"
+    if [ -d "$libdir" ]; then
+      echo "python-build: use libyaml from MacPorts"
+      export CPPFLAGS="-I$libdir/include${CPPFLAGS:+ $CPPFLAGS}"
+      export LDFLAGS="-L$libdir/lib${LDFLAGS:+ ${LDFLAGS% }}"
+    fi
   else
     return 1
   fi
@@ -1488,9 +1558,13 @@ use_freebsd_pkg() {
 has_broken_mac_readline() {
   # Mac OS X 10.4 has broken readline.
   # https://github.com/pyenv/pyenv/issues/23
-  is_mac &&
-  ! configured_with_package_dir "python" "readline/rlconf.h" &&
-  ! use_homebrew_readline
+  if is_mac && ! configured_with_package_dir "python" "readline/rlconf.h"; then
+    if is_homebrew_preferred; then
+      use_homebrew_readline && return 1
+    elif can_use_macports; then
+      use_macports_readline && return 1
+    fi
+  fi
 }
 
 use_homebrew_readline() {
@@ -1507,6 +1581,23 @@ use_homebrew_readline() {
   fi
 }
 
+use_macports_readline() {
+  can_use_macports || return 1
+  if ! configured_with_package_dir "python" "readline/rlconf.h"; then
+    local prefix="$(port -q location readline 2>/dev/null || true)"
+    if [ -n "$prefix" ]; then
+      local libdir="$prefix/opt/local"
+      if [ -d "$libdir" ]; then
+        echo "python-build: use readline from MacPorts"
+        export CPPFLAGS="-I$libdir/include${CPPFLAGS:+ $CPPFLAGS}"
+        export LDFLAGS="-L$libdir/lib${LDFLAGS:+ $LDFLAGS}"
+      fi
+    else
+      return 1
+    fi
+  fi
+}
+
 use_homebrew_ncurses() {
   can_use_homebrew || return 1
   local libdir="$(brew --prefix ncurses 2>/dev/null || true)"
@@ -1514,6 +1605,21 @@ use_homebrew_ncurses() {
     echo "python-build: use ncurses from homebrew"
     export CPPFLAGS="-I$libdir/include${CPPFLAGS:+ $CPPFLAGS}"
     export LDFLAGS="-L$libdir/lib${LDFLAGS:+ $LDFLAGS}"
+  else
+    return 1
+  fi
+}
+
+use_macports_ncurses() {
+  can_use_macports || return 1
+  local prefix="$(port -q location ncurses 2>/dev/null || true)"
+  if [[ -n "$prefix" ]]; then
+    local libdir="$prefix/opt/local"
+    if [ -d "$libdir" ]; then
+      echo "python-build: use ncurses from MacPorts"
+      export CPPFLAGS="-I$libdir/include${CPPFLAGS:+ $CPPFLAGS}"
+      export LDFLAGS="-L$libdir/lib${LDFLAGS:+ $LDFLAGS}"
+    fi
   else
     return 1
   fi
@@ -1548,8 +1654,13 @@ build_package_mac_readline() {
 has_broken_mac_openssl() {
   is_mac || return 1
   local openssl_version="$(/usr/bin/openssl version 2>/dev/null || true)"
-  [[ $openssl_version = "OpenSSL 0.9.8"?* || $openssl_version = "LibreSSL"* ]] &&
-  ! use_homebrew_openssl
+  if [[ $openssl_version = "OpenSSL 0.9.8"?* || $openssl_version = "LibreSSL"* ]]; then
+    if is_homebrew_preferred; then
+      use_homebrew_openssl && return 1
+    elif can_use_macports; then
+      use_macports_openssl && return 1
+    fi
+  fi
 }
 
 use_homebrew_openssl() {
@@ -1566,6 +1677,31 @@ use_homebrew_openssl() {
       else
         export CPPFLAGS="-I$ssldir/include ${CPPFLAGS:+ $CPPFLAGS}"
         export LDFLAGS="-L$ssldir/lib${LDFLAGS:+ $LDFLAGS}"
+      fi
+      export PKG_CONFIG_PATH="$ssldir/lib/pkgconfig/:${PKG_CONFIG_PATH}"
+      return
+    fi
+  done
+  return 1
+}
+
+use_macports_openssl() {
+  can_use_macports || return 1
+  command -v port >/dev/null || return 1
+  for openssl in ${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl}; do
+    local ssldir="$(port -q location "${openssl}" 2>/dev/null || true)"
+    if [ -n "$ssldir" ]; then
+      ssldir="${ssldir}/opt/local"
+      if [ -d "$ssldir" ]; then
+        echo "python-build: use ${openssl} from MacPorts"
+        if [[ -n "${PYTHON_BUILD_CONFIGURE_WITH_OPENSSL:-}" ]]; then
+          # configure script of newer CPython versions support `--with-openssl`
+          # https://bugs.python.org/issue21541
+          package_option python configure --with-openssl="${ssldir}"
+        else
+          export CPPFLAGS="-I$ssldir/include ${CPPFLAGS:+ $CPPFLAGS}"
+          export LDFLAGS="-L$ssldir/lib${LDFLAGS:+ $LDFLAGS}"
+        fi
       fi
       export PKG_CONFIG_PATH="$ssldir/lib/pkgconfig/:${PKG_CONFIG_PATH}"
       return
@@ -1684,6 +1820,21 @@ use_xcode_sdk_zlib() {
     if is_mac -ge 1100; then
       export LDFLAGS="${LDFLAGS:+$LDFLAGS }-L${xc_sdk_path}/usr/lib"
     fi
+  fi
+}
+
+use_macports_zlib() {
+  can_use_macports || return 1
+  local prefix="$(port -q location zlib 2>/dev/null || true)"
+  if [[ -n "$prefix" ]]; then
+      local libdir="$prefix/opt/local"
+      if [[ -d "$libdir" ]]; then
+        echo "python-build: use zlib from MacPorts"
+        export CPPFLAGS="-I$prefix/include ${CPPFLAGS}"
+        export LDFLAGS="-L$prefix/lib ${LDFLAGS}"
+      fi
+  else
+    return 1
   fi
 }
 

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -142,7 +142,7 @@ can_use_macports() {
   }
   [[ -n "$PYTHON_BUILD_USE_MACPORTS" ]] && return 0
   [[ -n "$PYTHON_BUILD_SKIP_MACPORTS" ]] && return 1
-  command -v port &>/dev/null && return 0
+  is_mac && command -v port &>/dev/null && return 0
   return 1
 }
 

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -867,7 +867,6 @@ build_package_standard_build() {
       else
         use_homebrew_zlib || true
       fi
-      use_homebrew || true
     fi
     if can_use_macports; then
       use_custom_tcltk || true
@@ -878,6 +877,11 @@ build_package_standard_build() {
       else
         use_macports_zlib || true
       fi
+    fi
+    if can_use_homebrew; then
+      use_homebrew || true
+    fi
+    if can_use_macports; then
       use_macports || true
     fi
 
@@ -1484,7 +1488,7 @@ prepend_ldflags_libs() {
 }
 
 use_homebrew() {
-  locked_in homebrew || return 1
+  can_use_homebrew || return 1
   # unless Homebrew is at the default /usr/local, need to add its paths to
   # compiler search to be able to use non-keg-only deps from there
   if command -v brew &>/dev/null; then
@@ -1493,17 +1497,19 @@ use_homebrew() {
     if [[ -n $brew_prefix && $brew_prefix != "/usr" && $brew_prefix != "/usr/local" ]]; then
       export CPPFLAGS="${CPPFLAGS:+$CPPFLAGS }-I${brew_prefix}/include"
       append_ldflags_libs "-L${brew_prefix}/lib -Wl,-rpath,${brew_prefix}/lib"
+      lock_in homebrew
     fi
   fi
 }
 
 use_macports() {
-  locked_in macports || return 1
+  can_use_macports || return 1
   local port_location="$(command -v port)"
   if [ -n "$port_location" ]; then
     local prefix="${port_location%/bin/port}"
     export CPPFLAGS="${CPPFLAGS:+$CPPFLAGS }-I${prefix}/include"
     append_ldflags_libs "-L${prefix}/lib -Wl,-rpath,${prefix}/lib"
+    lock_in macports
   fi
 }
 

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -81,7 +81,12 @@ abs_dirname() {
       cd "$cd_path"
     fi
     name="${path##*/}"
-    path="$(resolve_link "$name" || true)"
+    if [[ $name == ".." ]]; then
+      cd ..
+      path="$PWD"
+    else
+      path="$(resolve_link "$name" || true)"
+    fi
   done
 
   echo "$PWD"

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -122,6 +122,9 @@ is_mac() {
 }
 
 can_use_homebrew() {
+  if locked_in; then
+    locked_in homebrew && rc=$? || rc=$?; return $rc
+  fi
   [[ -n "$PYTHON_BUILD_USE_HOMEBREW" && -n "$PYTHON_BUILD_SKIP_HOMEBREW" ]] && {
     echo "error: mutually exclusive environment variables PYTHON_BUILD_USE_HOMEBREW and PYTHON_BUILD_SKIP_HOMEBREW are set" >&3
     exit 1
@@ -131,11 +134,17 @@ can_use_homebrew() {
   is_mac && command -v brew &>/dev/null && return 0
   # In Linux, if Pyenv itself is installed with Homebrew,
   # we assume the user wants to take dependencies from there as well by default
-  command -v brew &>/dev/null && [[ $(abs_dirname "${BASH_SOURCE}") == "$(abs_dirname "$(brew --prefix 2>/dev/null ||true)")"/* ]] && return 0
-  return 1
+  command -v brew &>/dev/null && [[ $(abs_dirname "${BASH_SOURCE}") == "$(abs_dirname "$(brew --prefix 2>/dev/null ||true)")"/* ]] &&
+  { lock_in homebrew; return 0; }
+  
+  # do not check the same stuff multiple times
+  declare -g PYTHON_BUILD_SKIP_HOMEBREW=1; return 1
 }
 
 can_use_macports() {
+  if locked_in; then
+    locked_in macports && rc=$? || rc=$?; return $rc
+  fi
   [[ -n "$PYTHON_BUILD_USE_MACPORTS" && -n "$PYTHON_BUILD_SKIP_MACPORTS" ]] && {
     echo "error: mutually exclusive environment variables PYTHON_BUILD_USE_MACPORTS and PYTHON_BUILD_SKIP_MACPORTS are set" >&3
     exit 1
@@ -143,7 +152,21 @@ can_use_macports() {
   [[ -n "$PYTHON_BUILD_USE_MACPORTS" ]] && return 0
   [[ -n "$PYTHON_BUILD_SKIP_MACPORTS" ]] && return 1
   is_mac && command -v port &>/dev/null && return 0
-  return 1
+
+  # do not check the same stuff multiple times
+  declare -g PYTHON_BUILD_SKIP_MACPORTS=1; return 1
+}
+
+locked_in() {
+  if [[ -z "$1" ]]; then
+    [[ -n $_PYTHON_BUILD_ECOSYSTEM_LOCKED_IN ]]
+  else
+    [[ $_PYTHON_BUILD_ECOSYSTEM_LOCKED_IN == "$1" ]]
+  fi
+}
+
+lock_in() {
+  declare -g _PYTHON_BUILD_ECOSYSTEM_LOCKED_IN=${1:?}
 }
 
 #  9.1  -> 901
@@ -827,7 +850,6 @@ build_package_standard_build() {
 
   if [ "$package_var_name" = "PYTHON" ]; then
     if can_use_homebrew; then
-      use_homebrew || true
       use_custom_tcltk || use_homebrew_tcltk || true
       use_homebrew_readline || true
       use_homebrew_ncurses || true
@@ -836,9 +858,9 @@ build_package_standard_build() {
       else
         use_homebrew_zlib || true
       fi
+      use_homebrew || true
     fi
     if can_use_macports; then
-      use_macports || true
       use_custom_tcltk || true
       use_macports_readline || true
       use_macports_ncurses || true
@@ -847,6 +869,7 @@ build_package_standard_build() {
       else
         use_macports_zlib || true
       fi
+      use_macports || true
     fi
 
     use_freebsd_pkg || true
@@ -1452,7 +1475,7 @@ prepend_ldflags_libs() {
 }
 
 use_homebrew() {
-  can_use_homebrew || return 1
+  locked_in homebrew || return 1
   # unless Homebrew is at the default /usr/local, need to add its paths to
   # compiler search to be able to use non-keg-only deps from there
   if command -v brew &>/dev/null; then
@@ -1466,7 +1489,7 @@ use_homebrew() {
 }
 
 use_macports() {
-  can_use_macports || return 1
+  locked_in macports || return 1
   local port_location="$(command -v port)"
   if [ -n "$port_location" ]; then
     local prefix="${port_location%/bin/port}"
@@ -1492,6 +1515,7 @@ use_homebrew_yaml() {
     echo "python-build: use libyaml from homebrew"
     export CPPFLAGS="-I$libdir/include${CPPFLAGS:+ $CPPFLAGS}"
     export LDFLAGS="-L$libdir/lib${LDFLAGS:+ ${LDFLAGS% }}"
+    lock_in homebrew
   else
     return 1
   fi
@@ -1506,6 +1530,7 @@ use_macports_yaml() {
       echo "python-build: use libyaml from MacPorts"
       export CPPFLAGS="-I$libdir/include${CPPFLAGS:+ $CPPFLAGS}"
       export LDFLAGS="-L$libdir/lib${LDFLAGS:+ ${LDFLAGS% }}"
+      lock_in macports
     fi
   else
     return 1
@@ -1563,6 +1588,7 @@ use_homebrew_readline() {
       echo "python-build: use readline from homebrew"
       export CPPFLAGS="-I$libdir/include${CPPFLAGS:+ $CPPFLAGS}"
       export LDFLAGS="-L$libdir/lib${LDFLAGS:+ $LDFLAGS}"
+      lock_in homebrew
     else
       return 1
     fi
@@ -1579,6 +1605,7 @@ use_macports_readline() {
         echo "python-build: use readline from MacPorts"
         export CPPFLAGS="-I$libdir/include${CPPFLAGS:+ $CPPFLAGS}"
         export LDFLAGS="-L$libdir/lib${LDFLAGS:+ $LDFLAGS}"
+        lock_in macports
       fi
     else
       return 1
@@ -1593,6 +1620,7 @@ use_homebrew_ncurses() {
     echo "python-build: use ncurses from homebrew"
     export CPPFLAGS="-I$libdir/include${CPPFLAGS:+ $CPPFLAGS}"
     export LDFLAGS="-L$libdir/lib${LDFLAGS:+ $LDFLAGS}"
+    lock_in homebrew
   else
     return 1
   fi
@@ -1607,6 +1635,7 @@ use_macports_ncurses() {
       echo "python-build: use ncurses from MacPorts"
       export CPPFLAGS="-I$libdir/include${CPPFLAGS:+ $CPPFLAGS}"
       export LDFLAGS="-L$libdir/lib${LDFLAGS:+ $LDFLAGS}"
+      lock_in macports
     fi
   else
     return 1
@@ -1668,7 +1697,8 @@ use_homebrew_openssl() {
         export LDFLAGS="-L$ssldir/lib${LDFLAGS:+ $LDFLAGS}"
       fi
       export PKG_CONFIG_PATH="$ssldir/lib/pkgconfig/:${PKG_CONFIG_PATH}"
-      return
+      lock_in homebrew
+      return 0
     fi
   done
   return 1
@@ -1693,7 +1723,8 @@ use_macports_openssl() {
         fi
       fi
       export PKG_CONFIG_PATH="$ssldir/lib/pkgconfig/:${PKG_CONFIG_PATH}"
-      return
+      lock_in macports
+      return 0
     fi
   done
   return 1
@@ -1793,6 +1824,7 @@ use_homebrew_zlib() {
   if [ -d "$brew_zlib" ]; then
     echo "python-build: use zlib from homebrew"
     export CFLAGS="-I${brew_zlib} ${CFLAGS}"
+    lock_in homebrew
   fi
 }
 
@@ -1821,6 +1853,7 @@ use_macports_zlib() {
         echo "python-build: use zlib from MacPorts"
         export CPPFLAGS="-I$prefix/include ${CPPFLAGS}"
         export LDFLAGS="-L$prefix/lib ${LDFLAGS}"
+        lock_in macports
       fi
   else
     return 1
@@ -1851,6 +1884,7 @@ use_homebrew_tcltk() {
         fi
       fi
       export PKG_CONFIG_PATH="${tcltk_libdir}/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+      lock_in homebrew
       return 0
     fi
   done

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -134,7 +134,7 @@ can_use_homebrew() {
   is_mac && command -v brew &>/dev/null && return 0
   # In Linux, if Pyenv itself is installed with Homebrew,
   # we assume the user wants to take dependencies from there as well by default
-  command -v brew &>/dev/null && [[ $(abs_dirname "${BASH_SOURCE}") == "$(abs_dirname "$(brew --prefix 2>/dev/null ||true)")"/* ]] &&
+  command -v brew &>/dev/null && [[ $(abs_dirname "${BASH_SOURCE}") == "$(abs_dirname "$(brew --prefix)")"/* ]] &&
   { lock_in homebrew; return 0; }
   
   # do not check the same stuff multiple times

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -134,7 +134,11 @@ can_use_homebrew() {
   is_mac && command -v brew &>/dev/null && return 0
   # In Linux, if Pyenv itself is installed with Homebrew,
   # we assume the user wants to take dependencies from there as well by default
-  command -v brew &>/dev/null && [[ $(abs_dirname "${BASH_SOURCE}") == "$(abs_dirname "$(brew --prefix)")"/* ]] &&
+  local brew_prefix
+  command -v brew &>/dev/null && \
+    # tests can have non-functional `brew' stub aliased to `false'
+    brew_prefix="$(brew --prefix)" && 
+    [[ $(abs_dirname "${BASH_SOURCE}") == "$(abs_dirname "${brew_prefix}")"/* ]] &&
   { lock_in homebrew; return 0; }
   
   # do not check the same stuff multiple times

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -27,7 +27,6 @@ shopt -s extglob
 
 exec 3<&2 # preserve original stderr at fd 3
 
-
 lib() {
   parse_options() {
     OPTIONS=()
@@ -147,7 +146,7 @@ can_use_homebrew() {
   { lock_in homebrew; return 0; }
   
   # do not check the same stuff multiple times
-  declare -g PYTHON_BUILD_SKIP_HOMEBREW=1; return 1
+  PYTHON_BUILD_SKIP_HOMEBREW=1; return 1
 }
 
 can_use_macports() {
@@ -163,7 +162,7 @@ can_use_macports() {
   is_mac && command -v port &>/dev/null && return 0
 
   # do not check the same stuff multiple times
-  declare -g PYTHON_BUILD_SKIP_MACPORTS=1; return 1
+  PYTHON_BUILD_SKIP_MACPORTS=1; return 1
 }
 
 locked_in() {
@@ -175,7 +174,7 @@ locked_in() {
 }
 
 lock_in() {
-  declare -g _PYTHON_BUILD_ECOSYSTEM_LOCKED_IN=${1:?}
+  _PYTHON_BUILD_ECOSYSTEM_LOCKED_IN=${1:?}
 }
 
 #  9.1  -> 901

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -141,8 +141,9 @@ can_use_homebrew() {
   local brew_prefix
   command -v brew &>/dev/null && \
     # tests can have non-functional `brew' stub aliased to `false'
-    brew_prefix="$(brew --prefix)" && 
-    [[ $(abs_dirname "${BASH_SOURCE}") == "$(abs_dirname "${brew_prefix}")"/* ]] &&
+    # in Bash 3.2, var="$(cmd)" errexits on failure even if part of a conditional chain
+    brew_prefix="$(brew --prefix || true)" && [[ -n "$brew_prefix" ]] && \
+    [[ $(abs_dirname "${BASH_SOURCE}") == "$(abs_dirname "${brew_prefix}")"/* ]] && \
   { lock_in homebrew; return 0; }
   
   # do not check the same stuff multiple times

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -146,21 +146,6 @@ can_use_macports() {
   return 1
 }
 
-is_homebrew_preferred() {
-  can_use_homebrew || return 1
-  [ -n "$PYTHON_BUILD_USE_HOMEBREW" ] && return 0
-  local brew_path port_path path paths
-  command -v port &>/dev/null && port_path=$(dirname "$(command -v port)")
-  [ -z "$port_path" ] && return 0
-  [ -n "$PYTHON_BUILD_USE_MACPORTS" ] && return 1
-  command -v brew &>/dev/null && brew_path=$(dirname "$(command -v brew)")
-  [ -z "$brew_path" ] && return 1
-  # Homebrew and MacPorts found in PATH
-  # find out what to use based on the PATH order
-  [[ $PATH == *$brew_path*":"*$port_path* ]] && return 0
-  return 1
-}
-
 #  9.1  -> 901
 # 10.9  -> 1009
 # 10.10 -> 1010
@@ -841,7 +826,7 @@ build_package_standard_build() {
   local PACKAGE_LDFLAGS="${package_var_name}_LDFLAGS"
 
   if [ "$package_var_name" = "PYTHON" ]; then
-    if is_homebrew_preferred; then
+    if can_use_homebrew; then
       use_homebrew || true
       use_custom_tcltk || use_homebrew_tcltk || true
       use_homebrew_readline || true
@@ -851,7 +836,8 @@ build_package_standard_build() {
       else
         use_homebrew_zlib || true
       fi
-    elif can_use_macports; then
+    fi
+    if can_use_macports; then
       use_macports || true
       use_custom_tcltk || true
       use_macports_readline || true
@@ -861,9 +847,10 @@ build_package_standard_build() {
       else
         use_macports_zlib || true
       fi
-    else
-      use_freebsd_pkg || true
     fi
+
+    use_freebsd_pkg || true
+
     use_dsymutil || true
     use_free_threading || true
   fi
@@ -1490,7 +1477,7 @@ use_macports() {
 
 needs_yaml() {
   if ! configured_with_package_dir "python" "yaml.h"; then
-    if is_homebrew_preferred; then
+    if can_use_homebrew; then
       use_homebrew_yaml && return 1
     elif can_use_macports; then
       use_macports_yaml && return 1
@@ -1559,9 +1546,10 @@ has_broken_mac_readline() {
   # Mac OS X 10.4 has broken readline.
   # https://github.com/pyenv/pyenv/issues/23
   if is_mac && ! configured_with_package_dir "python" "readline/rlconf.h"; then
-    if is_homebrew_preferred; then
+    if can_use_homebrew; then
       use_homebrew_readline && return 1
-    elif can_use_macports; then
+    fi
+    if can_use_macports; then
       use_macports_readline && return 1
     fi
   fi
@@ -1655,9 +1643,10 @@ has_broken_mac_openssl() {
   is_mac || return 1
   local openssl_version="$(/usr/bin/openssl version 2>/dev/null || true)"
   if [[ $openssl_version = "OpenSSL 0.9.8"?* || $openssl_version = "LibreSSL"* ]]; then
-    if is_homebrew_preferred; then
+    if can_use_homebrew; then
       use_homebrew_openssl && return 1
-    elif can_use_macports; then
+    fi
+    if can_use_macports; then
       use_macports_openssl && return 1
     fi
   fi

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -188,6 +188,135 @@ make install
 OUT
 }
 
+@test "Homebrew is used when brew is before port in PATH" {
+  cached_tarball "Python-3.6.2"
+
+  BREW_PREFIX="$TMP/homebrew-prefix"
+  mkdir -p "$BREW_PREFIX/bin"
+  PORT_PREFIX="$TMP/macports-prefix"
+  mkdir -p "$PORT_PREFIX/bin"
+
+  for i in {1..9}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
+  stub brew "--prefix : echo '$BREW_PREFIX'"
+  for i in {1..5}; do stub brew false; done
+  stub_make_install
+  export PATH="$BREW_PREFIX/bin:$PORT_PREFIX/bin:$PATH"
+
+  run_inline_definition <<DEF
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub sw_vers
+  unstub brew
+  unstub make
+
+  assert_build_log <<OUT
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I$BREW_PREFIX/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L$BREW_PREFIX/lib -Wl,-rpath,$BREW_PREFIX/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
+make -j 2
+make install
+OUT
+}
+
+@test "MacPorts is used over Homebrew when both present and port is first in PATH" {
+  cached_tarball "Python-3.6.2"
+
+  BREW_PREFIX="$TMP/homebrew-prefix"
+  mkdir -p "$BREW_PREFIX/bin"
+  PORT_PREFIX=$TMP
+
+  for i in {1..4}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
+  for i in {1..3}; do stub port false; done
+  stub_make_install
+  export PATH="$PORT_PREFIX/bin:$BREW_PREFIX/bin:$PATH"
+
+  run_inline_definition <<DEF
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub sw_vers
+  unstub port
+  unstub make
+
+  assert_build_log <<OUT
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I$PORT_PREFIX/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L$PORT_PREFIX/lib -Wl,-rpath,$PORT_PREFIX/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
+make -j 2
+make install
+OUT
+}
+
+@test "Non-empty PYTHON_BUILD_USE_HOMEBREW overrides PATH order selection" {
+  cached_tarball "Python-3.6.2"
+
+  BREW_PREFIX="$TMP/homebrew-prefix"
+  mkdir -p "$BREW_PREFIX/bin"
+  PORT_PREFIX=$TMP
+
+  for i in {1..3}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
+  stub brew "--prefix : echo '$BREW_PREFIX'"
+  for i in {1..5}; do stub brew false; done
+  stub_make_install
+  export PYTHON_BUILD_USE_HOMEBREW=1
+  export PATH="$PORT_PREFIX/bin:$BREW_PREFIX/bin:$PATH"
+
+  run_inline_definition <<DEF
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub sw_vers
+  unstub brew
+  unstub make
+
+  assert_build_log <<OUT
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I$BREW_PREFIX/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L$BREW_PREFIX/lib -Wl,-rpath,$BREW_PREFIX/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
+make -j 2
+make install
+OUT
+}
+
+@test "Non-empty PYTHON_BUILD_USE_MACPORTS overrides PATH order selection" {
+  cached_tarball "Python-3.6.2"
+
+  BREW_PREFIX="$TMP/homebrew-prefix"
+  mkdir -p "$BREW_PREFIX/bin"
+  PORT_PREFIX=$TMP
+
+  for i in {1..4}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
+  for i in {1..3}; do stub port false; done
+  stub_make_install
+  export PYTHON_BUILD_USE_MACPORTS=1
+  export PATH="$BREW_PREFIX/bin:$PORT_PREFIX/bin:$PATH"
+
+  run_inline_definition <<DEF
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub sw_vers
+  unstub port
+  unstub make
+
+  assert_build_log <<OUT
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I$PORT_PREFIX/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L$PORT_PREFIX/lib -Wl,-rpath,$PORT_PREFIX/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
+make -j 2
+make install
+OUT
+}
+
 @test "homebrew with uncommon prefix is added to search path" {
   cached_tarball "Python-3.6.2"
 
@@ -298,6 +427,95 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CFLAGS="" CPPFLAGS="-I$ncurses_libdir/include -I${TMP}/install/include" LDFLAGS="-L$ncurses_libdir/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
+make -j 2
+make install
+OUT
+}
+
+@test "yaml is linked from MacPorts" {
+  cached_tarball "Python-3.6.2"
+
+  yaml_libdir="$TMP/port-yaml"
+  mkdir -p "$yaml_libdir/opt/local"
+
+  for i in {1..5}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
+  stub port "-q location libyaml : echo '$yaml_libdir'"
+  for i in {1..3}; do stub port false; done
+  stub_make_install
+
+  install_fixture definitions/needs-yaml
+  assert_success
+
+  unstub uname
+  unstub sw_vers
+  unstub port
+  unstub make
+
+  assert_build_log <<OUT
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I$yaml_libdir/opt/local/include -I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L$yaml_libdir/opt/local/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L${TMP}/lib -Wl,-rpath,${TMP}/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
+make -j 2
+make install
+OUT
+}
+
+@test "readline is linked from MacPorts" {
+  cached_tarball "Python-3.6.2"
+
+  readline_libdir="$TMP/port-readline"
+  mkdir -p "$readline_libdir/opt/local"
+
+  for i in {1..4}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
+  stub port "-q location readline : echo '$readline_libdir'"
+  for i in {1..2}; do stub port false; done
+  stub_make_install
+
+  run_inline_definition <<DEF
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub sw_vers
+  unstub port
+  unstub make
+
+  assert_build_log <<OUT
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I$readline_libdir/opt/local/include -I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L$readline_libdir/opt/local/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L${TMP}/lib -Wl,-rpath,${TMP}/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
+make -j 2
+make install
+OUT
+}
+
+@test "ncurses is linked from MacPorts" {
+  cached_tarball "Python-3.6.2"
+
+  ncurses_libdir="$TMP/port-ncurses"
+  mkdir -p "$ncurses_libdir/opt/local"
+
+  for i in {1..4}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
+  stub port false
+  stub port "-q location ncurses : echo '$ncurses_libdir'"
+  stub port false
+  stub_make_install
+
+  run_inline_definition <<DEF
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub sw_vers
+  unstub port
+  unstub make
+
+  assert_build_log <<OUT
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I$ncurses_libdir/opt/local/include -I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L$ncurses_libdir/opt/local/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L${TMP}/lib -Wl,-rpath,${TMP}/lib" PKG_CONFIG_PATH=""
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -615,6 +833,33 @@ make -j 2
 make install
 OUT
 }
+
+@test "MacPorts is not touched if PYTHON_BUILD_SKIP_MACPORTS is set" {
+  cached_tarball "Python-3.6.2"
+
+  for i in {1..4}; do stub uname '-s : echo Darwin'; done
+  for i in {1..2}; do stub sw_vers '-productVersion : echo 1010'; done
+  stub port true; port
+  stub_make_install
+  export PYTHON_BUILD_SKIP_MACPORTS=1
+
+  run_inline_definition <<DEF
+install_package "Python-3.6.2" "http://python.org/ftp/python/3.6.2/Python-3.6.2.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub port
+  unstub make
+
+  assert_build_log <<OUT
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
+make -j 2
+make install
+OUT
+}
+
 @test "number of CPU cores defaults to 2" {
   cached_tarball "Python-3.6.2"
 

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -70,6 +70,9 @@ assert_build_log() {
   install_fixture definitions/needs-yaml
   assert_success
 
+  unstub uname
+  unstub make
+
   assert_build_log <<OUT
 yaml-0.1.6: CFLAGS="" CPPFLAGS="-I${TMP}/install/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH=""
 yaml-0.1.6: --prefix=$INSTALL_ROOT
@@ -80,9 +83,6 @@ Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
-
-  unstub uname
-  unstub make
 }
 
 @test "apply global and package-specific flags, package flags come later to have precedence" {

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -665,12 +665,9 @@ OUT
 @test "homebrew is used in Linux if Pyenv is installed with Homebrew" {
   cached_tarball "Python-3.6.2"
 
-  set -x
   BREW_PREFIX="$(type -p python-build)"
   BREW_PREFIX="${BREW_PREFIX%/*}"
-  BREW_PREFIX="$(cd "$BREW_PREFIX"; pwd)"
   BREW_PREFIX="${BREW_PREFIX%/*}"
-  set +x
 
   stub uname '-s : echo Linux'
   stub brew "--prefix : echo '$BREW_PREFIX'"

--- a/plugins/python-build/test/definitions.bats
+++ b/plugins/python-build/test/definitions.bats
@@ -55,7 +55,7 @@ NUM_DEFINITIONS="$(find "$BATS_TEST_DIRNAME"/../share/python-build -maxdepth 1 -
   echo true > "${TMP}/definitions/2.7.8-test"
   mkdir -p "${TMP}/other"
   echo false > "${TMP}/other/2.7.8-test"
-  run bin/python-build "2.7.8-test" "${TMP}/install"
+  run python-build "2.7.8-test" "${TMP}/install"
   assert_success ""
 }
 


### PR DESCRIPTION
This commit allows building Python on macOS without Homebrew,
with the following libraries installed via MacPorts:
 - ncurses
 - openssl
 - readline
 - zlib (XCode SDK zlib is still tried first)

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3075

### Description
- [x] Here are some details about my PR

If either Homebrew or MacPorts system is the only one installed, that system
will be used automatically.
When both systems are installed, then whatever is found first in PATH - brew
or port - will be used for all dependencies.
The following environment variables can be set to non-empty value to override
the selection:
PYTHON_BUILD_USE_HOMEBREW
PYTHON_BUILD_USE_MACPORTS

Tcl/Tk specific support is omitted due to CPython incompatibility with
Tcl/Tk 9, according to the comments in use_homebrew_tcltk().
Those who need Tcl/Tk module, can use PYTHON_CONFIGURE_OPTS --with-tcltk-libs=
pointing to the Tcl/Tk location which can be installed either from sources or
via MacPorts.

### Tests
- [x] My PR adds the following unit tests (if any)

Homebrew is used when brew is before port in PATH
MacPorts is used over Homebrew when both present and port is first in PATH
Non-empty PYTHON_BUILD_USE_HOMEBREW overrides PATH order selection
Non-empty PYTHON_BUILD_USE_MACPORTS overrides PATH order selection
Tests for added use_macports* functions are based off of the
corresponding brew counterparts.