### PR TITLE
miniforge3 26.1, 26.3, add_miniforge: exclude .pkg installers

### DIFF
--- a/plugins/python-build/scripts/add_miniforge.py
+++ b/plugins/python-build/scripts/add_miniforge.py
@@ -95,7 +95,7 @@ def py_version(version):
     raise ValueError("Bundled Python version unknown for release `%s'"%version)
 
 def supported(filename):
-    return ('pypy' not in filename) and ('Windows' not in filename)
+    return ('pypy' not in filename) and ('Windows' not in filename) and (not filename.endswith('.pkg'))
 
 def add_version(release, distributions):
     tag_name = release['tag_name']

--- a/plugins/python-build/scripts/add_miniforge.py
+++ b/plugins/python-build/scripts/add_miniforge.py
@@ -101,7 +101,8 @@ def add_version(release, distributions):
     tag_name = release['tag_name']
     download_urls = { f['name']: f['browser_download_url'] for f in release['assets'] }
     # can assume that sha files are named similar to release files so can also check supported(on their names)
-    shas = dict([download_sha(url) for (name, url) in download_urls.items() if name.endswith('.sha256') and supported(os.path.basename(name)) and tag_name in name])
+    shas = dict([download_sha(url) for (name, url) in download_urls.items()
+        if name.endswith('.sha256') and supported(os.path.splitext(name)[0]) and tag_name in name])
     specs = [create_spec(filename, sha, download_urls[filename]) for (filename, sha) in shas.items() if supported(filename)]
     
 

--- a/plugins/python-build/share/python-build/miniforge3-26.1.1-2
+++ b/plugins/python-build/share/python-build/miniforge3-26.1.1-2
@@ -8,14 +8,8 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86_64" )
   install_script "Miniforge3-26.1.1-2-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-2/Miniforge3-26.1.1-2-Linux-x86_64.sh#831421c1f32d8b510e0ef7f261aaabdbf567bdbba37373432d492621b824ab1f" "miniconda" verify_py312
   ;;
-"MacOSX-arm64.pkg" )
-  install_script "Miniforge3-26.1.1-2-MacOSX-arm64.pkg" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-2/Miniforge3-26.1.1-2-MacOSX-arm64.pkg#2cf96ab02ab575028bfe2c0d0f8ee8e7c39953588042189507d8f99c53971baf" "miniconda" verify_py312
-  ;;
 "MacOSX-arm64" )
   install_script "Miniforge3-26.1.1-2-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-2/Miniforge3-26.1.1-2-MacOSX-arm64.sh#ed60de20689ab24dd646b9ec4b06762d35f8c0043026778699ba7c9f0816492c" "miniconda" verify_py312
-  ;;
-"MacOSX-x86_64.pkg" )
-  install_script "Miniforge3-26.1.1-2-MacOSX-x86_64.pkg" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-2/Miniforge3-26.1.1-2-MacOSX-x86_64.pkg#5b7e555b22515debaf049b7cfe0eec73e0c8dc71ea1ba773b7132c852277aa72" "miniconda" verify_py312
   ;;
 "MacOSX-x86_64" )
   install_script "Miniforge3-26.1.1-2-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-2/Miniforge3-26.1.1-2-MacOSX-x86_64.sh#74f3e5cdb70bf0ff9bab3e4ba8d35aee5b46bf7eebca94202cbd8d46e16ecf77" "miniconda" verify_py312

--- a/plugins/python-build/share/python-build/miniforge3-26.1.1-3
+++ b/plugins/python-build/share/python-build/miniforge3-26.1.1-3
@@ -8,14 +8,8 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86_64" )
   install_script "Miniforge3-26.1.1-3-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-Linux-x86_64.sh#b25b828b702df4dd2a6d24d4eb56cfa912471dd8e3342cde2c3d86fe3dc2d870" "miniconda" verify_py312
   ;;
-"MacOSX-arm64.pkg" )
-  install_script "Miniforge3-26.1.1-3-MacOSX-arm64.pkg" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-MacOSX-arm64.pkg#864d4ba41bae5ad85d41d00a163535ea4b8b1ab7a4fd3b03f875c36c0c323b80" "miniconda" verify_py312
-  ;;
 "MacOSX-arm64" )
   install_script "Miniforge3-26.1.1-3-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-MacOSX-arm64.sh#38e73713bc504e11cf2a70f8bc01de4a778c547e9191e682606ba76fa4397fd9" "miniconda" verify_py312
-  ;;
-"MacOSX-x86_64.pkg" )
-  install_script "Miniforge3-26.1.1-3-MacOSX-x86_64.pkg" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-MacOSX-x86_64.pkg#34cb544a2473f2b4755bdd361520114f20a61284bcdf3c2b124a392a1aa9923f" "miniconda" verify_py312
   ;;
 "MacOSX-x86_64" )
   install_script "Miniforge3-26.1.1-3-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-MacOSX-x86_64.sh#d81e77d8f3c104c64e0ab27256f901e58ac9965288ccec774db87bf1a98a03e7" "miniconda" verify_py312

--- a/plugins/python-build/share/python-build/miniforge3-26.3.2-0
+++ b/plugins/python-build/share/python-build/miniforge3-26.3.2-0
@@ -8,14 +8,8 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86_64" )
   install_script "Miniforge3-26.3.2-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-Linux-x86_64.sh#1d9b75bdf29ba48d9f10bb155a685baab02d318d1d591d2495f97524579dccc1" "miniconda" verify_py312
   ;;
-"MacOSX-arm64.pkg" )
-  install_script "Miniforge3-26.3.2-0-MacOSX-arm64.pkg" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-MacOSX-arm64.pkg#9c9405a3b84135640e7ef61691b9585867c6cd694f15637f8957ec802a7a5f22" "miniconda" verify_py312
-  ;;
 "MacOSX-arm64" )
   install_script "Miniforge3-26.3.2-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-MacOSX-arm64.sh#a58d9e5a30cac3cd5ecdba2dc52dd042584a2f742a47e975779530f89e5768f5" "miniconda" verify_py312
-  ;;
-"MacOSX-x86_64.pkg" )
-  install_script "Miniforge3-26.3.2-0-MacOSX-x86_64.pkg" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-MacOSX-x86_64.pkg#d29414aa8ac138ceec454ca644c7c16a4928edfacb351b786cc6ffaa79f5988d" "miniconda" verify_py312
   ;;
 "MacOSX-x86_64" )
   install_script "Miniforge3-26.3.2-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-MacOSX-x86_64.sh#f19cc973899925b29141239880787e26cd524bcecd259c2fee72e0f561fc7b54" "miniconda" verify_py312

--- a/plugins/python-build/share/python-build/miniforge3-26.3.2-1
+++ b/plugins/python-build/share/python-build/miniforge3-26.3.2-1
@@ -8,14 +8,8 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86_64" )
   install_script "Miniforge3-26.3.2-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-Linux-x86_64.sh#0e80314f5f5088fb10bc06139ac6a097644ee009500e74b627192c93362b4502" "miniconda" verify_py312
   ;;
-"MacOSX-arm64.pkg" )
-  install_script "Miniforge3-26.3.2-1-MacOSX-arm64.pkg" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-MacOSX-arm64.pkg#2b23a8ed7e3827d6882d88d8260a1a06055e09832e91fb37fef1185d491941fb" "miniconda" verify_py312
-  ;;
 "MacOSX-arm64" )
   install_script "Miniforge3-26.3.2-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-MacOSX-arm64.sh#031cc06de7287d1d69d6419bea0daf1a4a8bb8108711f859b1c351aa722d7281" "miniconda" verify_py312
-  ;;
-"MacOSX-x86_64.pkg" )
-  install_script "Miniforge3-26.3.2-1-MacOSX-x86_64.pkg" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-MacOSX-x86_64.pkg#d0b10344beda4cbd2e06d793c4ca2a41719447a6ca225d092e352cea309bcb1f" "miniconda" verify_py312
   ;;
 "MacOSX-x86_64" )
   install_script "Miniforge3-26.3.2-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-MacOSX-x86_64.sh#720022a19b363b55eadb27c807dfbba6607dc0cc7b312fb39574bdb616f5cc19" "miniconda" verify_py312


### PR DESCRIPTION
According to Miniforge README, they are only meant for interactive installation

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR
see above

### Tests
- [x] My PR adds the following unit tests (if any)
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude macOS `.pkg` Miniforge installers in `python-build` to avoid interactive installs in CI. Only `.sh` installers are used for `miniforge3` 26.1.x and 26.3.x.

- **Bug Fixes**
  - In `plugins/python-build/scripts/add_miniforge.py`, updated `supported()` and SHA filtering to skip `.pkg` files and their `.sha256` assets.
  - Removed `.pkg` entries from `share/python-build/miniforge3-26.1.1-2`, `miniforge3-26.1.1-3`, `miniforge3-26.3.2-0`, and `miniforge3-26.3.2-1`.

<sup>Written for commit b6ebf378f54b4151ebf0d935ba6604cf33b2c5d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

