### PR TITLE
CI: Replace macos-13 with macos-15-intel

### DIFF
--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ${{fromJson(needs.discover_modified_scripts.outputs.versions)}}
-        os: ["macos-13", "macos-14", "macos-15"]
+        os: ["macos-14", "macos-15", "macos-15-intel"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ${{fromJson(needs.discover_modified_scripts.outputs.versions_cpython_only)}}
-        os: ["macos-13", "macos-14", "macos-15"]
+        os: ["macos-14", "macos-15", "macos-15-intel"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/pyenv_tests.yml
+++ b/.github/workflows/pyenv_tests.yml
@@ -12,8 +12,8 @@ jobs:
         os:
           - ubuntu-24.04
           - ubuntu-22.04
+          - macos-15-intel
           - macos-14
-          - macos-13
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description

> The macOS 13 Ventura based runner images will begin deprecation on September 22nd and will be fully unsupported by December 4th for GitHub and ADO.

https://github.com/actions/runner-images/issues/13046

### Tests
- [ ] My PR adds the following unit tests (if any)
