### PR TITLE
Add PyPy v7.3.19.

### DIFF
--- a/plugins/python-build/share/python-build/pypy2.7-7.3.19
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.19
@@ -1,0 +1,77 @@
+VERSION='7.3.19'
+PYVER='2.7'
+
+# https://www.pypy.org/checksums.html
+aarch64_hash=fe89d4fd4af13f76dfe7315975003518cf176520e3ccec1544a88d174f50910e
+linux32_hash=cc52df02b6926bd8645c1651cd7f6637ce51c2f352d0fb3c6b9330d15194b409
+linux64_hash=d38445508c2eaf14ebb380d9c1ded321c5ebeae31c7e66800173d83cb8ddf423
+osarm64_hash=28780e0b908ad6db4b4e096f4237124be79ecc9731946d840d9c8749eb67a759
+osx64_hash=6be28d448d8e64fffc586d9b0ae4d09064a83ccaeb5b8060c651c5cd9ae06878
+
+### end of manual settings - following lines same for every download
+
+function err_no_binary {
+    local archmsg="${1}"
+    local ver="pypy${PYVER}-v${VERSION}-src"
+    local url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for ${archmsg}."
+      echo "try '${url}' to build from source."
+      echo
+    } >&2
+    exit 1
+}
+
+function pypy_pkg_data {
+    # pypy architecture tag
+    local ARCH="${1}"
+
+    # defaults
+    local cmd='install_package'  # use bz2
+    local pkg="${ARCH}" # assume matches
+    local ext='tar.bz2'
+    local hash='' # undefined
+
+    # select the hash, fix pkg if not match ARCH
+    case "${ARCH}" in
+    'linux-aarch64' )
+      hash="${aarch64_hash}"
+      pkg='aarch64'
+      ;;
+    'linux' )
+      hash="${linux32_hash}"
+      pkg='linux32'
+      ;;
+    'linux64' )
+      hash="${linux64_hash}"
+      ;;
+    'osarm64' )
+      hash="${osarm64_hash}"
+      pkg='macos_arm64'
+      ;;
+    'osx64' )
+      if require_osx_version "10.13"; then
+        hash="${osx64_hash}"
+        pkg='macos_x86_64'
+      else
+        err_no_binary "${ARCH}, OS X < 10.13"
+      fi
+      ;;
+    * )
+      err_no_binary "${ARCH}"
+      ;;
+    esac
+
+    local basever="pypy${PYVER}-v${VERSION}"
+    local baseurl="https://downloads.python.org/pypy/${basever}"
+
+    # result - command, package dir, url+hash
+    echo "${cmd}" "${basever}-${pkg}" "${baseurl}-${pkg}.${ext}#${hash}"
+}
+
+# determine command, package directory, url+hash
+declare -a pd="$(pypy_pkg_data "$(pypy_architecture 2>/dev/null || true)")"
+
+# install
+${pd[0]} "${pd[1]}" "${pd[2]}" 'pypy' "verify_py${PYVER//./}" 'ensurepip_lt21'

--- a/plugins/python-build/share/python-build/pypy2.7-7.3.19-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.19-src
@@ -1,0 +1,14 @@
+VERSION='7.3.19'
+PYVER='2.7'
+
+# https://www.pypy.org/checksums.html
+hash=8703cdcb01f9f82966dd43b6a6018f140399db51ebb43c125c1f9a215e7bb003
+
+### end of manual settings - following lines same for every download
+
+ver="pypy${PYVER}-v${VERSION}-src"
+url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+
+prefer_openssl11
+install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
+install_package "${ver}" "${url}#${hash}" 'pypy_builder' "verify_py${PYVER//./}" 'ensurepip_lt21'

--- a/plugins/python-build/share/python-build/pypy3.10-7.3.19
+++ b/plugins/python-build/share/python-build/pypy3.10-7.3.19
@@ -1,0 +1,77 @@
+VERSION='7.3.19'
+PYVER='3.10'
+
+# https://www.pypy.org/checksums.html
+aarch64_hash=af27a589178f11198e2244ab65ca510630ba97c131d7ccc4021eb5bc58de7f57
+linux32_hash=e63a4fcad2641ee541e852918befb513abf04ce7070f743a50778cae9f9da80e
+linux64_hash=c73ac2cc2380ac9227fd297482bf2a3e17a80618ba46db7544d535515321ec1e
+osarm64_hash=3db8a03fc496164801646844d7f3b12baa0adb3ad9a0b7cb124521bc2e168a36
+osx64_hash=2c5e5c2a33ac882551d7f28b98d19d486b8995aa50824a73b4edcc6aeec35c63
+
+### end of manual settings - following lines same for every download
+
+function err_no_binary {
+    local archmsg="${1}"
+    local ver="pypy${PYVER}-v${VERSION}-src"
+    local url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for ${archmsg}."
+      echo "try '${url}' to build from source."
+      echo
+    } >&2
+    exit 1
+}
+
+function pypy_pkg_data {
+    # pypy architecture tag
+    local ARCH="${1}"
+
+    # defaults
+    local cmd='install_package'  # use bz2
+    local pkg="${ARCH}" # assume matches
+    local ext='tar.bz2'
+    local hash='' # undefined
+
+    # select the hash, fix pkg if not match ARCH
+    case "${ARCH}" in
+    'linux-aarch64' )
+      hash="${aarch64_hash}"
+      pkg='aarch64'
+      ;;
+    'linux' )
+      hash="${linux32_hash}"
+      pkg='linux32'
+      ;;
+    'linux64' )
+      hash="${linux64_hash}"
+      ;;
+    'osarm64' )
+      hash="${osarm64_hash}"
+      pkg='macos_arm64'
+      ;;
+    'osx64' )
+      if require_osx_version "10.13"; then
+        hash="${osx64_hash}"
+        pkg='macos_x86_64'
+      else
+        err_no_binary "${ARCH}, OS X < 10.13"
+      fi
+      ;;
+    * )
+      err_no_binary "${ARCH}"
+      ;;
+    esac
+
+    local basever="pypy${PYVER}-v${VERSION}"
+    local baseurl="https://downloads.python.org/pypy/${basever}"
+
+    # result - command, package dir, url+hash
+    echo "${cmd}" "${basever}-${pkg}" "${baseurl}-${pkg}.${ext}#${hash}"
+}
+
+# determine command, package directory, url+hash
+declare -a pd="$(pypy_pkg_data "$(pypy_architecture 2>/dev/null || true)")"
+
+# install
+${pd[0]} "${pd[1]}" "${pd[2]}" 'pypy' "verify_py${PYVER//./}" 'ensurepip'

--- a/plugins/python-build/share/python-build/pypy3.10-7.3.19-src
+++ b/plugins/python-build/share/python-build/pypy3.10-7.3.19-src
@@ -1,0 +1,14 @@
+VERSION='7.3.19'
+PYVER='3.10'
+
+# https://www.pypy.org/checksums.html
+hash=a7c22930b918f40870865ed8a74147f4434ef84d3d6ca2b3c1eba9355d4929c8
+
+### end of manual settings - following lines same for every download
+
+ver="pypy${PYVER}-v${VERSION}-src"
+url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+
+prefer_openssl11
+install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
+install_package "${ver}" "${url}#${hash}" 'pypy_builder' "verify_py${PYVER//./}" 'ensurepip'

--- a/plugins/python-build/share/python-build/pypy3.11-7.3.19
+++ b/plugins/python-build/share/python-build/pypy3.11-7.3.19
@@ -1,0 +1,77 @@
+VERSION='7.3.19'
+PYVER='3.11'
+
+# https://www.pypy.org/checksums.html
+aarch64_hash=13207dbf81ce24e96da760b1b863627b77bb20b1fb4c95191e02a0b72383df74
+linux32_hash=5c6cdafd0a0abd14ca59926ed1b6aeb13b228c18b4b46de655aae48734c731ad
+linux64_hash=9177d9e0bb91b05f921c642cb0ff71a0f3653b5d29a42d40d6a078c15b75720f
+osarm64_hash=7704e0d5302e53920d32dcfe9afeeb10436d4c94233e8830cf603aa955a861c1
+osx64_hash=a2439f9d30dfdae96a5e9101c7dc54a8a68b56c9d7314ea399b0a25d3e87ebb2
+
+### end of manual settings - following lines same for every download
+
+function err_no_binary {
+    local archmsg="${1}"
+    local ver="pypy${PYVER}-v${VERSION}-src"
+    local url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for ${archmsg}."
+      echo "try '${url}' to build from source."
+      echo
+    } >&2
+    exit 1
+}
+
+function pypy_pkg_data {
+    # pypy architecture tag
+    local ARCH="${1}"
+
+    # defaults
+    local cmd='install_package'  # use bz2
+    local pkg="${ARCH}" # assume matches
+    local ext='tar.bz2'
+    local hash='' # undefined
+
+    # select the hash, fix pkg if not match ARCH
+    case "${ARCH}" in
+    'linux-aarch64' )
+      hash="${aarch64_hash}"
+      pkg='aarch64'
+      ;;
+    'linux' )
+      hash="${linux32_hash}"
+      pkg='linux32'
+      ;;
+    'linux64' )
+      hash="${linux64_hash}"
+      ;;
+    'osarm64' )
+      hash="${osarm64_hash}"
+      pkg='macos_arm64'
+      ;;
+    'osx64' )
+      if require_osx_version "10.13"; then
+        hash="${osx64_hash}"
+        pkg='macos_x86_64'
+      else
+        err_no_binary "${ARCH}, OS X < 10.13"
+      fi
+      ;;
+    * )
+      err_no_binary "${ARCH}"
+      ;;
+    esac
+
+    local basever="pypy${PYVER}-v${VERSION}"
+    local baseurl="https://downloads.python.org/pypy/${basever}"
+
+    # result - command, package dir, url+hash
+    echo "${cmd}" "${basever}-${pkg}" "${baseurl}-${pkg}.${ext}#${hash}"
+}
+
+# determine command, package directory, url+hash
+declare -a pd="$(pypy_pkg_data "$(pypy_architecture 2>/dev/null || true)")"
+
+# install
+${pd[0]} "${pd[1]}" "${pd[2]}" 'pypy' "verify_py${PYVER//./}" 'ensurepip'

--- a/plugins/python-build/share/python-build/pypy3.11-7.3.19-src
+++ b/plugins/python-build/share/python-build/pypy3.11-7.3.19-src
@@ -1,0 +1,14 @@
+VERSION='7.3.19'
+PYVER='3.11'
+
+# https://www.pypy.org/checksums.html
+hash=4817c044bb469a3274e60aa3645770f81eb4f9166ea7fdc4e6c351345554c8d8
+
+### end of manual settings - following lines same for every download
+
+ver="pypy${PYVER}-v${VERSION}-src"
+url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+
+prefer_openssl11
+install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
+install_package "${ver}" "${url}#${hash}" 'pypy_builder' "verify_py${PYVER//./}" 'ensurepip'


### PR DESCRIPTION
The release blog entry is here:
  https://pypy.org/posts/2025/02/pypy-v7319-release.html

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
