### PR TITLE
python-build: Support patch paths with spaces/special characters

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1160,8 +1160,8 @@ setup_builtin_patches() {
     cat >"${package_name}.patch"
     HAS_PATCH=true
   elif [[ -d "${package_patch_path}" ]]; then
-    { find "${package_patch_path}" -maxdepth 1 -type f
-    } 2>/dev/null | sort | xargs cat 1>"${package_name}.patch"
+    { find "${package_patch_path}" -maxdepth 1 -type f -print0
+    } 2>/dev/null | sort -z | xargs -0 cat 1>"${package_name}.patch"
     HAS_PATCH=true
   fi
 }


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3249

### Description
- [x] Here are some details about my PR

This is now possible because all non-EOL MacOS versions now support `find -print0`/`sort -z`/`xargs -0`

### Tests
- [x] My PR adds the following unit tests (if any)
Not necessary since using `-print0` etc in applicable cases is standard practice