### PR TITLE
Add PyPy v7.3.21

### DIFF
--- a/plugins/python-build/share/python-build/pypy2.7-7.3.21
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.21
@@ -1,0 +1,77 @@
+VERSION='7.3.21'
+PYVER='2.7'
+
+# https://www.pypy.org/checksums.html
+aarch64_hash=8aaed1e612e6874235ee9d5bd545a8dcc7b86c867d305351df37969390b0c47b
+linux32_hash=14cb624e60b3012b4e5605571ab1477cea732a04e1c1385cc492d99f427a477f
+linux64_hash=d560f4043180b0df5826396af17d060bd731e4fee34755167040924ece876f3e
+osarm64_hash=7f69e5241ba7d10015e12d5b6dc1bb65458fcdc118385eee1ae0dde4e7f75776
+osx64_hash=e73061b21fc56f16a4fa7a4a24ffe0304c3df95b249852ea56e5b39110abdd70
+
+### end of manual settings - following lines same for every download
+
+function err_no_binary {
+    local archmsg="${1}"
+    local ver="pypy${PYVER}-v${VERSION}-src"
+    local url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for ${archmsg}."
+      echo "try '${url}' to build from source."
+      echo
+    } >&2
+    exit 1
+}
+
+function pypy_pkg_data {
+    # pypy architecture tag
+    local ARCH="${1}"
+
+    # defaults
+    local cmd='install_package'  # use bz2
+    local pkg="${ARCH}" # assume matches
+    local ext='tar.bz2'
+    local hash='' # undefined
+
+    # select the hash, fix pkg if not match ARCH
+    case "${ARCH}" in
+    'linux-aarch64' )
+      hash="${aarch64_hash}"
+      pkg='aarch64'
+      ;;
+    'linux' )
+      hash="${linux32_hash}"
+      pkg='linux32'
+      ;;
+    'linux64' )
+      hash="${linux64_hash}"
+      ;;
+    'osarm64' )
+      hash="${osarm64_hash}"
+      pkg='macos_arm64'
+      ;;
+    'osx64' )
+      if require_osx_version "10.13"; then
+        hash="${osx64_hash}"
+        pkg='macos_x86_64'
+      else
+        err_no_binary "${ARCH}, OS X < 10.13"
+      fi
+      ;;
+    * )
+      err_no_binary "${ARCH}"
+      ;;
+    esac
+
+    local basever="pypy${PYVER}-v${VERSION}"
+    local baseurl="https://downloads.python.org/pypy/${basever}"
+
+    # result - command, package dir, url+hash
+    echo "${cmd}" "${basever}-${pkg}" "${baseurl}-${pkg}.${ext}#${hash}"
+}
+
+# determine command, package directory, url+hash
+declare -a pd="$(pypy_pkg_data "$(pypy_architecture 2>/dev/null || true)")"
+
+# install
+${pd[0]} "${pd[1]}" "${pd[2]}" 'pypy' "verify_py${PYVER//./}" 'ensurepip_lt21'

--- a/plugins/python-build/share/python-build/pypy2.7-7.3.21-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.21-src
@@ -1,0 +1,14 @@
+VERSION='7.3.21'
+PYVER='2.7'
+
+# https://www.pypy.org/checksums.html
+hash=23537c62e875ad1a3e675c64d4435eff392ea20843e20d690fd1400b79363d64
+
+### end of manual settings - following lines same for every download
+
+ver="pypy${PYVER}-v${VERSION}-src"
+url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+
+prefer_openssl11
+install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
+install_package "${ver}" "${url}#${hash}" 'pypy_builder' "verify_py${PYVER//./}" 'ensurepip_lt21'

--- a/plugins/python-build/share/python-build/pypy3.11-7.3.21
+++ b/plugins/python-build/share/python-build/pypy3.11-7.3.21
@@ -1,0 +1,77 @@
+VERSION='7.3.21'
+PYVER='3.11'
+
+# https://www.pypy.org/checksums.html
+aarch64_hash=6141f5c64dd96faf87e0a3f7f362521eadd26d5e3f851f90fc386a72208f8c18
+linux32_hash=0c449ff3f20589e331f163807a0200a9bf5dd375c95f513a0f60bf7524795f02
+linux64_hash=43f27af8ee6673932493f2696ab407321cbf79dbed94c03d8b39e603f8f5f765
+osarm64_hash=a43f97ff9f6016aac09ee75eb626d806e8ad865608e7d8bc4d3c2fc37c2b4799
+osx64_hash=60dfb37dda85d548cd6a4d7bdb12ff26e19162042001b741fd9b6a8ecee802a6
+
+### end of manual settings - following lines same for every download
+
+function err_no_binary {
+    local archmsg="${1}"
+    local ver="pypy${PYVER}-v${VERSION}-src"
+    local url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for ${archmsg}."
+      echo "try '${url}' to build from source."
+      echo
+    } >&2
+    exit 1
+}
+
+function pypy_pkg_data {
+    # pypy architecture tag
+    local ARCH="${1}"
+
+    # defaults
+    local cmd='install_package'  # use bz2
+    local pkg="${ARCH}" # assume matches
+    local ext='tar.bz2'
+    local hash='' # undefined
+
+    # select the hash, fix pkg if not match ARCH
+    case "${ARCH}" in
+    'linux-aarch64' )
+      hash="${aarch64_hash}"
+      pkg='aarch64'
+      ;;
+    'linux' )
+      hash="${linux32_hash}"
+      pkg='linux32'
+      ;;
+    'linux64' )
+      hash="${linux64_hash}"
+      ;;
+    'osarm64' )
+      hash="${osarm64_hash}"
+      pkg='macos_arm64'
+      ;;
+    'osx64' )
+      if require_osx_version "10.13"; then
+        hash="${osx64_hash}"
+        pkg='macos_x86_64'
+      else
+        err_no_binary "${ARCH}, OS X < 10.13"
+      fi
+      ;;
+    * )
+      err_no_binary "${ARCH}"
+      ;;
+    esac
+
+    local basever="pypy${PYVER}-v${VERSION}"
+    local baseurl="https://downloads.python.org/pypy/${basever}"
+
+    # result - command, package dir, url+hash
+    echo "${cmd}" "${basever}-${pkg}" "${baseurl}-${pkg}.${ext}#${hash}"
+}
+
+# determine command, package directory, url+hash
+declare -a pd="$(pypy_pkg_data "$(pypy_architecture 2>/dev/null || true)")"
+
+# install
+${pd[0]} "${pd[1]}" "${pd[2]}" 'pypy' "verify_py${PYVER//./}" 'ensurepip'

--- a/plugins/python-build/share/python-build/pypy3.11-7.3.21-src
+++ b/plugins/python-build/share/python-build/pypy3.11-7.3.21-src
@@ -1,0 +1,14 @@
+VERSION='7.3.21'
+PYVER='3.11'
+
+# https://www.pypy.org/checksums.html
+hash=e7c9d8236ef279dba51abb9e691401a6c805bbe3250c6842dc9bac98f8de688a
+
+### end of manual settings - following lines same for every download
+
+ver="pypy${PYVER}-v${VERSION}-src"
+url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+
+prefer_openssl11
+install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
+install_package "${ver}" "${url}#${hash}" 'pypy_builder' "verify_py${PYVER//./}" 'ensurepip'


### PR DESCRIPTION
The release blog entry is here:
https://pypy.org/posts/2026/03/pypy-v7320-release.html

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
