### PR TITLE
miniforge 26, CI: switch check to 3.13

### DIFF
--- a/plugins/python-build/scripts/add_miniforge.py
+++ b/plugins/python-build/scripts/add_miniforge.py
@@ -86,6 +86,9 @@ def py_version(version):
     # transition points:
     # https://github.com/conda-forge/miniforge/blame/main/Miniforge3/construct.yaml
     # look for "- python <version>" in non-pypy branch and which tag the commit is first in
+    if version_tuple_ >= (26,1):
+        # https://github.com/conda-forge/miniforge/commit/0016367731e52c67234d6d0e7e6a24c6bf7673e4
+        return "313"
     if version_tuple_ >= (24,5):
         # yes, they jumped from 3.10 directly to 3.12
         # https://github.com/conda-forge/miniforge/commit/bddad0baf22b37cfe079e47fd1680fdfb2183590

--- a/plugins/python-build/share/python-build/miniforge3-26.1.0-0
+++ b/plugins/python-build/share/python-build/miniforge3-26.1.0-0
@@ -1,18 +1,18 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-aarch64" )
-  install_script "Miniforge3-26.1.0-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.0-0/Miniforge3-26.1.0-0-Linux-aarch64.sh#8baf8844ecf13e1458f81659ea286251d04b2d5ed90040efb77f158adedb2d95" "miniconda" verify_py312
+  install_script "Miniforge3-26.1.0-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.0-0/Miniforge3-26.1.0-0-Linux-aarch64.sh#8baf8844ecf13e1458f81659ea286251d04b2d5ed90040efb77f158adedb2d95" "miniconda" verify_py313
   ;;
 "Linux-ppc64le" )
-  install_script "Miniforge3-26.1.0-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.0-0/Miniforge3-26.1.0-0-Linux-ppc64le.sh#902190ad825b74b78a6a2816364453bb4d6989a599172aa3785d4afd0ebeb917" "miniconda" verify_py312
+  install_script "Miniforge3-26.1.0-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.0-0/Miniforge3-26.1.0-0-Linux-ppc64le.sh#902190ad825b74b78a6a2816364453bb4d6989a599172aa3785d4afd0ebeb917" "miniconda" verify_py313
   ;;
 "Linux-x86_64" )
-  install_script "Miniforge3-26.1.0-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.0-0/Miniforge3-26.1.0-0-Linux-x86_64.sh#127b5e14cfe6c83b787f624487cdc2168645ed82fdca1b0c1937caa086aed6d5" "miniconda" verify_py312
+  install_script "Miniforge3-26.1.0-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.0-0/Miniforge3-26.1.0-0-Linux-x86_64.sh#127b5e14cfe6c83b787f624487cdc2168645ed82fdca1b0c1937caa086aed6d5" "miniconda" verify_py313
   ;;
 "MacOSX-arm64" )
-  install_script "Miniforge3-26.1.0-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.0-0/Miniforge3-26.1.0-0-MacOSX-arm64.sh#219b9e0d733fa2086d7d094a5ed830db146ccf22ae32c330b2da5df5c9604b78" "miniconda" verify_py312
+  install_script "Miniforge3-26.1.0-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.0-0/Miniforge3-26.1.0-0-MacOSX-arm64.sh#219b9e0d733fa2086d7d094a5ed830db146ccf22ae32c330b2da5df5c9604b78" "miniconda" verify_py313
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniforge3-26.1.0-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.0-0/Miniforge3-26.1.0-0-MacOSX-x86_64.sh#90a41a28ad0221fbaf728ca1267f6243638a56c579fba8a1b970edfee4062d53" "miniconda" verify_py312
+  install_script "Miniforge3-26.1.0-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.0-0/Miniforge3-26.1.0-0-MacOSX-x86_64.sh#90a41a28ad0221fbaf728ca1267f6243638a56c579fba8a1b970edfee4062d53" "miniconda" verify_py313
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniforge3-26.1.1-2
+++ b/plugins/python-build/share/python-build/miniforge3-26.1.1-2
@@ -1,18 +1,18 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-aarch64" )
-  install_script "Miniforge3-26.1.1-2-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-2/Miniforge3-26.1.1-2-Linux-aarch64.sh#6525bfb24940c5e063ed14f2d840968b0fc4152a3f4edd253b7a1049a15656e7" "miniconda" verify_py312
+  install_script "Miniforge3-26.1.1-2-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-2/Miniforge3-26.1.1-2-Linux-aarch64.sh#6525bfb24940c5e063ed14f2d840968b0fc4152a3f4edd253b7a1049a15656e7" "miniconda" verify_py313
   ;;
 "Linux-ppc64le" )
-  install_script "Miniforge3-26.1.1-2-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-2/Miniforge3-26.1.1-2-Linux-ppc64le.sh#637cf03310343d199bcd7725aab54f59666fb1694bb99fc841973203da9c3f25" "miniconda" verify_py312
+  install_script "Miniforge3-26.1.1-2-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-2/Miniforge3-26.1.1-2-Linux-ppc64le.sh#637cf03310343d199bcd7725aab54f59666fb1694bb99fc841973203da9c3f25" "miniconda" verify_py313
   ;;
 "Linux-x86_64" )
-  install_script "Miniforge3-26.1.1-2-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-2/Miniforge3-26.1.1-2-Linux-x86_64.sh#831421c1f32d8b510e0ef7f261aaabdbf567bdbba37373432d492621b824ab1f" "miniconda" verify_py312
+  install_script "Miniforge3-26.1.1-2-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-2/Miniforge3-26.1.1-2-Linux-x86_64.sh#831421c1f32d8b510e0ef7f261aaabdbf567bdbba37373432d492621b824ab1f" "miniconda" verify_py313
   ;;
 "MacOSX-arm64" )
-  install_script "Miniforge3-26.1.1-2-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-2/Miniforge3-26.1.1-2-MacOSX-arm64.sh#ed60de20689ab24dd646b9ec4b06762d35f8c0043026778699ba7c9f0816492c" "miniconda" verify_py312
+  install_script "Miniforge3-26.1.1-2-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-2/Miniforge3-26.1.1-2-MacOSX-arm64.sh#ed60de20689ab24dd646b9ec4b06762d35f8c0043026778699ba7c9f0816492c" "miniconda" verify_py313
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniforge3-26.1.1-2-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-2/Miniforge3-26.1.1-2-MacOSX-x86_64.sh#74f3e5cdb70bf0ff9bab3e4ba8d35aee5b46bf7eebca94202cbd8d46e16ecf77" "miniconda" verify_py312
+  install_script "Miniforge3-26.1.1-2-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-2/Miniforge3-26.1.1-2-MacOSX-x86_64.sh#74f3e5cdb70bf0ff9bab3e4ba8d35aee5b46bf7eebca94202cbd8d46e16ecf77" "miniconda" verify_py313
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniforge3-26.1.1-3
+++ b/plugins/python-build/share/python-build/miniforge3-26.1.1-3
@@ -1,18 +1,18 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-aarch64" )
-  install_script "Miniforge3-26.1.1-3-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-Linux-aarch64.sh#83280e4ee71a5bd547d6b318f96e9ababe1054911ff6cc2b8801ce5493fe67e5" "miniconda" verify_py312
+  install_script "Miniforge3-26.1.1-3-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-Linux-aarch64.sh#83280e4ee71a5bd547d6b318f96e9ababe1054911ff6cc2b8801ce5493fe67e5" "miniconda" verify_py313
   ;;
 "Linux-ppc64le" )
-  install_script "Miniforge3-26.1.1-3-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-Linux-ppc64le.sh#5711fd69219bc9746389ef751ee4c2549d40d9b1626a0ea93cc63db1a739eee6" "miniconda" verify_py312
+  install_script "Miniforge3-26.1.1-3-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-Linux-ppc64le.sh#5711fd69219bc9746389ef751ee4c2549d40d9b1626a0ea93cc63db1a739eee6" "miniconda" verify_py313
   ;;
 "Linux-x86_64" )
-  install_script "Miniforge3-26.1.1-3-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-Linux-x86_64.sh#b25b828b702df4dd2a6d24d4eb56cfa912471dd8e3342cde2c3d86fe3dc2d870" "miniconda" verify_py312
+  install_script "Miniforge3-26.1.1-3-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-Linux-x86_64.sh#b25b828b702df4dd2a6d24d4eb56cfa912471dd8e3342cde2c3d86fe3dc2d870" "miniconda" verify_py313
   ;;
 "MacOSX-arm64" )
-  install_script "Miniforge3-26.1.1-3-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-MacOSX-arm64.sh#38e73713bc504e11cf2a70f8bc01de4a778c547e9191e682606ba76fa4397fd9" "miniconda" verify_py312
+  install_script "Miniforge3-26.1.1-3-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-MacOSX-arm64.sh#38e73713bc504e11cf2a70f8bc01de4a778c547e9191e682606ba76fa4397fd9" "miniconda" verify_py313
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniforge3-26.1.1-3-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-MacOSX-x86_64.sh#d81e77d8f3c104c64e0ab27256f901e58ac9965288ccec774db87bf1a98a03e7" "miniconda" verify_py312
+  install_script "Miniforge3-26.1.1-3-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-MacOSX-x86_64.sh#d81e77d8f3c104c64e0ab27256f901e58ac9965288ccec774db87bf1a98a03e7" "miniconda" verify_py313
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniforge3-26.3.2-0
+++ b/plugins/python-build/share/python-build/miniforge3-26.3.2-0
@@ -1,18 +1,18 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-aarch64" )
-  install_script "Miniforge3-26.3.2-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-Linux-aarch64.sh#b8f0320c0fe9bc9dd24be8896ecf4995bbba4227c9822902daeeb7f3689ba7d3" "miniconda" verify_py312
+  install_script "Miniforge3-26.3.2-0-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-Linux-aarch64.sh#b8f0320c0fe9bc9dd24be8896ecf4995bbba4227c9822902daeeb7f3689ba7d3" "miniconda" verify_py313
   ;;
 "Linux-ppc64le" )
-  install_script "Miniforge3-26.3.2-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-Linux-ppc64le.sh#ccfef271bf337a9278d53d57760e7231f678e5ba64c5b6c9a69cbff7669a527f" "miniconda" verify_py312
+  install_script "Miniforge3-26.3.2-0-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-Linux-ppc64le.sh#ccfef271bf337a9278d53d57760e7231f678e5ba64c5b6c9a69cbff7669a527f" "miniconda" verify_py313
   ;;
 "Linux-x86_64" )
-  install_script "Miniforge3-26.3.2-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-Linux-x86_64.sh#1d9b75bdf29ba48d9f10bb155a685baab02d318d1d591d2495f97524579dccc1" "miniconda" verify_py312
+  install_script "Miniforge3-26.3.2-0-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-Linux-x86_64.sh#1d9b75bdf29ba48d9f10bb155a685baab02d318d1d591d2495f97524579dccc1" "miniconda" verify_py313
   ;;
 "MacOSX-arm64" )
-  install_script "Miniforge3-26.3.2-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-MacOSX-arm64.sh#a58d9e5a30cac3cd5ecdba2dc52dd042584a2f742a47e975779530f89e5768f5" "miniconda" verify_py312
+  install_script "Miniforge3-26.3.2-0-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-MacOSX-arm64.sh#a58d9e5a30cac3cd5ecdba2dc52dd042584a2f742a47e975779530f89e5768f5" "miniconda" verify_py313
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniforge3-26.3.2-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-MacOSX-x86_64.sh#f19cc973899925b29141239880787e26cd524bcecd259c2fee72e0f561fc7b54" "miniconda" verify_py312
+  install_script "Miniforge3-26.3.2-0-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-MacOSX-x86_64.sh#f19cc973899925b29141239880787e26cd524bcecd259c2fee72e0f561fc7b54" "miniconda" verify_py313
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniforge3-26.3.2-1
+++ b/plugins/python-build/share/python-build/miniforge3-26.3.2-1
@@ -1,18 +1,18 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-aarch64" )
-  install_script "Miniforge3-26.3.2-1-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-Linux-aarch64.sh#22b8f855a3934c105a05a164d23f9a4c770dd127ec1ae26ad43114625585d9f2" "miniconda" verify_py312
+  install_script "Miniforge3-26.3.2-1-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-Linux-aarch64.sh#22b8f855a3934c105a05a164d23f9a4c770dd127ec1ae26ad43114625585d9f2" "miniconda" verify_py313
   ;;
 "Linux-ppc64le" )
-  install_script "Miniforge3-26.3.2-1-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-Linux-ppc64le.sh#d00248a68f2083bc1bea9c157191ba2f6be43756bf5b0d6021b70f1f9372843e" "miniconda" verify_py312
+  install_script "Miniforge3-26.3.2-1-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-Linux-ppc64le.sh#d00248a68f2083bc1bea9c157191ba2f6be43756bf5b0d6021b70f1f9372843e" "miniconda" verify_py313
   ;;
 "Linux-x86_64" )
-  install_script "Miniforge3-26.3.2-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-Linux-x86_64.sh#0e80314f5f5088fb10bc06139ac6a097644ee009500e74b627192c93362b4502" "miniconda" verify_py312
+  install_script "Miniforge3-26.3.2-1-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-Linux-x86_64.sh#0e80314f5f5088fb10bc06139ac6a097644ee009500e74b627192c93362b4502" "miniconda" verify_py313
   ;;
 "MacOSX-arm64" )
-  install_script "Miniforge3-26.3.2-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-MacOSX-arm64.sh#031cc06de7287d1d69d6419bea0daf1a4a8bb8108711f859b1c351aa722d7281" "miniconda" verify_py312
+  install_script "Miniforge3-26.3.2-1-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-MacOSX-arm64.sh#031cc06de7287d1d69d6419bea0daf1a4a8bb8108711f859b1c351aa722d7281" "miniconda" verify_py313
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniforge3-26.3.2-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-MacOSX-x86_64.sh#720022a19b363b55eadb27c807dfbba6607dc0cc7b312fb39574bdb616f5cc19" "miniconda" verify_py312
+  install_script "Miniforge3-26.3.2-1-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-1/Miniforge3-26.3.2-1-MacOSX-x86_64.sh#720022a19b363b55eadb27c807dfbba6607dc0cc7b312fb39574bdb616f5cc19" "miniconda" verify_py313
   ;;
 * )
   { echo


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Miniforge 26 installers to Python 3.13 in `python-build`, and update CI checks to 3.13. `add_miniforge.py` now maps Miniforge >= 26.1 to 313, and the `miniforge3-26.*` definitions use verify_py313.

<sup>Written for commit 42b87902ff989d8a777fb66c8d7e8098dc389dbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

