### PR TITLE
CI: modified-scripts-build: fix discover job output declares

### DIFF
--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -5,6 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       versions: ${{steps.modified-versions.outputs.versions}}
+      versions_cpython_only: ${{steps.modified-versions.outputs.versions_cpython_only}}
     steps:
       - uses: actions/checkout@v5
       - run: git fetch origin "$GITHUB_BASE_REF"


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR
  This should fix errors like `Error when evaluating 'strategy' for job 'macos_build_bundled_dependencies'.` in `modified_scripts` CIs.

### Tests
- [ ] My PR adds the following unit tests (if any)
