### PR TITLE
Add CPython 3.14.0a5

### DIFF
--- a/plugins/python-build/share/python-build/3.14.0a4
+++ b/plugins/python-build/share/python-build/3.14.0a4
@@ -1,9 +1,0 @@
-prefer_openssl3
-export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-3.3.2" "https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.3.2.tar.gz#2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281" mac_openssl --if has_broken_mac_openssl
-install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
-if has_tar_xz_support; then
-    install_package "Python-3.14.0a4" "https://www.python.org/ftp/python/3.14.0/Python-3.14.0a4.tar.xz#c24f07881873c1d460228795ca6ca8c99130e30c773c91463d30d7ea8ff0e70b" standard verify_py313 copy_python_gdb ensurepip
-else
-    install_package "Python-3.14.0a4" "https://www.python.org/ftp/python/3.14.0/Python-3.14.0a4.tgz#cc9dcee27cc27fc6ef4ff47eb93abf48f158396a70aa67f1504893232911b4e2" standard verify_py313 copy_python_gdb ensurepip
-fi

--- a/plugins/python-build/share/python-build/3.14.0a4t
+++ b/plugins/python-build/share/python-build/3.14.0a4t
@@ -1,2 +1,0 @@
-export PYTHON_BUILD_FREE_THREADING=1
-source "$(dirname "${BASH_SOURCE[0]}")"/3.14.0a4

--- a/plugins/python-build/share/python-build/3.14.0a5
+++ b/plugins/python-build/share/python-build/3.14.0a5
@@ -1,0 +1,9 @@
+prefer_openssl3
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-3.4.1" "https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz#002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+    install_package "Python-3.14.0a5" "https://www.python.org/ftp/python/3.14.0/Python-3.14.0a5.tar.xz#e42d91d6dd3016bfc2f6f96c1129b40ca6d8f6e1bf3b30a11de146d930f43b32" standard verify_py313 copy_python_gdb ensurepip
+else
+    install_package "Python-3.14.0a5" "https://www.python.org/ftp/python/3.14.0/Python-3.14.0a5.tgz#bfbb9b63e072b21c44ae20da14dd8ef14fa8c0cb632d93924d5defd5db2eded3" standard verify_py313 copy_python_gdb ensurepip
+fi

--- a/plugins/python-build/share/python-build/3.14.0a5t
+++ b/plugins/python-build/share/python-build/3.14.0a5t
@@ -1,0 +1,2 @@
+export PYTHON_BUILD_FREE_THREADING=1
+source "$(dirname "${BASH_SOURCE[0]}")"/3.14.0a5


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description

- Adds [CPython 3.14.0a5](https://www.python.org/downloads/release/python-3140a5/) to replace 3.14.0a4
- Bumps OpenSSL to 3.4.1

### Tests
- [ ] My PR adds the following unit tests (if any)
