### PR TITLE
Add defensive check for unset PYENV_ROOT in init_dirs

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -169,6 +169,11 @@ function help_() {
 }
 
 function init_dirs() {
+  if [ -z "$PYENV_ROOT" ]; then
+    echo 'Error: PYENV_ROOT is not set. Aborting.' >&2
+    exit 1
+  fi
+
   mkdir -p "${PYENV_ROOT}/"{shims,versions}
 }
 


### PR DESCRIPTION
### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  *  Not suitable as a plugin because `init_dirs` is part of `pyenv-init`, which is core initialization logic run directly by `pyenv init`. The check must occur within the core script to be effective.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * This logic is pyenv-specific. rbenv does not use `PYENV_ROOT`, and there is no equivalent `init_dirs` function. Upstreaming would not be applicable.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes Issue [#3256](https://github.com/pyenv/pyenv/issues/3256)
 
### Description
This PR adds a defensive check to the `init_dirs` function in `libexec/pyenv-init` to ensure that the `PYENV_ROOT` environment variable is set before directory creation.  Without this check, the script may create directories like /shims and /versions if $PYENV_ROOT is unset.

Currently, if `PYENV_ROOT` is unset, the following command silently creates directories in the root of the filesystem:

```bash
mkdir -p "${PYENV_ROOT}/"{shims,versions}
```

This update adds:
```bash
if [ -z "$PYENV_ROOT" ]; then
  echo "Error: PYENV_ROOT is not set. Aborting." >&2
  exit 1
fi
```

Improvements:
- Prevents silent failure or root-level directory creation
- Improves user experience and error clarity
- Maintains Bash 3.2 compatibility


### Tests
- [x] My PR adds the following unit tests (if any)
   - No tests have been added
