### PR TITLE
(regression) Use Zlib from XCode SDK in MacOS without Homebrew or Macports

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -884,6 +884,9 @@ build_package_standard_build() {
     if can_use_macports; then
       use_macports || true
     fi
+    if is_mac -ge 1014 && ! can_use_homebrew && ! can_use_macports; then
+      use_xcode_sdk_zlib || true
+    fi
 
     use_freebsd_pkg || true
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3281

### Description
- [x] Here are some details about my PR

https://github.com/pyenv/pyenv/pull/3272 accidentally removed trying ZLib from XCode SDK when neither Homebrew nor MacPorts are present.

### Tests
- [ ] My PR adds the following unit tests (if any)
