### PR TITLE
Bump OpenSSL to 3.5.1 in the latest releases and branch tips in CPython 3.12 - 3.15

### DIFF
--- a/plugins/python-build/share/python-build/3.12.11
+++ b/plugins/python-build/share/python-build/3.12.11
@@ -1,6 +1,6 @@
 prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-3.3.3" "https://github.com/openssl/openssl/releases/download/openssl-3.3.3/openssl-3.3.3.tar.gz#712590fd20aaa60ec75d778fe5b810d6b829ca7fb1e530577917a131f9105539" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.5.1" "https://github.com/openssl/openssl/releases/download/openssl-3.5.1/openssl-3.5.1.tar.gz#529043b15cffa5f36077a4d0af83f3de399807181d607441d734196d889b641f" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.12.11" "https://www.python.org/ftp/python/3.12.11/Python-3.12.11.tar.xz#c30bb24b7f1e9a19b11b55a546434f74e739bb4c271a3e3a80ff4380d49f7adb" standard verify_py312 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.13-dev
+++ b/plugins/python-build/share/python-build/3.13-dev
@@ -2,6 +2,6 @@ prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
 export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
-install_package "openssl-3.3.0" "https://www.openssl.org/source/openssl-3.3.0.tar.gz#53e66b043322a606abf0087e7699a0e033a37fa13feb9742df35c3a33b18fb02" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.5.1" "https://www.openssl.org/source/openssl-3.5.1.tar.gz#529043b15cffa5f36077a4d0af83f3de399807181d607441d734196d889b641f" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_git "Python-3.13-dev" "https://github.com/python/cpython" 3.13 standard verify_py313 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.13.5
+++ b/plugins/python-build/share/python-build/3.13.5
@@ -1,6 +1,6 @@
 prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-3.4.1" "https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz#002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.5.1" "https://github.com/openssl/openssl/releases/download/openssl-3.5.1/openssl-3.5.1.tar.gz#529043b15cffa5f36077a4d0af83f3de399807181d607441d734196d889b641f" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.13.5" "https://www.python.org/ftp/python/3.13.5/Python-3.13.5.tar.xz#93e583f243454e6e9e4588ca2c2662206ad961659863277afcdb96801647d640" standard verify_py313 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.14-dev
+++ b/plugins/python-build/share/python-build/3.14-dev
@@ -2,6 +2,6 @@ prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
 export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
-install_package "openssl-3.3.0" "https://www.openssl.org/source/openssl-3.3.0.tar.gz#53e66b043322a606abf0087e7699a0e033a37fa13feb9742df35c3a33b18fb02" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.5.1" "https://www.openssl.org/source/openssl-3.5.1.tar.gz#529043b15cffa5f36077a4d0af83f3de399807181d607441d734196d889b641f" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_git "Python-3.14-dev" "https://github.com/python/cpython" 3.14 standard verify_py314 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.14.0b4
+++ b/plugins/python-build/share/python-build/3.14.0b4
@@ -1,6 +1,6 @@
 prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-install_package "openssl-3.4.2" "https://github.com/openssl/openssl/releases/download/openssl-3.4.2/openssl-3.4.2.tar.gz#17b02459fc28be415470cccaae7434f3496cac1306b86b52c83886580e82834c" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.5.1" "https://github.com/openssl/openssl/releases/download/openssl-3.5.1/openssl-3.5.1.tar.gz#529043b15cffa5f36077a4d0af83f3de399807181d607441d734196d889b641f" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
     install_package "Python-3.14.0b4" "https://www.python.org/ftp/python/3.14.0/Python-3.14.0b4.tar.xz#15e123e056abebba6de5e73cfa304459a8c82cafa85d4fc7fc6de80e6a3e1b39" standard verify_py314 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.15-dev
+++ b/plugins/python-build/share/python-build/3.15-dev
@@ -2,6 +2,6 @@ prefer_openssl3
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
 export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
-install_package "openssl-3.4.1" "https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz#002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-3.5.1" "https://github.com/openssl/openssl/releases/download/openssl-3.5.1/openssl-3.5.1.tar.gz#529043b15cffa5f36077a4d0af83f3de399807181d607441d734196d889b641f" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.2" "https://ftpmirror.gnu.org/readline/readline-8.2.tar.gz#3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35" mac_readline --if has_broken_mac_readline
 install_git "Python-3.15-dev" "https://github.com/python/cpython" main standard verify_py315 copy_python_gdb ensurepip


### PR DESCRIPTION
### Prerequisite

NA

### Description

Updates the OpenSSL version for the most recent CPython versions to the latest at the time of writing (https://openssl-library.org/source/).

### Tests

NA
