### PR TITLE
Support linking to MacPorts ports installed from binary archives

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1538,13 +1538,14 @@ use_homebrew_yaml() {
 
 use_macports_yaml() {
   can_use_macports || return 1
-  local prefix="$(port -q location libyaml 2>/dev/null || true)"
+  local port_location="$(command -v port)"
+  local prefix="${port_location%/bin/port}"
   if [ -n "$prefix" ]; then
-    local libdir="$prefix/opt/local"
-    if [ -d "$libdir" ]; then
+    local installation="$(port -q list libyaml)"
+    if [ -n "$installation" ]; then
       echo "python-build: use libyaml from MacPorts"
-      export CPPFLAGS="-I$libdir/include${CPPFLAGS:+ $CPPFLAGS}"
-      export LDFLAGS="-L$libdir/lib${LDFLAGS:+ ${LDFLAGS% }}"
+      export CPPFLAGS="-I$prefix/include${CPPFLAGS:+ $CPPFLAGS}"
+      export LDFLAGS="-L$prefix/lib${LDFLAGS:+ ${LDFLAGS% }}"
       lock_in macports
     fi
   else
@@ -1615,13 +1616,14 @@ use_homebrew_readline() {
 use_macports_readline() {
   can_use_macports || return 1
   if ! configured_with_package_dir "python" "readline/rlconf.h"; then
-    local prefix="$(port -q location readline 2>/dev/null || true)"
+    local port_location="$(command -v port)"
+    local prefix="${port_location%/bin/port}"
     if [ -n "$prefix" ]; then
-      local libdir="$prefix/opt/local"
-      if [ -d "$libdir" ]; then
+      local installation="$(port -q list readline)"
+      if [ -n "$installation" ]; then
         echo "python-build: use readline from MacPorts"
-        export CPPFLAGS="-I$libdir/include${CPPFLAGS:+ $CPPFLAGS}"
-        export LDFLAGS="-L$libdir/lib${LDFLAGS:+ $LDFLAGS}"
+        export CPPFLAGS="-I$prefix/include${CPPFLAGS:+ $CPPFLAGS}"
+        export LDFLAGS="-L$prefix/lib${LDFLAGS:+ $LDFLAGS}"
         lock_in macports
       fi
     else
@@ -1645,13 +1647,14 @@ use_homebrew_ncurses() {
 
 use_macports_ncurses() {
   can_use_macports || return 1
-  local prefix="$(port -q location ncurses 2>/dev/null || true)"
-  if [[ -n "$prefix" ]]; then
-    local libdir="$prefix/opt/local"
-    if [ -d "$libdir" ]; then
+  local port_location="$(command -v port)"
+  local prefix="${port_location%/bin/port}"
+  if [ -n "$prefix" ]; then
+    local installation="$(port -q list ncurses)"
+    if [ -n "$installation" ]; then
       echo "python-build: use ncurses from MacPorts"
-      export CPPFLAGS="-I$libdir/include${CPPFLAGS:+ $CPPFLAGS}"
-      export LDFLAGS="-L$libdir/lib${LDFLAGS:+ $LDFLAGS}"
+      export CPPFLAGS="-I$prefix/include${CPPFLAGS:+ $CPPFLAGS}"
+      export LDFLAGS="-L$prefix/lib${LDFLAGS:+ $LDFLAGS}"
       lock_in macports
     fi
   else
@@ -1725,18 +1728,19 @@ use_macports_openssl() {
   can_use_macports || return 1
   command -v port >/dev/null || return 1
   for openssl in ${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl}; do
-    local ssldir="$(port -q location "${openssl}" 2>/dev/null || true)"
-    if [ -n "$ssldir" ]; then
-      ssldir="${ssldir}/opt/local"
-      if [ -d "$ssldir" ]; then
+    local port_location="$(command -v port)"
+    local prefix="${port_location%/bin/port}"
+    local installation="$(port -q list $openssl)"
+    if [ -n "$prefix" ]; then
+      if [ -n "$installation" ]; then
         echo "python-build: use ${openssl} from MacPorts"
         if [[ -n "${PYTHON_BUILD_CONFIGURE_WITH_OPENSSL:-}" ]]; then
           # configure script of newer CPython versions support `--with-openssl`
           # https://bugs.python.org/issue21541
-          package_option python configure --with-openssl="${ssldir}"
+          package_option python configure --with-openssl="${prefix}"
         else
-          export CPPFLAGS="-I$ssldir/include ${CPPFLAGS:+ $CPPFLAGS}"
-          export LDFLAGS="-L$ssldir/lib${LDFLAGS:+ $LDFLAGS}"
+          export CPPFLAGS="-I$prefix/include ${CPPFLAGS:+ $CPPFLAGS}"
+          export LDFLAGS="-L$prefix/lib${LDFLAGS:+ $LDFLAGS}"
         fi
       fi
       export PKG_CONFIG_PATH="$ssldir/lib/pkgconfig/:${PKG_CONFIG_PATH}"
@@ -1863,10 +1867,11 @@ use_xcode_sdk_zlib() {
 
 use_macports_zlib() {
   can_use_macports || return 1
-  local prefix="$(port -q location zlib 2>/dev/null || true)"
-  if [[ -n "$prefix" ]]; then
-      local libdir="$prefix/opt/local"
-      if [[ -d "$libdir" ]]; then
+  local port_location="$(command -v port)"
+  local prefix="${port_location%/bin/port}"
+  if [ -n "$prefix" ]; then
+    local installation="$(port -q list zlib)"
+    if [ -n "$installation" ]; then
         echo "python-build: use zlib from MacPorts"
         export CPPFLAGS="-I$prefix/include ${CPPFLAGS}"
         export LDFLAGS="-L$prefix/lib ${LDFLAGS}"

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1508,7 +1508,7 @@ use_macports() {
   if [ -n "$port_location" ]; then
     local prefix="${port_location%/bin/port}"
     export CPPFLAGS="${CPPFLAGS:+$CPPFLAGS }-I${prefix}/include"
-    append_ldflags_libs "-L${prefix}/lib -Wl,-rpath,${prefix}/lib"
+    prepend_ldflags_libs "-L${prefix}/lib -Wl,-rpath,${prefix}/lib"
     export PKG_CONFIG_PATH="$prefix/lib/pkgconfig/:${PKG_CONFIG_PATH}"
     lock_in macports
   fi
@@ -1707,6 +1707,8 @@ use_homebrew_openssl() {
 use_macports_openssl() {
   can_use_macports || return 1
   command -v port >/dev/null || return 1
+  local port_location="$(command -v port)"
+  local prefix="${port_location%/bin/port}"
   for openssl in ${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl}; do
     if [[ $(port -q installed ${openssl} | awk '{print $3}') == "(active)" ]]; then
       echo "python-build: use ${openssl} from MacPorts"
@@ -2679,3 +2681,5 @@ mkdir -p "$BUILD_PATH"
 source "$DEFINITION_PATH"
 [ -z "${KEEP_BUILD_PATH}" ] && rm -fr "$BUILD_PATH"
 trap - ERR
+
+

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1507,7 +1507,7 @@ use_macports() {
   local port_location="$(command -v port)"
   if [ -n "$port_location" ]; then
     local prefix="${port_location%/bin/port}"
-    export CPPFLAGS="${CPPFLAGS:+$CPPFLAGS }-I${prefix}/include"
+    export CPPFLAGS="-I${prefix}/include${CPPFLAGS:+ $CPPFLAGS}"
     prepend_ldflags_libs "-L${prefix}/lib -Wl,-rpath,${prefix}/lib"
     export PKG_CONFIG_PATH="$prefix/lib/pkgconfig/:${PKG_CONFIG_PATH}"
     lock_in macports

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1541,8 +1541,7 @@ use_macports_yaml() {
   local port_location="$(command -v port)"
   local prefix="${port_location%/bin/port}"
   if [ -n "$prefix" ]; then
-    local installation="$(port -q list libyaml)"
-    if [ -n "$installation" ]; then
+    if [[ $(port -q installed libyaml | awk '{print $3}') == "(active)" ]]; then
       echo "python-build: use libyaml from MacPorts"
       export CPPFLAGS="-I$prefix/include${CPPFLAGS:+ $CPPFLAGS}"
       export LDFLAGS="-L$prefix/lib${LDFLAGS:+ ${LDFLAGS% }}"
@@ -1619,8 +1618,7 @@ use_macports_readline() {
     local port_location="$(command -v port)"
     local prefix="${port_location%/bin/port}"
     if [ -n "$prefix" ]; then
-      local installation="$(port -q list readline)"
-      if [ -n "$installation" ]; then
+      if [[ $(port -q installed readline | awk '{print $3}') == "(active)" ]]; then
         echo "python-build: use readline from MacPorts"
         export CPPFLAGS="-I$prefix/include${CPPFLAGS:+ $CPPFLAGS}"
         export LDFLAGS="-L$prefix/lib${LDFLAGS:+ $LDFLAGS}"
@@ -1650,8 +1648,7 @@ use_macports_ncurses() {
   local port_location="$(command -v port)"
   local prefix="${port_location%/bin/port}"
   if [ -n "$prefix" ]; then
-    local installation="$(port -q list ncurses)"
-    if [ -n "$installation" ]; then
+    if [[ $(port -q installed ncurses | awk '{print $3}') == "(active)" ]]; then
       echo "python-build: use ncurses from MacPorts"
       export CPPFLAGS="-I$prefix/include${CPPFLAGS:+ $CPPFLAGS}"
       export LDFLAGS="-L$prefix/lib${LDFLAGS:+ $LDFLAGS}"
@@ -1730,9 +1727,8 @@ use_macports_openssl() {
   for openssl in ${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl}; do
     local port_location="$(command -v port)"
     local prefix="${port_location%/bin/port}"
-    local installation="$(port -q list $openssl)"
     if [ -n "$prefix" ]; then
-      if [ -n "$installation" ]; then
+      if [[ $(port -q installed ${openssl} | awk '{print $3}') == "(active)" ]]; then
         echo "python-build: use ${openssl} from MacPorts"
         if [[ -n "${PYTHON_BUILD_CONFIGURE_WITH_OPENSSL:-}" ]]; then
           # configure script of newer CPython versions support `--with-openssl`
@@ -1870,8 +1866,7 @@ use_macports_zlib() {
   local port_location="$(command -v port)"
   local prefix="${port_location%/bin/port}"
   if [ -n "$prefix" ]; then
-    local installation="$(port -q list zlib)"
-    if [ -n "$installation" ]; then
+    if [[ $(port -q installed zlib | awk '{print $3}') == "(active)" ]]; then
         echo "python-build: use zlib from MacPorts"
         export CPPFLAGS="-I$prefix/include ${CPPFLAGS}"
         export LDFLAGS="-L$prefix/lib ${LDFLAGS}"

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1509,6 +1509,7 @@ use_macports() {
     local prefix="${port_location%/bin/port}"
     export CPPFLAGS="${CPPFLAGS:+$CPPFLAGS }-I${prefix}/include"
     append_ldflags_libs "-L${prefix}/lib -Wl,-rpath,${prefix}/lib"
+    export PKG_CONFIG_PATH="$prefix/lib/pkgconfig/:${PKG_CONFIG_PATH}"
     lock_in macports
   fi
 }
@@ -1538,15 +1539,9 @@ use_homebrew_yaml() {
 
 use_macports_yaml() {
   can_use_macports || return 1
-  local port_location="$(command -v port)"
-  local prefix="${port_location%/bin/port}"
-  if [ -n "$prefix" ]; then
-    if [[ $(port -q installed libyaml | awk '{print $3}') == "(active)" ]]; then
-      echo "python-build: use libyaml from MacPorts"
-      export CPPFLAGS="-I$prefix/include${CPPFLAGS:+ $CPPFLAGS}"
-      export LDFLAGS="-L$prefix/lib${LDFLAGS:+ ${LDFLAGS% }}"
-      lock_in macports
-    fi
+  if [[ $(port -q installed libyaml | awk '{print $3}') == "(active)" ]]; then
+    echo "python-build: use libyaml from MacPorts"
+    lock_in macports
   else
     return 1
   fi
@@ -1615,15 +1610,9 @@ use_homebrew_readline() {
 use_macports_readline() {
   can_use_macports || return 1
   if ! configured_with_package_dir "python" "readline/rlconf.h"; then
-    local port_location="$(command -v port)"
-    local prefix="${port_location%/bin/port}"
-    if [ -n "$prefix" ]; then
-      if [[ $(port -q installed readline | awk '{print $3}') == "(active)" ]]; then
-        echo "python-build: use readline from MacPorts"
-        export CPPFLAGS="-I$prefix/include${CPPFLAGS:+ $CPPFLAGS}"
-        export LDFLAGS="-L$prefix/lib${LDFLAGS:+ $LDFLAGS}"
-        lock_in macports
-      fi
+    if [[ $(port -q installed readline | awk '{print $3}') == "(active)" ]]; then
+      echo "python-build: use readline from MacPorts"
+      lock_in macports
     else
       return 1
     fi
@@ -1645,15 +1634,9 @@ use_homebrew_ncurses() {
 
 use_macports_ncurses() {
   can_use_macports || return 1
-  local port_location="$(command -v port)"
-  local prefix="${port_location%/bin/port}"
-  if [ -n "$prefix" ]; then
-    if [[ $(port -q installed ncurses | awk '{print $3}') == "(active)" ]]; then
-      echo "python-build: use ncurses from MacPorts"
-      export CPPFLAGS="-I$prefix/include${CPPFLAGS:+ $CPPFLAGS}"
-      export LDFLAGS="-L$prefix/lib${LDFLAGS:+ $LDFLAGS}"
-      lock_in macports
-    fi
+  if [[ $(port -q installed ncurses | awk '{print $3}') == "(active)" ]]; then
+    echo "python-build: use ncurses from MacPorts"
+    lock_in macports
   else
     return 1
   fi
@@ -1725,21 +1708,13 @@ use_macports_openssl() {
   can_use_macports || return 1
   command -v port >/dev/null || return 1
   for openssl in ${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl}; do
-    local port_location="$(command -v port)"
-    local prefix="${port_location%/bin/port}"
-    if [ -n "$prefix" ]; then
-      if [[ $(port -q installed ${openssl} | awk '{print $3}') == "(active)" ]]; then
-        echo "python-build: use ${openssl} from MacPorts"
-        if [[ -n "${PYTHON_BUILD_CONFIGURE_WITH_OPENSSL:-}" ]]; then
-          # configure script of newer CPython versions support `--with-openssl`
-          # https://bugs.python.org/issue21541
-          package_option python configure --with-openssl="${prefix}"
-        else
-          export CPPFLAGS="-I$prefix/include ${CPPFLAGS:+ $CPPFLAGS}"
-          export LDFLAGS="-L$prefix/lib${LDFLAGS:+ $LDFLAGS}"
-        fi
+    if [[ $(port -q installed ${openssl} | awk '{print $3}') == "(active)" ]]; then
+      echo "python-build: use ${openssl} from MacPorts"
+      if [[ -n "${PYTHON_BUILD_CONFIGURE_WITH_OPENSSL:-}" ]]; then
+        # configure script of newer CPython versions support `--with-openssl`
+        # https://bugs.python.org/issue21541
+        package_option python configure --with-openssl="${prefix}"
       fi
-      export PKG_CONFIG_PATH="$ssldir/lib/pkgconfig/:${PKG_CONFIG_PATH}"
       lock_in macports
       return 0
     fi
@@ -1863,15 +1838,11 @@ use_xcode_sdk_zlib() {
 
 use_macports_zlib() {
   can_use_macports || return 1
-  local port_location="$(command -v port)"
-  local prefix="${port_location%/bin/port}"
-  if [ -n "$prefix" ]; then
-    if [[ $(port -q installed zlib | awk '{print $3}') == "(active)" ]]; then
-        echo "python-build: use zlib from MacPorts"
-        export CPPFLAGS="-I$prefix/include ${CPPFLAGS}"
-        export LDFLAGS="-L$prefix/lib ${LDFLAGS}"
-        lock_in macports
-      fi
+  if [[ $(port -q installed zlib | awk '{print $3}') == "(active)" ]]; then
+    echo "python-build: use zlib from MacPorts"
+    export CPPFLAGS="-I$prefix/include ${CPPFLAGS}"
+    export LDFLAGS="-L$prefix/lib ${LDFLAGS}"
+    lock_in macports
   else
     return 1
   fi

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1842,8 +1842,6 @@ use_macports_zlib() {
   can_use_macports || return 1
   if [[ $(port -q installed zlib | awk '{print $3}') == "(active)" ]]; then
     echo "python-build: use zlib from MacPorts"
-    export CPPFLAGS="-I$prefix/include ${CPPFLAGS}"
-    export LDFLAGS="-L$prefix/lib ${LDFLAGS}"
     lock_in macports
   else
     return 1
@@ -2681,5 +2679,3 @@ mkdir -p "$BUILD_PATH"
 source "$DEFINITION_PATH"
 [ -z "${KEEP_BUILD_PATH}" ] && rm -fr "$BUILD_PATH"
 trap - ERR
-
-

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1509,7 +1509,7 @@ use_macports() {
     local prefix="${port_location%/bin/port}"
     export CPPFLAGS="-I${prefix}/include${CPPFLAGS:+ $CPPFLAGS}"
     prepend_ldflags_libs "-L${prefix}/lib -Wl,-rpath,${prefix}/lib"
-    export PKG_CONFIG_PATH="$prefix/lib/pkgconfig/:${PKG_CONFIG_PATH}"
+    export PKG_CONFIG_PATH="$prefix/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
     lock_in macports
   fi
 }

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -275,7 +275,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I$PORT_PREFIX/include" LDFLAGS="-L$PORT_PREFIX/lib -Wl,-rpath,$PORT_PREFIX/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I$PORT_PREFIX/include -I${TMP}/install/include" LDFLAGS="-L$PORT_PREFIX/lib -Wl,-rpath,$PORT_PREFIX/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -388,7 +388,7 @@ OUT
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/include -I${TMP}/install/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -415,7 +415,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/include -I${TMP}/install/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -443,7 +443,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/include -I${TMP}/install/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -617,7 +617,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/include -I${TMP}/install/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -275,7 +275,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I$PORT_PREFIX/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L$PORT_PREFIX/lib -Wl,-rpath,$PORT_PREFIX/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I$PORT_PREFIX/include" LDFLAGS="-L$PORT_PREFIX/lib -Wl,-rpath,$PORT_PREFIX/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -388,7 +388,7 @@ OUT
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L${TMP}/lib -Wl,-rpath,${TMP}/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -415,7 +415,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L${TMP}/lib -Wl,-rpath,${TMP}/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -443,7 +443,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L${TMP}/lib -Wl,-rpath,${TMP}/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -617,7 +617,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L${TMP}/lib -Wl,-rpath,${TMP}/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -275,7 +275,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I$PORT_PREFIX/include -I${TMP}/install/include" LDFLAGS="-L$PORT_PREFIX/lib -Wl,-rpath,$PORT_PREFIX/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I$PORT_PREFIX/include -I${TMP}/install/include" LDFLAGS="-L$PORT_PREFIX/lib -Wl,-rpath,$PORT_PREFIX/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -388,7 +388,7 @@ OUT
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/include -I${TMP}/install/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/include -I${TMP}/install/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -415,7 +415,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/include -I${TMP}/install/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/include -I${TMP}/install/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -443,7 +443,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/include -I${TMP}/install/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/include -I${TMP}/install/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -617,7 +617,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/include -I${TMP}/install/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/include -I${TMP}/install/include" LDFLAGS="-L${TMP}/lib -Wl,-rpath,${TMP}/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -275,7 +275,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I$PORT_PREFIX/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L$PORT_PREFIX/lib -Wl,-rpath,$PORT_PREFIX/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I$PORT_PREFIX/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L$PORT_PREFIX/lib -Wl,-rpath,$PORT_PREFIX/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -373,12 +373,9 @@ OUT
 @test "yaml is linked from MacPorts" {
   cached_tarball "Python-3.6.2"
 
-  yaml_libdir="$TMP/port-yaml"
-  mkdir -p "$yaml_libdir/opt/local"
-
   stub uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 1010'
-  stub port "-q location libyaml : echo '$yaml_libdir'"
+  stub port "-q installed libyaml : echo '  libyaml @0.2.5_0 (active)'"
   for i in {1..3}; do stub port false; done
   stub_make_install
 
@@ -391,7 +388,7 @@ OUT
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I$yaml_libdir/opt/local/include -I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L$yaml_libdir/opt/local/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L${TMP}/lib -Wl,-rpath,${TMP}/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L${TMP}/lib -Wl,-rpath,${TMP}/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -401,12 +398,9 @@ OUT
 @test "readline is linked from MacPorts" {
   cached_tarball "Python-3.6.2"
 
-  readline_libdir="$TMP/port-readline"
-  mkdir -p "$readline_libdir/opt/local"
-
   stub uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 1010'
-  stub port "-q location readline : echo '$readline_libdir'"
+  stub port "-q installed readline : echo '  readline @8.2.013_0 (active)'"
   for i in {1..2}; do stub port false; done
   stub_make_install
 
@@ -421,7 +415,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I$readline_libdir/opt/local/include -I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L$readline_libdir/opt/local/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L${TMP}/lib -Wl,-rpath,${TMP}/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L${TMP}/lib -Wl,-rpath,${TMP}/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -431,13 +425,10 @@ OUT
 @test "ncurses is linked from MacPorts" {
   cached_tarball "Python-3.6.2"
 
-  ncurses_libdir="$TMP/port-ncurses"
-  mkdir -p "$ncurses_libdir/opt/local"
-
   stub uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 1010'
   stub port false
-  stub port "-q location ncurses : echo '$ncurses_libdir'"
+  stub port "-q installed ncurses : echo '$ncurses_libdir'"
   stub port false
   stub_make_install
 
@@ -452,7 +443,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I$ncurses_libdir/opt/local/include -I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L$ncurses_libdir/opt/local/lib -L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L${TMP}/lib -Wl,-rpath,${TMP}/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L${TMP}/lib -Wl,-rpath,${TMP}/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
@@ -626,7 +617,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I$PORT_PREFIX/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L$PORT_PREFIX/lib -Wl,-rpath,$PORT_PREFIX/lib" PKG_CONFIG_PATH=""
+Python-3.6.2: CFLAGS="" CPPFLAGS="-I${TMP}/install/include -I${TMP}/include" LDFLAGS="-L${TMP}/install/lib -Wl,-rpath,${TMP}/install/lib -L${TMP}/lib -Wl,-rpath,${TMP}/lib" PKG_CONFIG_PATH="${TMP}/lib/pkgconfig/:"
 Python-3.6.2: --prefix=$INSTALL_ROOT --enable-shared --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Related to https://github.com/pyenv/pyenv/issues/3075

### Description
- [x] Here are some details about my PR

Macports support added from https://github.com/pyenv/pyenv/pull/3186 was not working on my machine. `python-build` was not picking up the correct `CPPFLAGS` and `LDFLAGS`.
I tried to modify the script to match what works on my setup (M1 macbook), so let me know if there's a concern about compatibility.

### Tests
- [ ] My PR adds the following unit tests (if any)
