### PR TITLE
rehash: Fix hanging for 60 seconds when shims directory is not writable due to Linux Landlock

### DIFF
--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -35,7 +35,7 @@ release_lock() {
 }
 
 if [ ! -w "$SHIM_PATH" ]; then
-  echo "pyenv: cannot rehash: $SHIM_PATH isn't writable"
+  echo "pyenv: cannot rehash: $SHIM_PATH isn't writable" >&2
   exit 1
 fi
 
@@ -53,18 +53,20 @@ while (( SECONDS <= start + ${PYENV_REHASH_TIMEOUT:-60} )); do
     # in a way that taxes the usual use case as little as possible.
     if [[ -z $tested_for_other_write_errors ]]; then
       ( t="$(mktemp -p "$SHIM_PATH")" && rm "$t" ) && tested_for_other_write_errors=1 ||
-        { echo "pyenv: cannot rehash: $SHIM_PATH isn't writable"; break }
+        { echo "pyenv: cannot rehash: $SHIM_PATH isnt writable" >&2; break; }
     fi
     # POSIX sleep(1) doesn't provide subsecond precision, but many others do
     sleep 0.1 2>/dev/null || sleep 1
   fi
 done
-unset tested_for_other_write_errors
 
 if [ -z "${acquired}" ]; then
-  echo "pyenv: cannot rehash: $PROTOTYPE_SHIM_PATH exists"
+  if [[ -n $tested_for_other_write_errors ]]; then
+      echo "pyenv: cannot rehash: $PROTOTYPE_SHIM_PATH exists" >&2
+  fi
   exit 1
 fi
+unset tested_for_other_write_errors
 
 # The prototype shim file is a script that re-execs itself, passing
 # its filename and any arguments to `pyenv exec`. This file is


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3365

### Description
- [x] Here are some details about my PR

Linux Landlock makes `access` produce false information, most likely a bug/limitation.
So the fact that shims directory is not writable is not caught by the existing test.
Implemented an additional test in a way with virtually no impact on normal use cases.

### Tests
- [ ] My PR adds the following unit tests (if any)
