### PR TITLE
rehash: support older BSD `mktemp`

### DIFF
--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -52,7 +52,7 @@ while (( SECONDS <= start + ${PYENV_REHASH_TIMEOUT:-60} )); do
     #So check for writablity by trying to write to a different file,
     # in a way that taxes the usual use case as little as possible.
     if [[ -z $tested_for_other_write_errors ]]; then
-      ( t="$(mktemp -p "$SHIM_PATH")" && rm "$t" ) && tested_for_other_write_errors=1 ||
+      ( t="$(TMPDIR="$SHIM_PATH" mktemp)" && rm "$t" ) && tested_for_other_write_errors=1 ||
         { echo "pyenv: cannot rehash: $SHIM_PATH isnt writable" >&2; break; }
     fi
     # POSIX sleep(1) doesn't provide subsecond precision, but many others do


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

macOS 12 `mktemp' doesn't support `-p`

### Tests
- [x] My PR adds the following unit tests (if any)
N/A