### PR TITLE
Add miniconda3 26.3.2-2, miniforge3 26.3.2-0, 26.3.2-1

### DIFF
--- a/plugins/python-build/share/python-build/miniconda3-3.10-26.3.2-2
+++ b/plugins/python-build/share/python-build/miniconda3-3.10-26.3.2-2
@@ -1,0 +1,20 @@
+export CONDA_PLUGINS_AUTO_ACCEPT_TOS=true
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py310_26.3.2-2-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_26.3.2-2-Linux-aarch64.sh#4b217efc09a7ce2bed8e818ee3c0242c5b267a96254b64ce55a585eca4a79b1a" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py310_26.3.2-2-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_26.3.2-2-Linux-x86_64.sh#f07a277e0f62e2eabe42a6bc1e2ccd3d40503fbeb2b7adb7e808b2d888355761" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py310_26.3.2-2-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_26.3.2-2-MacOSX-arm64.sh#9b699985b4e27b4bfb987f7cbb79096271e3cdb2b1ea14fe0f43dbb63111d593" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.11-26.3.2-2
+++ b/plugins/python-build/share/python-build/miniconda3-3.11-26.3.2-2
@@ -1,0 +1,20 @@
+export CONDA_PLUGINS_AUTO_ACCEPT_TOS=true
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py311_26.3.2-2-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_26.3.2-2-Linux-aarch64.sh#4d18bc365dc233d34b35f30d1e2f3491c7a2956cd84c6a13eaa8851619d894b1" "miniconda" verify_py311
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py311_26.3.2-2-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_26.3.2-2-Linux-x86_64.sh#1f5ece9c2c8c5a643f95e0101fab6c824b101e82dee9132c222cbc1c1475bd32" "miniconda" verify_py311
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py311_26.3.2-2-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_26.3.2-2-MacOSX-arm64.sh#4c2ddf372bf41603a5958c756348d436ff19357628cd7e93dd091c1c1c22f229" "miniconda" verify_py311
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.12-26.3.2-2
+++ b/plugins/python-build/share/python-build/miniconda3-3.12-26.3.2-2
@@ -1,0 +1,20 @@
+export CONDA_PLUGINS_AUTO_ACCEPT_TOS=true
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py312_26.3.2-2-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_26.3.2-2-Linux-aarch64.sh#03d0268de83af20b3ea4e5a8927559b03e968d20f2e080794bc0fb762510773a" "miniconda" verify_py312
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py312_26.3.2-2-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_26.3.2-2-Linux-x86_64.sh#32673413a39a21ae3997c9b38236e9df15c9fcef930b510487c64fe259e03f95" "miniconda" verify_py312
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py312_26.3.2-2-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_26.3.2-2-MacOSX-arm64.sh#ac941aaca113aa07fb429ad3b2f6b8f086d14b1fca5872f190c4a3ac8837308c" "miniconda" verify_py312
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.13-26.3.2-2
+++ b/plugins/python-build/share/python-build/miniconda3-3.13-26.3.2-2
@@ -1,0 +1,20 @@
+export CONDA_PLUGINS_AUTO_ACCEPT_TOS=true
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py313_26.3.2-2-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py313_26.3.2-2-Linux-aarch64.sh#81a5e828724478a7a036027a74356ceff0206147d3b1243c8ba32e0cfa187967" "miniconda" verify_py313
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py313_26.3.2-2-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py313_26.3.2-2-Linux-x86_64.sh#2284bafb7863a23411b19874d216e237964d4b32dd9beb6807fa8b2d84570961" "miniconda" verify_py313
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py313_26.3.2-2-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py313_26.3.2-2-MacOSX-arm64.sh#6efc019c78003166fec1551486c68e08605eaca009039b1cda5f4e919e0c6dce" "miniconda" verify_py313
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-26.3.2-0
+++ b/plugins/python-build/share/python-build/miniforge3-26.3.2-0
@@ -1,0 +1,31 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-26.3.2-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-Linux-aarch64.sh#b8f0320c0fe9bc9dd24be8896ecf4995bbba4227c9822902daeeb7f3689ba7d3" "miniconda" verify_py312
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-26.3.2-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-Linux-ppc64le.sh#ccfef271bf337a9278d53d57760e7231f678e5ba64c5b6c9a69cbff7669a527f" "miniconda" verify_py312
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-26.3.2-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-Linux-x86_64.sh#1d9b75bdf29ba48d9f10bb155a685baab02d318d1d591d2495f97524579dccc1" "miniconda" verify_py312
+  ;;
+"MacOSX-arm64.pkg" )
+  install_script "Miniforge3-26.3.2-0-MacOSX-arm64.pkg" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-MacOSX-arm64.pkg#9c9405a3b84135640e7ef61691b9585867c6cd694f15637f8957ec802a7a5f22" "miniconda" verify_py312
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-26.3.2-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-MacOSX-arm64.sh#a58d9e5a30cac3cd5ecdba2dc52dd042584a2f742a47e975779530f89e5768f5" "miniconda" verify_py312
+  ;;
+"MacOSX-x86_64.pkg" )
+  install_script "Miniforge3-26.3.2-0-MacOSX-x86_64.pkg" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-MacOSX-x86_64.pkg#d29414aa8ac138ceec454ca644c7c16a4928edfacb351b786cc6ffaa79f5988d" "miniconda" verify_py312
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-26.3.2-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-MacOSX-x86_64.sh#f19cc973899925b29141239880787e26cd524bcecd259c2fee72e0f561fc7b54" "miniconda" verify_py312
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-26.3.2-1
+++ b/plugins/python-build/share/python-build/miniforge3-26.3.2-1
@@ -1,0 +1,31 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-26.3.2-1-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-Linux-aarch64.sh#22b8f855a3934c105a05a164d23f9a4c770dd127ec1ae26ad43114625585d9f2" "miniconda" verify_py312
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-26.3.2-1-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-Linux-ppc64le.sh#d00248a68f2083bc1bea9c157191ba2f6be43756bf5b0d6021b70f1f9372843e" "miniconda" verify_py312
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-26.3.2-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-Linux-x86_64.sh#0e80314f5f5088fb10bc06139ac6a097644ee009500e74b627192c93362b4502" "miniconda" verify_py312
+  ;;
+"MacOSX-arm64.pkg" )
+  install_script "Miniforge3-26.3.2-1-MacOSX-arm64.pkg" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-MacOSX-arm64.pkg#2b23a8ed7e3827d6882d88d8260a1a06055e09832e91fb37fef1185d491941fb" "miniconda" verify_py312
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-26.3.2-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-MacOSX-arm64.sh#031cc06de7287d1d69d6419bea0daf1a4a8bb8108711f859b1c351aa722d7281" "miniconda" verify_py312
+  ;;
+"MacOSX-x86_64.pkg" )
+  install_script "Miniforge3-26.3.2-1-MacOSX-x86_64.pkg" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-MacOSX-x86_64.pkg#d0b10344beda4cbd2e06d793c4ca2a41719447a6ca225d092e352cea309bcb1f" "miniconda" verify_py312
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-26.3.2-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-MacOSX-x86_64.sh#720022a19b363b55eadb27c807dfbba6607dc0cc7b312fb39574bdb616f5cc19" "miniconda" verify_py312
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `python-build` definitions for `miniconda3` 26.3.2-2 and `miniforge3` 26.3.2-0/-1 to enable installing these releases on Linux and macOS. Includes per-arch installers with checksums and auto-accepts Conda Plugins TOS for Miniconda.

- **New Features**
  - Added `miniconda3-3.10-26.3.2-2`, `miniconda3-3.11-26.3.2-2`, `miniconda3-3.12-26.3.2-2`, `miniconda3-3.13-26.3.2-2` for Linux aarch64/x86_64 and macOS arm64 (verify_py310–verify_py313); sets `CONDA_PLUGINS_AUTO_ACCEPT_TOS=true`.
  - Added `miniforge3-26.3.2-0` and `miniforge3-26.3.2-1` for Linux aarch64/x86_64/ppc64le and macOS arm64/x86_64 with both `.sh` and `.pkg` installers (verify_py312).
  - All installers include SHA256 hashes and return a clear error on unsupported architectures.

<sup>Written for commit 08c798f05b95e296eb6479f76b5fa17bea42d5c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

