### PR TITLE
Add PyPy v7.3.22

### DIFF
--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -99,7 +99,7 @@ jobs:
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
       - run: |
           #prerequisites
-          brew install openssl openssl@1.1 readline sqlite3 xz zlib
+          brew install openssl readline sqlite3 xz zlib
           if [[ "${{ matrix.python-version }}" =~ pypy.*-(src|dev) ]]; then
             export PYENV_BOOTSTRAP_VERSION=pypy2.7-7
             echo "PYENV_BOOTSTRAP_VERSION=$PYENV_BOOTSTRAP_VERSION" >> $GITHUB_ENV

--- a/plugins/python-build/share/python-build/pypy2.7-7.3.22
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.22
@@ -1,0 +1,77 @@
+VERSION='7.3.22'
+PYVER='2.7'
+
+# https://www.pypy.org/checksums.html
+aarch64_hash=49829ef97a36d50870b0a4a7d6d67c4817d98a0bbd936e7a86ac6ef615b07205
+linux32_hash=3512d44a9005b52611ad2d84e63c575c8b592fb1dd1a708a00f787b46e6ee07b
+linux64_hash=c47a4030542cbd34d0cb673a0de1956c94c1ebe6c6b094f2ae6a167c55375f68
+osarm64_hash=83f7c9aab17f090a8fc54d917fb627ebf45f57e37e951e25d34cc94f796cb62a
+osx64_hash=25adfddbf502a479d57f1948e19881a90162180b2b6dc7e3c2efacead1353438
+
+### end of manual settings - following lines same for every download
+
+function err_no_binary {
+    local archmsg="${1}"
+    local ver="pypy${PYVER}-v${VERSION}-src"
+    local url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for ${archmsg}."
+      echo "try '${url}' to build from source."
+      echo
+    } >&2
+    exit 1
+}
+
+function pypy_pkg_data {
+    # pypy architecture tag
+    local ARCH="${1}"
+
+    # defaults
+    local cmd='install_package'  # use bz2
+    local pkg="${ARCH}" # assume matches
+    local ext='tar.bz2'
+    local hash='' # undefined
+
+    # select the hash, fix pkg if not match ARCH
+    case "${ARCH}" in
+    'linux-aarch64' )
+      hash="${aarch64_hash}"
+      pkg='aarch64'
+      ;;
+    'linux' )
+      hash="${linux32_hash}"
+      pkg='linux32'
+      ;;
+    'linux64' )
+      hash="${linux64_hash}"
+      ;;
+    'osarm64' )
+      hash="${osarm64_hash}"
+      pkg='macos_arm64'
+      ;;
+    'osx64' )
+      if require_osx_version "10.13"; then
+        hash="${osx64_hash}"
+        pkg='macos_x86_64'
+      else
+        err_no_binary "${ARCH}, OS X < 10.13"
+      fi
+      ;;
+    * )
+      err_no_binary "${ARCH}"
+      ;;
+    esac
+
+    local basever="pypy${PYVER}-v${VERSION}"
+    local baseurl="https://downloads.python.org/pypy/${basever}"
+
+    # result - command, package dir, url+hash
+    echo "${cmd}" "${basever}-${pkg}" "${baseurl}-${pkg}.${ext}#${hash}"
+}
+
+# determine command, package directory, url+hash
+declare -a pd="$(pypy_pkg_data "$(pypy_architecture 2>/dev/null || true)")"
+
+# install
+${pd[0]} "${pd[1]}" "${pd[2]}" 'pypy' "verify_py${PYVER//./}" 'ensurepip_lt21'

--- a/plugins/python-build/share/python-build/pypy2.7-7.3.22-src
+++ b/plugins/python-build/share/python-build/pypy2.7-7.3.22-src
@@ -1,0 +1,14 @@
+VERSION='7.3.22'
+PYVER='2.7'
+
+# https://www.pypy.org/checksums.html
+hash=f4445c1a835effe4d3b26521e73a7780893dec02520aa6799a377c9a0fcdd8ad
+
+### end of manual settings - following lines same for every download
+
+ver="pypy${PYVER}-v${VERSION}-src"
+url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+
+prefer_openssl11
+install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
+install_package "${ver}" "${url}#${hash}" 'pypy_builder' "verify_py${PYVER//./}" 'ensurepip_lt21'

--- a/plugins/python-build/share/python-build/pypy3.11-7.3.22
+++ b/plugins/python-build/share/python-build/pypy3.11-7.3.22
@@ -1,0 +1,77 @@
+VERSION='7.3.22'
+PYVER='3.11'
+
+# https://www.pypy.org/checksums.html
+aarch64_hash=c29a8933e2084f52df74c829aa0d8f5652b9d5919f68e9fb89cab3afe35dd884
+linux32_hash=6fdad58d6d376810cf6291be1d396032f4da8109517357de0091adc3874f04c9
+linux64_hash=c0c239a6b0d381338bcccf852d0690b9daca632e0216389a3796f8817fd66e0e
+osarm64_hash=5de96e2b68a8b347fb24f8b3f5345ce0724605d4122ce194e1decce4dab8d5a0
+osx64_hash=26adf960b6f57cacb39a9f0e8fd87e9de7986762b467c75b3aaf94177aa7af87
+
+### end of manual settings - following lines same for every download
+
+function err_no_binary {
+    local archmsg="${1}"
+    local ver="pypy${PYVER}-v${VERSION}-src"
+    local url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+    { echo
+      colorize 1 "ERROR"
+      echo ": The binary distribution of PyPy is not available for ${archmsg}."
+      echo "try '${url}' to build from source."
+      echo
+    } >&2
+    exit 1
+}
+
+function pypy_pkg_data {
+    # pypy architecture tag
+    local ARCH="${1}"
+
+    # defaults
+    local cmd='install_package'  # use bz2
+    local pkg="${ARCH}" # assume matches
+    local ext='tar.bz2'
+    local hash='' # undefined
+
+    # select the hash, fix pkg if not match ARCH
+    case "${ARCH}" in
+    'linux-aarch64' )
+      hash="${aarch64_hash}"
+      pkg='aarch64'
+      ;;
+    'linux' )
+      hash="${linux32_hash}"
+      pkg='linux32'
+      ;;
+    'linux64' )
+      hash="${linux64_hash}"
+      ;;
+    'osarm64' )
+      hash="${osarm64_hash}"
+      pkg='macos_arm64'
+      ;;
+    'osx64' )
+      if require_osx_version "10.13"; then
+        hash="${osx64_hash}"
+        pkg='macos_x86_64'
+      else
+        err_no_binary "${ARCH}, OS X < 10.13"
+      fi
+      ;;
+    * )
+      err_no_binary "${ARCH}"
+      ;;
+    esac
+
+    local basever="pypy${PYVER}-v${VERSION}"
+    local baseurl="https://downloads.python.org/pypy/${basever}"
+
+    # result - command, package dir, url+hash
+    echo "${cmd}" "${basever}-${pkg}" "${baseurl}-${pkg}.${ext}#${hash}"
+}
+
+# determine command, package directory, url+hash
+declare -a pd="$(pypy_pkg_data "$(pypy_architecture 2>/dev/null || true)")"
+
+# install
+${pd[0]} "${pd[1]}" "${pd[2]}" 'pypy' "verify_py${PYVER//./}" 'ensurepip'

--- a/plugins/python-build/share/python-build/pypy3.11-7.3.22-src
+++ b/plugins/python-build/share/python-build/pypy3.11-7.3.22-src
@@ -1,0 +1,14 @@
+VERSION='7.3.22'
+PYVER='3.11'
+
+# https://www.pypy.org/checksums.html
+hash=9f885a47a232b957f9b5cc4307264af229570ddea62a9c175351afa3a6321820
+
+### end of manual settings - following lines same for every download
+
+ver="pypy${PYVER}-v${VERSION}-src"
+url="https://downloads.python.org/pypy/${ver}.tar.bz2"
+
+prefer_openssl11
+install_package "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz#186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" mac_openssl --if has_broken_mac_openssl
+install_package "${ver}" "${url}#${hash}" 'pypy_builder' "verify_py${PYVER//./}" 'ensurepip'


### PR DESCRIPTION
The release blog entry is here:
https://pypy.org/posts/2026/04/pypy-v7322-release.html

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [ ] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/XXXX

### Description
- [ ] Here are some details about my PR

### Tests
- [ ] My PR adds the following unit tests (if any)
