### PR TITLE
rehash: detect and remove a stale lockfile

### DIFF
--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -19,7 +19,7 @@ acquire_lock() {
   local ret
   set -o noclobber
   # Assuming an old lockfile is stale
-  # Unknowns why this happens for some users but this at least unblocks them
+  # Unknown why this happens for some users but this at least unblocks them
   last_acquire_error="$( { ( echo -n > "$PROTOTYPE_SHIM_PATH"; ) 2>&1 1>&3 3>&1-; } 3>&1)" \
     || { find "$PROTOTYPE_SHIM_PATH" -mmin +10 -exec rm -f {} \; ; ret=1; }
   set +o noclobber

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -2,7 +2,7 @@
 # Summary: Rehash pyenv shims (run this after installing executables)
 
 set -e
-[ -n "$PYENV_DEBUG" ] && set -x
+[[ -n "$PYENV_DEBUG" ]] && set -x
 
 SHIM_PATH="${PYENV_ROOT}/shims"
 PROTOTYPE_SHIM_PATH="${SHIM_PATH}/.pyenv-shim"
@@ -15,13 +15,15 @@ declare last_acquire_error
 acquire_lock() {
   # Ensure only one instance of pyenv-rehash is running at a time by
   # setting the shell's `noclobber` option and attempting to write to
-  # the prototype shim file. If the file already exists, print a warning
-  # to stderr and exit with a non-zero status.
+  # the prototype shim file.
   local ret
   set -o noclobber
-  last_acquire_error="$( { ( echo -n > "$PROTOTYPE_SHIM_PATH"; ) 2>&1 1>&3 3>&1-; } 3>&1)" || ret=1
+  # Assuming an old lockfile is stale
+  # Unknowns why this happens for some users but this at least unblocks them
+  last_acquire_error="$( { ( echo -n > "$PROTOTYPE_SHIM_PATH"; ) 2>&1 1>&3 3>&1-; } 3>&1)" \
+    || { find "$PROTOTYPE_SHIM_PATH" -mmin +10 -exec rm -f {} \; ; ret=1; }
   set +o noclobber
-  [ -z "${ret}" ]
+  [[ -z "${ret}" ]]
 }
 
 remove_prototype_shim() {

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -40,7 +40,7 @@ pyenv: cannot rehash: couldn't acquire lock ${PYENV_ROOT}/shims/.pyenv-shim for 
 
 @test "stale lockfile is removed" {
   mkdir -p "${PYENV_ROOT}/shims"
-  touch -t "$(date --date '-10 min' '+%Y%m%d%H%M.%S' 2>/dev/null || date -v-10M '+%Y%m%d%H%M.%S')" "${PYENV_ROOT}/shims/.pyenv-shim"
+  touch -t 200001010000.00 "${PYENV_ROOT}/shims/.pyenv-shim"
   run pyenv-rehash
   assert_success ""
   assert [ ! -e "${PYENV_ROOT}/shims/.pyenv-shim" ]

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -40,6 +40,8 @@ pyenv: cannot rehash: couldn't acquire lock ${PYENV_ROOT}/shims/.pyenv-shim for 
 
 @test "stale lockfile is removed" {
   mkdir -p "${PYENV_ROOT}/shims"
+  #GNU and BSD `date` support generating relative dates via different syntax
+  # but BusyBox `date` used in Bash Docker images doesn't
   touch -t 200001010000.00 "${PYENV_ROOT}/shims/.pyenv-shim"
   run pyenv-rehash
   assert_success ""

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -38,6 +38,16 @@ pyenv: cannot rehash: couldn't acquire lock ${PYENV_ROOT}/shims/.pyenv-shim for 
   assert_success
 }
 
+@test "stale lockfile is removed" {
+  mkdir -p "${PYENV_ROOT}/shims"
+  touch -t "$(date --date '-10 min' '+%Y%m%d%H%M.%S' 2>/dev/null || date -v-10M '+%Y%m%d%H%M.%S')" "${PYENV_ROOT}/shims/.pyenv-shim"
+  run pyenv-rehash
+  assert_success ""
+  assert [ ! -e "${PYENV_ROOT}/shims/.pyenv-shim" ]
+}
+
+
+
 @test "creates shims" {
   create_alt_executable_in_version "2.7" "python"
   create_alt_executable_in_version "2.7" "fab"


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/2829

### Description
- [x] Here are some details about my PR

fixes stalling for 60s and failing if some past fault has resulting in a stale lockfile being present

### Tests
- [x] My PR adds the following unit tests (if any)
Test for the added feature

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect and remove stale `.pyenv-shim` lockfiles older than 10 minutes during `pyenv-rehash`. Prevents 60s stalls and failures from leftover locks; adds a test to verify cleanup.

<sup>Written for commit 11a46aa94c6eee53a53303a9608a9dc3ad2d3957. Summary will update on new commits. <a href="https://cubic.dev/pr/pyenv/pyenv/pull/3450?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

