### PR TITLE
Add CPython 3.14.5rc1

### DIFF
--- a/plugins/python-build/share/python-build/3.14.5rc1
+++ b/plugins/python-build/share/python-build/3.14.5rc1
@@ -1,0 +1,10 @@
+prefer_openssl3
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
+install_package "openssl-3.6.2" "https://github.com/openssl/openssl/releases/download/openssl-3.6.2/openssl-3.6.2.tar.gz#aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.3" "https://ftpmirror.gnu.org/readline/readline-8.3.tar.gz#fe5383204467828cd495ee8d1d3c037a7eba1389c22bc6a041f627976f9061cc" mac_readline --if has_broken_mac_readline
+if has_tar_xz_support; then
+    install_package "Python-3.14.5rc1" "https://www.python.org/ftp/python/3.14.5/Python-3.14.5rc1.tar.xz#67ee56f36fc22e5ada84d452430362e71081804c4f85c33dc5bf4206c27f973c" standard verify_py314 copy_python_gdb ensurepip
+else
+    install_package "Python-3.14.5rc1" "https://www.python.org/ftp/python/3.14.5/Python-3.14.5rc1.tgz#6d3e5301534e221e2a4e8add507fb1a20e31d3530d32eb618f3ae0a7170bc2f0" standard verify_py314 copy_python_gdb ensurepip
+fi

--- a/plugins/python-build/share/python-build/3.14.5rc1t
+++ b/plugins/python-build/share/python-build/3.14.5rc1t
@@ -1,0 +1,2 @@
+export PYTHON_BUILD_FREE_THREADING=1
+source "${BASH_SOURCE[0]%t}"


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `python-build` definitions for CPython `3.14.5rc1`, including a free‑threaded variant `3.14.5rc1t`. This lets users install and test the upcoming release and free‑threading mode via pyenv.

- **New Features**
  - New `3.14.5rc1` definition with `.tar.xz` (fallback to `.tgz`), `verify_py314`, and `ensurepip`.
  - Prefers OpenSSL 3; sets `PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1` and `PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1`.
  - Installs `openssl-3.6.2` and `readline-8.3` on macOS when needed.
  - New `3.14.5rc1t` enables `PYTHON_BUILD_FREE_THREADING=1` and sources the same build script.

<sup>Written for commit 7c8d8ccfcef42af9282698c97c109727ab26909b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

