### PR TITLE
CI: exclude unsupported MacOS-x64 for recent Miniconda versions

### DIFF
--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -6,7 +6,7 @@ jobs:
     outputs:
       versions: ${{steps.modified-versions.outputs.versions}}
       versions_cpython_only: ${{steps.modified-versions.outputs.versions_cpython_only}}
-      versions_macos_intel_supported: ${{steps.modified-versions.outputs.versions_macos_intel_supported}}
+      versions_macos_build_exclude: ${{steps.modified-versions.outputs.versions_macos_build_exclude}}
     steps:
       - uses: actions/checkout@v6
       - run: git fetch origin "$GITHUB_BASE_REF"
@@ -27,34 +27,41 @@ jobs:
           echo "versions_cpython_only<<$EOF" >> $GITHUB_ENV;
           echo "$versions_cpython_only" >> $GITHUB_ENV;
           echo "$EOF" >> $GITHUB_ENV;
-      - name: Build macOS Intel supported list
-        shell: bash
+      - run: pip install packaging
+      - name: Build exclusions JSON
+        shell: python
         run: |
-          versions_macos_intel_supported=$(
-            while IFS= read -r v; do
-              if [[ "$v" == miniconda*-* ]]; then
-                def="plugins/python-build/share/python-build/$v"
-                if [[ -f "$def" ]]; then
-                  if grep -q 'MacOSX-x86_64' "$def"; then
-                    echo "$v"
-                  fi
-                else
-                  echo "$v"
-                fi
-              else
-                echo "$v"
-              fi
-            done <<<"$versions"
-          )
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "versions_macos_intel_supported<<$EOF" >> $GITHUB_ENV
-          echo "$versions_macos_intel_supported" >> $GITHUB_ENV
-          echo "$EOF" >> $GITHUB_ENV
+          import base64
+          import os
+          import json
+          import random
+          import re
+          import subprocess
+          
+          import packaging.version
+          
+          result=[]
+          
+          for line in os.environ['versions'].splitlines():
+            if m:=re.match(r'([^-]+)-(\d+\.\d+)-(\d+\.\d+.\d+)', line):
+              name, version = m.group(1), packaging.version.Version(m.group(3))
+              
+              # Miniconda dropped MacOS x64 support
+              if name == 'miniconda3' and version >= packaging.version.Version('25.9.1'):
+                result.append({'os':'macos-15-intel','python-version':line})
+          
+          EOF = str(random.getrandbits(15*8))
+          
+          with open(os.environ['GITHUB_ENV'],'w') as f:
+            f.write(f"versions_macos_build_exclude_json<<{EOF}\n")
+            json.dump(result, f)
+            f.write(f'\n{EOF}\n')
+          
       - id: modified-versions
         run: |
           echo "versions=`echo "${{ env.versions }}" | jq -R . | jq -sc .`" >> $GITHUB_OUTPUT
           echo "versions_cpython_only=`echo "${{ env.versions_cpython_only }}" | jq -R . | jq -sc .`" >> $GITHUB_OUTPUT
-          echo "versions_macos_intel_supported=`echo "${{ env.versions_macos_intel_supported }}" | jq -R . | jq -sc .`" >> $GITHUB_OUTPUT
+          echo 'versions_macos_build_exclude=${{ env.versions_macos_build_exclude_json }}' >> $GITHUB_OUTPUT
   macos_build:
     needs: discover_modified_scripts
     if: needs.discover_modified_scripts.outputs.versions != '[""]'
@@ -62,7 +69,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ${{fromJson(needs.discover_modified_scripts.outputs.versions)}}
-        os: ["macos-14", "macos-15"]
+        os: ["macos-14", "macos-15", "macos-15-intel"]
+        exclude: ${{fromJson(needs.discover_modified_scripts.outputs.versions_macos_build_exclude)}}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -116,69 +124,6 @@ jobs:
           pyenv global system
           rm -f "$(pyenv root)"/shims/*
           
-  macos_build_intel:
-    needs: discover_modified_scripts
-    if: needs.discover_modified_scripts.outputs.versions_macos_intel_supported != '[""]'
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ${{fromJson(needs.discover_modified_scripts.outputs.versions_macos_intel_supported)}}
-        os: ["macos-15-intel"]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v6
-      - run: |
-          #envvars
-          export PYENV_ROOT="$GITHUB_WORKSPACE"
-          echo "PYENV_ROOT=$PYENV_ROOT" >> $GITHUB_ENV
-          echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
-      - run: |
-          #prerequisites
-          brew install openssl openssl@1.1 readline sqlite3 xz zlib
-          if [[ "${{ matrix.python-version }}" =~ pypy.*-(src|dev) ]]; then
-            export PYENV_BOOTSTRAP_VERSION=pypy2.7-7
-            echo "PYENV_BOOTSTRAP_VERSION=$PYENV_BOOTSTRAP_VERSION" >> $GITHUB_ENV
-            pyenv install $PYENV_BOOTSTRAP_VERSION
-          fi
-      - run: |
-          #build
-          pyenv --debug install ${{ matrix.python-version }} && rc=$? || rc=$?
-          if [[ $rc -ne 0 ]]; then
-            echo config.log:; cat $TMPDIR/python-build*/*/config.log
-            false
-          fi
-          pyenv global ${{ matrix.python-version }}
-      # Micropython doesn't support --version
-      - run: |
-          #print version
-          if [[ "${{ matrix.python-version }}" == "micropython-"* ]]; then
-            python -c 'import sys; print(sys.version)'
-          else
-            python --version
-            python -m pip --version
-          fi
-      # Micropython doesn't support sys.executable, os.path, older versions even os
-      - env:
-          EXPECTED_PYTHON: ${{ matrix.python-version }}
-        run: |
-          #check
-          if [[ "${{ matrix.python-version }}" == "micropython-"* ]]; then
-            [[ $(pyenv which python) == "${{ env.PYENV_ROOT }}/versions/${{ matrix.python-version }}/bin/python" ]] || exit 1
-            python -c 'import sys; assert sys.implementation.name == "micropython"'
-          else
-            python -c 'if True:
-            import os, sys, os.path
-            correct_dir = os.path.join(
-              os.environ["PYENV_ROOT"],
-              "versions",
-              os.environ["EXPECTED_PYTHON"],
-              "bin")
-            assert os.path.dirname(sys.executable) == correct_dir'
-          fi
-      # bundled executables in some Anaconda releases cause the post-run step to hang in MacOS
-      - run: |
-          pyenv global system
-          rm -f "$(pyenv root)"/shims/*
 
   macos_build_bundled_dependencies:
     needs: discover_modified_scripts


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins]
(https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a
plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv),
since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv
will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with
rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [x] Here are some details about my PR
  - Split the macOS Intel build into a dedicated job.
  - Build the Intel matrix from versions that actually include `MacOSX-x86_64` in their definition
files.
  - Keep non-Intel macOS builds unchanged.

### Tests
- [x] My PR adds the following unit tests (if any)
  - None (workflow-only change; relies on CI jobs)