### PR TITLE
Fix specifying XCode SDK for distutils; Revert to preferring XCode Zlib

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -863,7 +863,9 @@ build_package_standard_build() {
       use_homebrew_readline || true
       use_homebrew_ncurses || true
       if is_mac -ge 1014; then
-        use_homebrew_zlib || use_xcode_sdk_zlib || true
+        # While XCode SDK is "always available",
+        # still need a fallback in case we are using an alternate compiler
+        use_xcode_sdk_zlib || use_homebrew_zlib || true
       else
         use_homebrew_zlib || true
       fi
@@ -873,7 +875,9 @@ build_package_standard_build() {
       use_macports_readline || true
       use_macports_ncurses || true
       if is_mac -ge 1014; then
-        use_macports_zlib || use_xcode_sdk_zlib || true
+        # While XCode SDK is "always available",
+        # still need a fallback in case we are using an alternate compiler
+        use_xcode_sdk_zlib || use_homebrew_zlib || true
       else
         use_macports_zlib || true
       fi
@@ -1823,6 +1827,7 @@ use_homebrew_zlib() {
     export CPPFLAGS="-I${brew_zlib}/include${CPPFLAGS:+ ${CPPFLAGS}}"
     export LDFLAGS="-L${brew_zlib}/lib${LDFLAGS:+ ${LDFLAGS}}"
     lock_in homebrew
+    rc=0
   fi
 }
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3310

### Description
- [x] Here are some details about my PR

It turns out, 2.7.18 is also capable of using libs from modern XCode SDK when explicitly specified -- but we didn't specify it in the right variable

### Tests
- [x] My PR adds the following unit tests (if any)
