### PR TITLE
pyenv-install upgrade message based on PYENV_ROOT

### DIFF
--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -256,7 +256,6 @@ for DEFINITION in "${DEFINITIONS[@]}"; do
   # Display a more helpful message if the definition wasn't found.
   if [ "$STATUS" == "2" ]; then
     { candidates="$(definitions "$DEFINITION")"
-      here="$(dirname "${0%/*}")/../.."
       if [ -n "$candidates" ]; then
         echo
         echo "The following versions contain \`$DEFINITION' in the name:"
@@ -266,12 +265,12 @@ for DEFINITION in "${DEFINITIONS[@]}"; do
       echo "See all available versions with \`pyenv install --list'."
       echo
       echo -n "If the version you need is missing, try upgrading pyenv"
-      if [ "$here" != "${here#$(brew --prefix 2>/dev/null)}" ]; then
+      if [ "$PYENV_ROOT" != "${PYENV_ROOT#$(brew --prefix 2>/dev/null)}" ]; then
         printf ":\n\n"
         echo "  brew update && brew upgrade pyenv"
-      elif [ -d "${here}/.git" ]; then
+      elif [ -d "${PYENV_ROOT}/.git" ]; then
         printf ":\n\n"
-        echo "  cd ${here} && git pull && cd -"
+        echo "  cd ${PYENV_ROOT} && git pull && cd -"
       else
         printf ".\n"
       fi

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -135,6 +135,7 @@ OUT
 }
 
 @test "upgrade instructions given for a nonexistent version" {
+  mkdir -p "${PYENV_ROOT}/.git"
   stub brew false
   stub_python_build_lib
   stub_python_build 'echo ERROR >&2 && exit 2'
@@ -153,14 +154,14 @@ See all available versions with \`pyenv install --list'.
 
 If the version you need is missing, try upgrading pyenv:
 
-  cd ${BATS_TEST_DIRNAME}/../../.. && git pull && cd -
+  cd ${PYENV_ROOT} && git pull && cd -
 OUT
 
   unstub python-build
 }
 
 @test "homebrew upgrade instructions given when pyenv is homebrew-installed" {
-  stub brew "--prefix : echo '${BATS_TEST_DIRNAME%/*}'"
+  stub brew "--prefix : echo '${PYENV_ROOT%/*}'"
   stub_python_build_lib
   stub_python_build 'echo ERROR >&2 && exit 2' \
     "--definitions : true"


### PR DESCRIPTION
### Description
PYENV_ROOT used in pyenv-install for upgrade message because used everywhere and more robust

### Tests
Test upgraded in consequence
