### PR TITLE
upgrade pip detetcion in pip-rehash to accept multiple variations:

### DIFF
--- a/pyenv.d/exec/pip-rehash.bash
+++ b/pyenv.d/exec/pip-rehash.bash
@@ -4,6 +4,9 @@ PYENV_REHASH_COMMAND="${PYENV_COMMAND##*/}"
 # Remove any version information, from e.g. "pip2" or "pip3.10".
 if [[ $PYENV_REHASH_COMMAND =~ ^(pip|easy_install)[23](\.[0-9]+)?$ ]]; then
   PYENV_REHASH_COMMAND="${BASH_REMATCH[1]}"
+# Check for ` -m pip ` in arguments
+elif [[ "$*" =~ [[:space:]]-m[[:space:]]pip[[:space:]] ]]; then
+  PYENV_REHASH_COMMAND="pip"
 fi
 
 if [ -x "${PYENV_PIP_REHASH_ROOT}/${PYENV_REHASH_COMMAND}" ]; then

--- a/test/pip-rehash.bats
+++ b/test/pip-rehash.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+create_executable() {
+  local bin="${PYENV_ROOT}/versions/${PYENV_VERSION}/bin"
+  mkdir -p "$bin"
+  echo "#!/bin/sh" > "${bin}/$1"
+  chmod +x "${bin}/$1"
+}
+
+copy_src_pyenvd() {
+  mkdir -p "${PYENV_ROOT}"
+  cp -r "${BATS_TEST_DIRNAME}/../pyenv.d" "${PYENV_ROOT}"
+}
+
+@test "pip-rehash triggered when using 'pip'" {
+  export PYENV_VERSION="3.7.14"
+  create_executable "example"
+  create_executable "pip"
+  copy_src_pyenvd
+  run command -v example 2> /dev/null
+  assert_failure
+  run pyenv-exec pip install example
+  assert_success
+  run command -v example 2> /dev/null
+  assert_success
+}
+
+@test "pip-rehash triggered when using 'pip3'" {
+  export PYENV_VERSION="3.7.14"
+  create_executable "example"
+  create_executable "pip3"
+  copy_src_pyenvd
+  run command -v example 2> /dev/null
+  assert_failure
+  run pyenv-exec pip3 install example
+  assert_success
+  run command -v example 2> /dev/null
+  assert_success
+}
+
+@test "pip-rehash triggered when using 'pip3.x'" {
+  export PYENV_VERSION="3.7.14"
+  create_executable "example"
+  create_executable "pip3.7"
+  copy_src_pyenvd
+  run command -v example 2> /dev/null
+  assert_failure
+  run pyenv-exec pip3.7 install example
+  assert_success
+  run command -v example 2> /dev/null
+  assert_success
+}
+
+@test "pip-rehash triggered when using 'python -m pip install'" {
+  export PYENV_VERSION="3.7.14"
+  create_executable "example"
+  create_executable "python"
+  copy_src_pyenvd
+  run command -v example 2> /dev/null
+  assert_failure
+  run pyenv-exec python -m pip install example
+  assert_success
+  run command -v example 2> /dev/null
+  assert_success
+}


### PR DESCRIPTION
- pip
- pip3
- pip3.10
- python -m pip
- uv pip

Co-author: Christian Fredrik Johnsen <christian@johnsen.no> @ChristianFredrikJohnsen 

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [X] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3031
* [X] My PR addresses the following pyenv PR (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3140

### Tests
- [X] My PR adds the following unit tests (if any)

tests added in new pyenv-rehash file