### PR TITLE
Support curl from a snap

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -464,7 +464,7 @@ http_get_curl() {
   local curl_is_snap;
   if [[ $(command -v curl) == "/snap/"* ]]; then curl_is_snap=1; fi
   if [[ -n $2 && -n $curl_is_snap ]]; then out="$HOME/$(basename "$2")"; else out="$2"; fi
-  curl -q -o "${out:--}" -sSLf ${CURL_OPTS} "$1"
+  curl -q -o "${out:--}" -sSLf ${CURL_OPTS} "$1" || return $?
   if [[ -n $out && -n $curl_is_snap ]]; then mv "$out" "$2"; fi
 }
 

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -458,7 +458,14 @@ http_head_curl() {
 }
 
 http_get_curl() {
-  curl -q -o "${2:--}" -sSLf ${CURL_OPTS} "$1"
+  local out;
+  # Curl is also available as a snap. Snaps cannot read or write /tmp
+  # (files cannot be found, any write result is silently discarded).
+  local curl_is_snap;
+  if [[ $(command -v curl) == "/snap/"* ]]; then curl_is_snap=1; fi
+  if [[ -n $2 && -n $curl_is_snap ]]; then out="$HOME/$(basename "$2")"; else out="$2"; fi
+  curl -q -o "${out:--}" -sSLf ${CURL_OPTS} "$1"
+  if [[ -n $out && -n $curl_is_snap ]]; then mv "$out" "$2"; fi
 }
 
 http_head_wget() {


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3325

### Description
- [x] Here are some details about my PR
Same as for aria2c from a snap

### Tests
- [ ] My PR adds the following unit tests (if any)
