### PR TITLE
Don't fail the build if `xcodebuild` fails

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1831,7 +1831,7 @@ use_xcode_sdk_zlib() {
   [[ "${CC:-clang}" != "clang" || "$(command -v clang 2>/dev/null || true)" != "/usr/bin/clang" ]] && return 1
   # The flags set by this function break the build in XCode 16 due to unknown changes from XCode 15
   # For future-proofing, also disable it if we cannot determine the version
-  [[ $(xcodebuild -version) =~ ^Xcode\ ([[:digit:]]+) ]] && xcode_major="${BASH_REMATCH[1]}"
+  [[ $(xcodebuild -version 2>/dev/null || true) =~ ^Xcode\ ([[:digit:]]+) ]] && xcode_major="${BASH_REMATCH[1]}"
   [[ -z $xcode_major || $xcode_major -ge 16 ]] && return 1
   local xc_sdk_path="$(xcrun --show-sdk-path 2>/dev/null || true)"
   if [ -d "$xc_sdk_path" ]; then


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Partially addresses https://github.com/pyenv/pyenv/issues/3300

### Description
- [x] Here are some details about my PR

With no full XCode, `xcodebuild -version` fails with `xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance` which fails the build.

### Tests
- [x] My PR adds the following unit tests (if any)
N/A