### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @pyenv/pyenv-core-maintainers @pyenv/pyenv-core-committers


### PR DESCRIPTION
to get notifications of pull requests ready for review

- [x] Here are some details about my PR

[By advice from @edgarrmondragon](https://github.com/pyenv/pyenv/pull/3245#issuecomment-2863401922).

According to [About code owners - GitHub Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), the listed groups will automatically be notified when a pull request is ready for review (either new or a draft marked ready for review).

Currently, no notification is sent at all when a draft pull request is marked ready for review which causes unnecessary delays.

@pyenv/pyenv-core-maintainers @pyenv/pyenv-core-committers , are you okay with receiving notifications about pull requests ready for review?