### PR TITLE
pyenv-latest: fast path for when there is an exact match

### DIFF
--- a/libexec/pyenv-latest
+++ b/libexec/pyenv-latest
@@ -10,6 +10,7 @@
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
+
 while [[ $# -gt 0 ]]
 do
     case "$1" in
@@ -38,6 +39,10 @@ exitcode=0
 IFS=$'\n'
 
     if [[ -z $FROM_KNOWN ]]; then
+        if [[ -d $PYENV_ROOT/versions/$prefix ]]; then
+            echo "$prefix"
+            exit $exitcode;
+        fi
         DEFINITION_CANDIDATES=( $(pyenv-versions --bare --skip-envs) )
     else
         DEFINITION_CANDIDATES=( $(python-build --definitions ) )


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A, a helper for https://github.com/pyenv/pyenv-virtualenv/pull/502

### Description
- [x] Here are some details about my PR

Avoids O(N^2) complexity when pyenv-latest is called in a loop for existing entries

### Tests
- [x] My PR adds the following unit tests (if any)
N/A