### PR TITLE
Simplify resolving symlinks: replace native extension with `pwd -P`

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -20,41 +20,6 @@ abort() {
   exit 1
 }
 
-if enable -f "${BASH_SOURCE%/*}"/../libexec/pyenv-realpath.dylib realpath 2>/dev/null; then
-  abs_dirname() {
-    local path
-    path="$(realpath "$1")"
-    echo "${path%/*}"
-  }
-else
-  [ -z "$PYENV_NATIVE_EXT" ] || abort "failed to load \`realpath' builtin"
-
-  READLINK=$(type -P readlink)
-  [ -n "$READLINK" ] || abort "cannot find readlink - are you missing GNU coreutils?"
-
-  resolve_link() {
-    $READLINK "$1"
-  }
-
-  abs_dirname() {
-    local path="$1"
-
-    # Use a subshell to avoid changing the current path
-    (
-    while [ -n "$path" ]; do
-      cd_path="${path%/*}"
-      if [[ "$cd_path" != "$path" ]]; then
-        cd "$cd_path"
-      fi
-      name="${path##*/}"
-      path="$(resolve_link "$name" || true)"
-    done
-
-    echo "$PWD"
-    )
-  }
-fi
-
 if [ -z "${PYENV_ROOT}" ]; then
   PYENV_ROOT="${HOME}/.pyenv"
 else

--- a/libexec/pyenv-hooks
+++ b/libexec/pyenv-hooks
@@ -21,43 +21,12 @@ if [ -z "$PYENV_COMMAND" ]; then
   exit 1
 fi
 
-if ! enable -f "${BASH_SOURCE%/*}"/pyenv-realpath.dylib realpath 2>/dev/null; then
-  if [ -n "$PYENV_NATIVE_EXT" ]; then
-    echo "pyenv: failed to load \`realpath' builtin" >&2
-    exit 1
-  fi
-READLINK=$(type -P readlink)
-if [ -z "$READLINK" ]; then
-  echo "pyenv: cannot find readlink - are you missing GNU coreutils?" >&2
-  exit 1
-fi
-
-resolve_link() {
-  $READLINK "$1"
-}
-
-realpath() {
-  local path="$1"
-  local name
-  # Use a subshell to avoid changing the current path
-  (
-  while [ -n "$path" ]; do
-    name="${path##*/}"
-    [ "$name" = "$path" ] || cd "${path%/*}"
-    path="$(resolve_link "$name" || true)"
-  done
-
-  echo "${PWD}/$name"
-  )
-}
-fi
-
 IFS=: hook_paths=($PYENV_HOOK_PATH)
 
 shopt -s nullglob
 for path in "${hook_paths[@]}"; do
   for script in "$path/$PYENV_COMMAND"/*.bash; do
-    realpath "$script"
+    echo "$script"
   done
 done
 shopt -u nullglob

--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -26,43 +26,14 @@ for arg; do
   esac
 done
 
+canonicalize_dir() {
+  { cd "$1" && pwd -P
+  } 2>/dev/null || echo "$1"
+}
+
 versions_dir="${PYENV_ROOT}/versions"
-
-if ! enable -f "${BASH_SOURCE%/*}"/pyenv-realpath.dylib realpath 2>/dev/null; then
-  if [ -n "$PYENV_NATIVE_EXT" ]; then
-    echo "pyenv: failed to load \`realpath' builtin" >&2
-    exit 1
-  fi
-
-  READLINK=$(type -P readlink)
-  if [ -z "$READLINK" ]; then
-    echo "pyenv: cannot find readlink - are you missing GNU coreutils?" >&2
-    exit 1
-  fi
-
-  resolve_link() {
-    $READLINK "$1"
-  }
-
-  realpath() {
-    local path="$1"
-    local name
-
-    # Use a subshell to avoid changing the current path
-    (
-    while [ -n "$path" ]; do
-      name="${path##*/}"
-      [ "$name" = "$path" ] || cd "${path%/*}"
-      path="$(resolve_link "$name" || true)"
-    done
-
-    echo "${PWD}/$name"
-    )
-  }
-fi
-
 if [ -d "$versions_dir" ]; then
-  versions_dir="$(realpath "$versions_dir")"
+  versions_dir="$(canonicalize_dir "$versions_dir")"
 fi
 
 if ((${BASH_VERSINFO[0]} > 3)); then
@@ -150,7 +121,7 @@ fi
 for path in "${versions_dir_entries[@]}"; do
   if [ -d "$path" ]; then
     if [ -n "$skip_aliases" ] && [ -L "$path" ]; then
-      target="$(realpath "$path")"
+      target="$(canonicalize_dir "$path")"
       [ "${target%/*}" == "$versions_dir" ] && continue
       [ "${target%/*/envs/*}" == "$versions_dir" ] && continue
     fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

This method is used in Rbenv (https://github.com/rbenv/rbenv/pull/1428) and Homebrew (https://github.com/Homebrew/brew/blob/fa5368edd38eb8d43f8cfcca15c7cfb83ee5a78d/Library/Homebrew/brew.sh#L76-L78).

`pwd -P` is portable between Linux and BSD (MacOS), unlike `readlink -f`.

### Tests
- [ ] My PR adds the following unit tests (if any)
