### PR TITLE
suppress "Invalid argument" error for Ubuntu coreutils

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -33,7 +33,7 @@ else
   [ -n "$READLINK" ] || abort "cannot find readlink - are you missing GNU coreutils?"
 
   resolve_link() {
-    $READLINK "$1"
+    $READLINK -s "$1"
   }
 
   abs_dirname() {

--- a/libexec/pyenv-hooks
+++ b/libexec/pyenv-hooks
@@ -33,7 +33,7 @@ if [ -z "$READLINK" ]; then
 fi
 
 resolve_link() {
-  $READLINK "$1"
+  $READLINK -s "$1"
 }
 
 realpath() {

--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -63,7 +63,7 @@ if ! enable -f "${BASH_SOURCE%/*}"/pyenv-realpath.dylib realpath 2>/dev/null; th
   fi
 
   resolve_link() {
-    $READLINK "$1"
+    $READLINK -s "$1"
   }
 
   realpath() {

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -66,7 +66,7 @@ if [ -z "$READLINK" ]; then
 fi
 
 resolve_link() {
-  $READLINK "$1"
+  $READLINK -s "$1"
 }
 
 abs_dirname() {


### PR DESCRIPTION
In Ubuntu 26.04 used  new `uutils coreutils` written in Rust. `readlink` behavior is little bit different in comparison with `GNU coreutils`. If `readlink` parameter is not a link it will print `Invalid argument` error. What is making a bunch of noise in console:

```text
readlink: pyenv: Invalid argument
readlink: pyenv: Invalid argument
readlink: conda.bash: Invalid argument
readlink: source.bash: Invalid argument
readlink: envs.bash: Invalid argument
```

Here is a possible option `-s` (or `--silent`) to suppress the errors. Option `-s` also exists in `GNU coreutils` so it should be okay for both versions