### PR TITLE
CI: add_cpython: Support prereleases for non-initial CPython releases

### DIFF
--- a/.github/workflows/add_version.yml
+++ b/.github/workflows/add_version.yml
@@ -25,6 +25,8 @@ jobs:
       - name: check for a release
         run: |
           python plugins/python-build/scripts/add_cpython.py --verbose >added_versions.lst && rc=$? || rc=$?
+          #0 means new version found, 1 not found, 2 another error
+          [[ $rc -gt 1 ]] && false
           echo "rc=$rc" >> $GITHUB_ENV
       - name: set PR properties
         if: env.rc == 0

--- a/plugins/python-build/scripts/add_cpython.py
+++ b/plugins/python-build/scripts/add_cpython.py
@@ -369,8 +369,8 @@ class CPythonAvailableVersionsDirectory(KeyedList[_CPythonAvailableVersionInfo, 
             download_version = packaging.version.Version(m.group("version"))
             if download_version != version:
                 if not refine_mode:
-                    raise ValueError(f"Unexpectedly found a download {name} for {download_version} "
-                                     f"at page {entry.download_page_url} for {version}")
+                    raise ValueError(f"Unexpectedly found a download {name} ({download_version}) "
+                                     f"for {version} at page {entry.download_page_url}")
                 entry_to_fill = additional_versions_found.get_or_create(
                     download_version,
                     download_page_url=entry.download_page_url

--- a/plugins/python-build/scripts/add_cpython.py
+++ b/plugins/python-build/scripts/add_cpython.py
@@ -30,6 +30,13 @@ import requests_html
 import sortedcontainers
 import tqdm
 
+#CI uses exit code 1 as a signal that no new version is found
+#so have to produce a different exit code on an exception
+def _excepthook(type,value,traceback):
+    logging.error("Unhandled exception occured",exc_info=(type,value,traceback))
+    sys.exit(2)
+sys.excepthook = _excepthook
+
 logger = logging.getLogger(__name__)
 
 CUTOFF_VERSION=packaging.version.Version('3.10')

--- a/plugins/python-build/scripts/add_cpython.py
+++ b/plugins/python-build/scripts/add_cpython.py
@@ -199,11 +199,17 @@ def main():
     VersionDirectory.existing.populate()
     VersionDirectory.available.populate()
 
-    for initial_release in (v for v in frozenset(VersionDirectory.available.keys())
-                            if v.micro == 0 and v not in VersionDirectory.existing):
-        # may actually be a prerelease
-        VersionDirectory.available.get_store_available_source_downloads(initial_release, True)
-        del initial_release
+    # Prereleases are placed under the same directory as the corresponding release.
+    # So until we know the release is out, its directory is a potential prerelease directory.
+    # Normally, prereleases are only made for initial releases (x.y.0) --
+    # but rarely, they may make them for other releases (e.g. 3.14.5).
+    for release in (v for v in frozenset(VersionDirectory.available.keys())     #refining changes the
+                                                                                #corresponding directory key
+                                                                                #which breaks iteration
+                                                                                #so have to iterate over a copy
+                            if v not in VersionDirectory.existing):
+        VersionDirectory.available.get_store_available_source_downloads(release, True)
+        del release
 
     versions_to_add = sorted(VersionDirectory.available.keys() - VersionDirectory.existing.keys())
 


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Addresses https://github.com/pyenv/pyenv/pull/3440#issuecomment-4402195607

### Description
- [x] Here are some details about my PR

CPython devs unexpectedly shipped 3.14.5rc1 which caused script malfunction

### Tests
- [x] My PR adds the following unit tests (if any)
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support CPython prereleases for non-initial releases and make CI resilient by separating “no new version” from real errors to avoid false failures.

- **Bug Fixes**
  - Search all pending releases for prereleases, not just x.y.0; keep release dirs as prerelease targets until the final release exists.
  - Add a global exception hook to exit with code 2 on unhandled errors; clarify the mismatch error message in logs.
  - CI workflow: fail only when exit code > 1 (0 = added, 1 = none).

<sup>Written for commit 3399b2e2e5eae25f6ddc3960b61d561e7d6ea7c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

