### PR TITLE
fix(rehash): fix rehash hook for pipx/pipx.x/pipx.xx

### DIFF
--- a/pyenv.d/exec/pip-rehash.bash
+++ b/pyenv.d/exec/pip-rehash.bash
@@ -1,8 +1,8 @@
 PYENV_PIP_REHASH_ROOT="${BASH_SOURCE[0]%/*}/pip-rehash"
 PYENV_REHASH_COMMAND="${PYENV_COMMAND##*/}"
 
-# Remove any version information, from e.g. "pip2" or "pip3.4".
-if [[ $PYENV_REHASH_COMMAND =~ ^(pip|easy_install)[23](\.\d)?$ ]]; then
+# Remove any version information, from e.g. "pip2" or "pip3.10".
+if [[ $PYENV_REHASH_COMMAND =~ ^(pip|easy_install)[23](\.[0-9])*$ ]]; then
   PYENV_REHASH_COMMAND="${BASH_REMATCH[1]}"
 fi
 

--- a/pyenv.d/exec/pip-rehash.bash
+++ b/pyenv.d/exec/pip-rehash.bash
@@ -2,7 +2,7 @@ PYENV_PIP_REHASH_ROOT="${BASH_SOURCE[0]%/*}/pip-rehash"
 PYENV_REHASH_COMMAND="${PYENV_COMMAND##*/}"
 
 # Remove any version information, from e.g. "pip2" or "pip3.10".
-if [[ $PYENV_REHASH_COMMAND =~ ^(pip|easy_install)[23](\.[0-9]+)*$ ]]; then
+if [[ $PYENV_REHASH_COMMAND =~ ^(pip|easy_install)[23](\.[0-9]+)?$ ]]; then
   PYENV_REHASH_COMMAND="${BASH_REMATCH[1]}"
 fi
 

--- a/pyenv.d/exec/pip-rehash.bash
+++ b/pyenv.d/exec/pip-rehash.bash
@@ -2,7 +2,7 @@ PYENV_PIP_REHASH_ROOT="${BASH_SOURCE[0]%/*}/pip-rehash"
 PYENV_REHASH_COMMAND="${PYENV_COMMAND##*/}"
 
 # Remove any version information, from e.g. "pip2" or "pip3.10".
-if [[ $PYENV_REHASH_COMMAND =~ ^(pip|easy_install)[23](\.[0-9])*$ ]]; then
+if [[ $PYENV_REHASH_COMMAND =~ ^(pip|easy_install)[23](\.[0-9]+)*$ ]]; then
   PYENV_REHASH_COMMAND="${BASH_REMATCH[1]}"
 fi
 


### PR DESCRIPTION
### Description
`\d` in the bash regex was not working when calling pip3.X or pip3.xx so the rehash was not executed.
I replace it with a compatible regex and now works as expected 

### Tests
Can't find a way to source the file impacted by my change to add a `bats` test.
