### PR TITLE
miniconda3-latest: auto accept TOS

### DIFF
--- a/plugins/python-build/share/python-build/miniconda3-latest
+++ b/plugins/python-build/share/python-build/miniconda3-latest
@@ -1,3 +1,4 @@
+export CONDA_PLUGINS_AUTO_ACCEPT_TOS=true
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
   install_script "Miniconda3-latest-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86.sh" "miniconda" verify_py3_latest


### PR DESCRIPTION
Since 14.07.2025, Anaconda requires accepting the new TOS upon installation that limit eligibility for free use

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

see above

### Tests
- [x] My PR adds the following unit tests (if any)
N/A