### PR TITLE
Fix python-build's `has_broken_mac_readline`

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1585,7 +1585,8 @@ use_freebsd_pkg() {
 has_broken_mac_readline() {
   # Mac OS X 10.4 has broken readline.
   # https://github.com/pyenv/pyenv/issues/23
-  if is_mac && ! configured_with_package_dir "python" "readline/rlconf.h"; then
+  is_mac || return 1
+  if ! configured_with_package_dir "python" "readline/rlconf.h"; then
     if can_use_homebrew; then
       use_homebrew_readline && return 1
     fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite

> * [ ] Please consider implementing the feature as a hook script or plugin as a first step.
>   * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.

Not a feature.

> * [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
>   * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
>   * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.

Not a feature.

* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3253

### Description

The `has_broken_mac_openssl` python-build function, introduced in #3186, is careful enough to start with `is_mac || return 1` in order not to affect non-mac systems. That PR however didn't do so in `has_broken_mac_readline`.

### Tests

Should I add any?