### PR TITLE
Add CPython 3.13.6

### DIFF
--- a/plugins/python-build/share/python-build/3.13.6
+++ b/plugins/python-build/share/python-build/3.13.6
@@ -1,0 +1,9 @@
+prefer_openssl3
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+install_package "openssl-3.5.2" "https://github.com/openssl/openssl/releases/download/openssl-3.5.2/openssl-3.5.2.tar.gz#c53a47e5e441c930c3928cf7bf6fb00e5d129b630e0aa873b08258656e7345ec" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.3" "https://mirror.cs.odu.edu/gnu/readline/readline-8.3.tar.gz#fe5383204467828cd495ee8d1d3c037a7eba1389c22bc6a041f627976f9061cc" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+    install_package "Python-3.13.6" "https://www.python.org/ftp/python/3.13.6/Python-3.13.6.tar.xz#17ba5508819d8736a14fbfc47d36e184946a877851b2e9c4b6c43acb44a3b104" standard verify_py313 copy_python_gdb ensurepip
+else
+    install_package "Python-3.13.6" "https://www.python.org/ftp/python/3.13.6/Python-3.13.6.tgz#6cf50672cc03928488817d45af24bc927a48f910fe7893d6f388130e59ba98d7" standard verify_py313 copy_python_gdb ensurepip
+fi

--- a/plugins/python-build/share/python-build/3.13.6t
+++ b/plugins/python-build/share/python-build/3.13.6t
@@ -1,0 +1,2 @@
+export PYTHON_BUILD_FREE_THREADING=1
+source "$(dirname "${BASH_SOURCE[0]}")"/3.13.6


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description

- Add CPython 3.13.6 and 3.13.6t
- Use openssl-3.5.2 and readline-8.3

### Tests
- [ ] My PR adds the following unit tests (if any)
