### PR TITLE
2.7, 3.4: force C99 standard; 2.7.14-18: force OpenSSL 1 formula

### DIFF
--- a/plugins/python-build/share/python-build/2.7-dev
+++ b/plugins/python-build/share/python-build/2.7-dev
@@ -1,4 +1,4 @@
-prefer_openssl11
+export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl@1.1 openssl@1.0}"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7-dev
+++ b/plugins/python-build/share/python-build/2.7-dev
@@ -1,4 +1,5 @@
 export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl@1.1 openssl@1.0}"
+export PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA="${PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA:-openssl11 openssl10}"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7-dev
+++ b/plugins/python-build/share/python-build/2.7-dev
@@ -1,4 +1,5 @@
 prefer_openssl11
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_git "Python-2.7-dev" "https://github.com/python/cpython" "2.7" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.0
+++ b/plugins/python-build/share/python-build/2.7.0
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_package "Python-2.7" "https://www.python.org/ftp/python/2.7/Python-2.7.tgz#5670dd6c0c93b0b529781d070852f7b51ce6855615b16afcd318341af2910fb5" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.1
+++ b/plugins/python-build/share/python-build/2.7.1
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_package "Python-2.7.1" "https://www.python.org/ftp/python/2.7.1/Python-2.7.1.tgz#ca13e7b1860821494f70de017202283ad73b1fb7bd88586401c54ef958226ec8" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.10
+++ b/plugins/python-build/share/python-build/2.7.10
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/2.7.11
+++ b/plugins/python-build/share/python-build/2.7.11
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/2.7.12
+++ b/plugins/python-build/share/python-build/2.7.12
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/2.7.13
+++ b/plugins/python-build/share/python-build/2.7.13
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/2.7.14
+++ b/plugins/python-build/share/python-build/2.7.14
@@ -1,4 +1,5 @@
 export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl@1.1 openssl@1.0}"
+export PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA="${PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA:-openssl11 openssl10}"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7.14
+++ b/plugins/python-build/share/python-build/2.7.14
@@ -1,5 +1,4 @@
 export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl@1.1 openssl@1.0}"
-export PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA="${PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA:-openssl11 openssl3 openssl}"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7.14
+++ b/plugins/python-build/share/python-build/2.7.14
@@ -1,4 +1,5 @@
-export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="openssl@1.1 openssl@1.0"
+export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl@1.1 openssl@1.0}"
+export PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA="${PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA:-openssl11 openssl3 openssl}"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7.14
+++ b/plugins/python-build/share/python-build/2.7.14
@@ -1,4 +1,4 @@
-prefer_openssl11
+export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="openssl@1.1 openssl@1.0"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7.14
+++ b/plugins/python-build/share/python-build/2.7.14
@@ -1,4 +1,5 @@
 prefer_openssl11
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/2.7.15
+++ b/plugins/python-build/share/python-build/2.7.15
@@ -1,4 +1,5 @@
 export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl@1.1 openssl@1.0}"
+export PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA="${PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA:-openssl11 openssl10}"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7.15
+++ b/plugins/python-build/share/python-build/2.7.15
@@ -1,5 +1,4 @@
 export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl@1.1 openssl@1.0}"
-export PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA="${PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA:-openssl11 openssl3 openssl}"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7.15
+++ b/plugins/python-build/share/python-build/2.7.15
@@ -1,4 +1,5 @@
-export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="openssl@1.1 openssl@1.0"
+export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl@1.1 openssl@1.0}"
+export PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA="${PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA:-openssl11 openssl3 openssl}"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7.15
+++ b/plugins/python-build/share/python-build/2.7.15
@@ -1,4 +1,4 @@
-prefer_openssl11
+export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="openssl@1.1 openssl@1.0"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7.15
+++ b/plugins/python-build/share/python-build/2.7.15
@@ -1,4 +1,5 @@
 prefer_openssl11
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/2.7.16
+++ b/plugins/python-build/share/python-build/2.7.16
@@ -1,4 +1,4 @@
-export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="openssl@1.1 openssl@1.0"
+export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl@1.1 openssl@1.0}"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7.16
+++ b/plugins/python-build/share/python-build/2.7.16
@@ -1,3 +1,5 @@
+prefer_openssl11
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/2.7.16
+++ b/plugins/python-build/share/python-build/2.7.16
@@ -1,4 +1,4 @@
-prefer_openssl11
+export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="openssl@1.1 openssl@1.0"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7.16
+++ b/plugins/python-build/share/python-build/2.7.16
@@ -1,4 +1,5 @@
 export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl@1.1 openssl@1.0}"
+export PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA="${PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA:-openssl11 openssl10}"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7.17
+++ b/plugins/python-build/share/python-build/2.7.17
@@ -1,3 +1,5 @@
+export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="openssl@1.1 openssl@1.0"
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/2.7.17
+++ b/plugins/python-build/share/python-build/2.7.17
@@ -1,4 +1,4 @@
-export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="openssl@1.1 openssl@1.0"
+export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl@1.1 openssl@1.0}"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7.17
+++ b/plugins/python-build/share/python-build/2.7.17
@@ -1,4 +1,5 @@
 export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl@1.1 openssl@1.0}"
+export PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA="${PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA:-openssl11 openssl10}"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7.18
+++ b/plugins/python-build/share/python-build/2.7.18
@@ -1,4 +1,4 @@
-export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="openssl@1.1 openssl@1.0"
+export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl@1.1 openssl@1.0}"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.1v" "https://www.openssl.org/source/openssl-1.1.1v.tar.gz" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7.18
+++ b/plugins/python-build/share/python-build/2.7.18
@@ -1,4 +1,5 @@
 export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl@1.1 openssl@1.0}"
+export PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA="${PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA:-openssl11 openssl10}"
 export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.1v" "https://www.openssl.org/source/openssl-1.1.1v.tar.gz" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline

--- a/plugins/python-build/share/python-build/2.7.18
+++ b/plugins/python-build/share/python-build/2.7.18
@@ -1,4 +1,5 @@
-export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="openssl@1.1 openssl@1.0 openssl"
+export PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA="openssl@1.1 openssl@1.0"
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.1v" "https://www.openssl.org/source/openssl-1.1.1v.tar.gz" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/2.7.2
+++ b/plugins/python-build/share/python-build/2.7.2
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_package "Python-2.7.2" "https://www.python.org/ftp/python/2.7.2/Python-2.7.2.tgz#1d54b7096c17902c3f40ffce7e5b84e0072d0144024184fff184a84d563abbb3" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.3
+++ b/plugins/python-build/share/python-build/2.7.3
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_package "Python-2.7.3" "https://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz#d4c20f2b5faf95999fd5fecb3f7d32071b0820516224a6d2b72932ab47a1cb8e" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.4
+++ b/plugins/python-build/share/python-build/2.7.4
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_package "Python-2.7.4" "https://www.python.org/ftp/python/2.7.4/Python-2.7.4.tgz#98c5eb9c8e65effcc0122112ba17a0bce880aa23ecb560af56b55eb55632b81a" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.5
+++ b/plugins/python-build/share/python-build/2.7.5
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_package "Python-2.7.5" "https://www.python.org/ftp/python/2.7.5/Python-2.7.5.tgz#8e1b5fa87b91835afb376a9c0d319d41feca07ffebc0288d97ab08d64f48afbf" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.6
+++ b/plugins/python-build/share/python-build/2.7.6
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_package "Python-2.7.6" "https://www.python.org/ftp/python/2.7.6/Python-2.7.6.tgz#99c6860b70977befa1590029fae092ddb18db1d69ae67e8b9385b66ed104ba58" standard verify_py27 copy_python_gdb ensurepip

--- a/plugins/python-build/share/python-build/2.7.7
+++ b/plugins/python-build/share/python-build/2.7.7
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/2.7.8
+++ b/plugins/python-build/share/python-build/2.7.8
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/2.7.9
+++ b/plugins/python-build/share/python-build/2.7.9
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.4-dev
+++ b/plugins/python-build/share/python-build/3.4-dev
@@ -1,4 +1,5 @@
 prefer_openssl11
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 install_git "Python-3.4-dev" "https://github.com/python/cpython" "3.4" standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.0
+++ b/plugins/python-build/share/python-build/3.4.0
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.4.1
+++ b/plugins/python-build/share/python-build/3.4.1
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.4.10
+++ b/plugins/python-build/share/python-build/3.4.10
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 has_tar_xz_support \

--- a/plugins/python-build/share/python-build/3.4.2
+++ b/plugins/python-build/share/python-build/3.4.2
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.4.3
+++ b/plugins/python-build/share/python-build/3.4.3
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.4.4
+++ b/plugins/python-build/share/python-build/3.4.4
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.4.5
+++ b/plugins/python-build/share/python-build/3.4.5
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.4.6
+++ b/plugins/python-build/share/python-build/3.4.6
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.4.7
+++ b/plugins/python-build/share/python-build/3.4.7
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.4.8
+++ b/plugins/python-build/share/python-build/3.4.8
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then

--- a/plugins/python-build/share/python-build/3.4.9
+++ b/plugins/python-build/share/python-build/3.4.9
@@ -1,3 +1,4 @@
+export PYTHON_CFLAGS="${PYTHON_CFLAGS:+$PYTHON_CFLAGS }-std=c99"
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then


### PR DESCRIPTION
GCC 15+ uses C23 by default
(https://www.phoronix.com/news/GCC-15-Default-C23)

fixes "error: static declaration of ‘sinpi’ follows non-static declaration"
fixes "error: cannot use keyword ‘false’ as enumeration constant"

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3335
  - Closes https://github.com/pyenv/pyenv/issues/3409

### Description
- [x] Here are some details about my PR
see above

### Tests
- [x] My PR adds the following unit tests (if any)
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force C99 when building Python 2.7 and 3.4 in `python-build` to keep them compiling with GCC 15+. Also lock OpenSSL for late 2.7 to 1.x on Homebrew and MacPorts, removing the `openssl` fallback.

- **Bug Fixes**
  - Export `PYTHON_CFLAGS` with `-std=c99` across all 2.7.x and 3.4.x definitions.
  - Resolves GCC 15+ build failures:
    - “static declaration of ‘sinpi’ follows non-static declaration”
    - “cannot use keyword ‘false’ as enumeration constant”

- **Dependencies**
  - Homebrew: for `2.7-dev` and 2.7.14–2.7.18, default `PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA` to `openssl@1.1 openssl@1.0` (only if unset); remove `openssl` fallback from 2.7.18; replace `prefer_openssl11` where needed.
  - MacPorts: for `2.7-dev` and 2.7.14–2.7.18, default `PYTHON_BUILD_MACPORTS_OPENSSL_FORMULA` to `openssl11 openssl10` (only if unset).

<sup>Written for commit 3b83d8cc3fa89bcb4d399c32ec5b1f225d02effe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

