### PR TITLE
Add graalpy 24.2

### DIFF
--- a/plugins/python-build/share/python-build/graalpy-24.2.0
+++ b/plugins/python-build/share/python-build/graalpy-24.2.0
@@ -1,0 +1,64 @@
+# Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+VERSION='24.2.0'
+BUILD=''
+
+colorize 1 "GraalPy 23.1 and later installed by python-build use the faster Oracle GraalVM distribution" && echo
+colorize 1 "Oracle GraalVM uses the GFTC license, which is free for development and production use, see https://medium.com/graalvm/161527df3d76" && echo
+colorize 1 "The GraalVM Community Edition variant of GraalPy is also available, under the name graalpy-community-${VERSION}" && echo
+
+
+graalpy_arch="$(graalpy_architecture 2>/dev/null || true)"
+
+case "$graalpy_arch" in
+"linux-amd64" )
+  checksum="06381ebe89a242bbb66afdc7dc35d21ae537f7eb130f16db1f0e94c2a65249ba"
+  ;;
+"linux-aarch64" )
+  checksum="a80f4fe8c4b2ad53af6e5090bab462c7d0797b9b281e35bfc8284b703610c5cf"
+  ;;
+"macos-amd64" )
+  checksum="dafd706de39041887d016ef84413f5252d085b03ad47a44a6f680f40ed1a87e4"
+  ;;
+"macos-aarch64" )
+  checksum="108ad4c15b814aecc5b69b83a10a3a5e8982c656c4b639740d034a4783eb3839"
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": No binary distribution of GraalPy is available for $(uname -sm)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac
+
+if [ -n "${BUILD}" ]; then
+  { echo
+    colorize 1 "ERROR"
+    echo "Oracle GraalPy currently doesn't provide snapshot builds. Use graalpy-community if you need snapshots."
+    echo
+  } >&2
+  exit 1
+fi
+
+url="https://github.com/oracle/graalpython/releases/download/graal-${VERSION}/graalpy-${VERSION}-${graalpy_arch}.tar.gz#${checksum}"
+
+install_package "graalpy-${VERSION}" "${url}" "copy" ensurepip

--- a/plugins/python-build/share/python-build/graalpy-community-24.2.0
+++ b/plugins/python-build/share/python-build/graalpy-community-24.2.0
@@ -1,0 +1,54 @@
+# Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+VERSION='24.2.0'
+BUILD=''
+
+graalpy_arch="$(graalpy_architecture 2>/dev/null || true)"
+
+case "$graalpy_arch" in
+"linux-amd64" )
+  checksum="a3be9d91af186e270819cd3983507e073eeba33a303c5e5bec05ed1ac6078262"
+  ;;
+"linux-aarch64" )
+  checksum="6d5792eaebdf7847e1e75089f5d1f15f3762e55b8c69ea5631108c0e737cbf45"
+  ;;
+"macos-amd64" )
+  checksum="4a16be069341bdb3597d39c09eb11bfb994504f1c4c4b114cbb4489555229b6f"
+  ;;
+"macos-aarch64" )
+  checksum="bed8b15bc260a899766a2051d87c6fe9172c30751fa9c2e9a7ea2f5c8c49b781"
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": No binary distribution of GraalPy is available for $(uname -sm)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac
+
+if [ -n "${BUILD}" ]; then
+  url="https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/${VERSION}-dev-${BUILD}/graalpy-community-dev-${graalpy_arch}.tar.gz"
+else
+  url="https://github.com/oracle/graalpython/releases/download/graal-${VERSION}/graalpy-community-${VERSION}-${graalpy_arch}.tar.gz#${checksum}"
+fi
+
+install_package "graalpy-community-${VERSION}${BUILD}" "${url}" "copy" ensurepip


### PR DESCRIPTION
Add newly released [graalpy 24.2](https://github.com/oracle/graalpython/releases/tag/graal-24.2.0)

CC @timfel 