### PR TITLE
Add CPython 3.16-dev, switch 3.15-dev to maintenance branch

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2276,6 +2276,11 @@ build_package_verify_py315() {
   build_package_verify_py314 "$1" "${2:-3.15}"
 }
 
+# Post-install check for Python 3.16.x
+build_package_verify_py316() {
+  build_package_verify_py315 "$1" "${2:-3.16}"
+}
+
 # Post-install check for Python 3.x rolling release scripts
 # XXX: Will need splitting into project-specific ones if there emerge
 # multiple rolling-release scripts with different checks needed

--- a/plugins/python-build/share/python-build/3.16-dev
+++ b/plugins/python-build/share/python-build/3.16-dev
@@ -5,4 +5,4 @@ export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
 export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
 install_package "openssl-3.6.0" "https://github.com/openssl/openssl/releases/download/openssl-3.6.0/openssl-3.6.0.tar.gz#b6a5f44b7eb69e3fa35dbf15524405b44837a481d43d81daddde3ff21fcbb8e9" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.3" "https://ftpmirror.gnu.org/readline/readline-8.3.tar.gz#fe5383204467828cd495ee8d1d3c037a7eba1389c22bc6a041f627976f9061cc" mac_readline --if has_broken_mac_readline
-install_git "Python-3.15-dev" "https://github.com/python/cpython" 3.15 standard verify_py315 copy_python_gdb ensurepip
+install_git "Python-3.16-dev" "https://github.com/python/cpython" main standard verify_py316 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/3.16t-dev
+++ b/plugins/python-build/share/python-build/3.16t-dev
@@ -1,0 +1,2 @@
+export PYTHON_BUILD_FREE_THREADING=1
+source "$(dirname "${BASH_SOURCE[0]}")"/3.16-dev


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Python 3.16 dev support to `python-build`, including a post-install verification and a free‑threading `3.16t-dev` variant. Also pin `3.15-dev` to the CPython `3.15` branch.

- **New Features**
  - Add `share/python-build/3.16-dev` with OpenSSL 3 preference, `openssl-3.6.0`, and `readline-8.3`; installs from CPython `main` and runs `verify_py316`.
  - Add `share/python-build/3.16t-dev` that enables free-threading via `PYTHON_BUILD_FREE_THREADING=1` and sources `3.16-dev`.
  - Add `build_package_verify_py316` by reusing the 3.15 verification logic.

- **Refactors**
  - Update `3.15-dev` to install from CPython `3.15` instead of `main`.

<sup>Written for commit b7bc4b44eaef83bf1ecaeaf64b6b4979bcaba3c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

