### PR TITLE
Add GraalPy 25.0.3

### DIFF
--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -56,7 +56,7 @@ jobs:
               if name == 'anaconda3' and version >= packaging.version.Version('2025.12'):
                 result.append({'os':'macos-15-intel','python-version':line})
           
-            if m:=re.match(r'graalpy-(community-)?-(\d+\.\d+.\d+)', line):
+            if m:=re.match(r'graalpy-(community-)?(\d+\.\d+.\d+)', line):
               version = packaging.version.Version(m.group(2))
               
               # GraalPy dropped MacOS x64 support

--- a/plugins/python-build/share/python-build/graalpy-25.0.3
+++ b/plugins/python-build/share/python-build/graalpy-25.0.3
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+VERSION='25.0.3'
+BUILD=''
+
+colorize 1 "GraalPy 23.1 and later installed by python-build use the faster Oracle GraalVM distribution" && echo
+colorize 1 "Oracle GraalVM uses the GFTC license, which is free for development and production use, see https://medium.com/graalvm/161527df3d76" && echo
+colorize 1 "The GraalVM Community Edition variant of GraalPy is also available, under the name graalpy-community-${VERSION}" && echo
+
+
+graalpy_arch="$(graalpy_architecture 2>/dev/null || true)"
+
+case "$graalpy_arch" in
+"linux-amd64" )
+  checksum="c351b503d212519ad5e7e835fd9eb56b557ca9d5b6ef59e32b40435603f90bf8"
+  ;;
+"linux-aarch64" )
+  checksum="f889a02425b0b55a0f070d63324f3d08e0975ea0b33aa69041c14418cf6cdeec"
+  ;;
+"macos-aarch64" )
+  checksum="387d9f5b376860842bea4d55aae5820974f3f3b68fc36c77ae863a061a888857"
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": No binary distribution of GraalPy is available for $(uname -sm)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac
+
+if [ -n "${BUILD}" ]; then
+  { echo
+    colorize 1 "ERROR"
+    echo "Oracle GraalPy currently doesn't provide snapshot builds. Use graalpy-community if you need snapshots."
+    echo
+  } >&2
+  exit 1
+fi
+
+url="https://github.com/oracle/graalpython/releases/download/graal-${VERSION}/graalpy-${VERSION}-${graalpy_arch}.tar.gz#${checksum}"
+
+install_package "graalpy-${VERSION}" "${url}" "copy" ensurepip

--- a/plugins/python-build/share/python-build/graalpy-community-25.0.3
+++ b/plugins/python-build/share/python-build/graalpy-community-25.0.3
@@ -1,0 +1,51 @@
+# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+VERSION='25.0.3'
+BUILD=''
+
+graalpy_arch="$(graalpy_architecture 2>/dev/null || true)"
+
+case "$graalpy_arch" in
+"linux-amd64" )
+  checksum="e27fb0a39e687713fd23e096725b858d64e26459be52f6a7d2305e2e666d49de"
+  ;;
+"linux-aarch64" )
+  checksum="1e077318fe2f525f2c6d423548d781bffd4fd01bbf51eccdaa33771e843a0d4f"
+  ;;
+"macos-aarch64" )
+  checksum="2054e717d51facd60fc9f280492c0596eaca86c23731dcb156fef89975f2d00a"
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": No binary distribution of GraalPy is available for $(uname -sm)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac
+
+if [ -n "${BUILD}" ]; then
+  url="https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/${VERSION}-dev-${BUILD}/graalpy-community-dev-${graalpy_arch}.tar.gz"
+else
+  url="https://github.com/oracle/graalpython/releases/download/graal-${VERSION}/graalpy-community-${VERSION}-${graalpy_arch}.tar.gz#${checksum}"
+fi
+
+install_package "graalpy-community-${VERSION}${BUILD}" "${url}" "copy" ensurepip


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `graalpy-25.0.3` and `graalpy-community-25.0.3` to `python-build`, with arch-specific binaries and ensurepip enabled. Also fixes CI version detection for GraalPy entries.

- **New Features**
  - Install definitions for Oracle and Community variants of GraalPy 25.0.3.
  - Validates architecture and uses release tarballs with SHA-256 checksums; clear error for unsupported platforms.
  - Oracle variant prints distribution/license notes and rejects `BUILD` snapshots; Community variant supports `-dev` builds via `BUILD`.

- **Bug Fixes**
  - Corrects regex in `modified_scripts_build.yml` to detect `graalpy-<version>` and `graalpy-community-<version>` properly, ensuring CI matrix rules apply (e.g., skip macOS x64).

<sup>Written for commit e52da606ff38b573879db16ca4096ec8a911d8f0. Summary will update on new commits. <a href="https://cubic.dev/pr/pyenv/pyenv/pull/3452?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

