### PR TITLE
Fix Readline and OpenSSL detection for MacPorts without the corresponding package

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1593,6 +1593,7 @@ has_broken_mac_readline() {
   if can_use_macports; then
     use_macports_readline && return 1
   fi
+  return 0
 }
 
 use_homebrew_readline() {
@@ -1682,6 +1683,7 @@ has_broken_mac_openssl() {
       use_macports_openssl && return 1
     fi
   fi
+  return 0
 }
 
 use_homebrew_openssl() {


### PR DESCRIPTION
…package

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3315

### Description
- [x] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)
