### PR TITLE
CI: use CCache in macos-build and ubuntu-build

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2      
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
             create-symlink: true
             key: ${{ github.job }}-${{ matrix.python-version }}

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -18,6 +18,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2      
+        with:
+            create-symlink: true
+            key: ${{ github.job }}-${{ matrix.python-version }}
       - run: |
           brew install openssl readline sqlite3 xz tcl-tk@8 libb2 zstd
       - run: |

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2      
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
             create-symlink: true
             key: ${{ github.job }}-${{ matrix.python-version }}

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -18,6 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2      
+        with:
+            create-symlink: true
+            key: ${{ github.job }}-${{ matrix.python-version }}
       - run: |
           sudo apt-get update -q; sudo apt install -yq make build-essential libssl-dev zlib1g-dev \
           libbz2-dev libreadline-dev libsqlite3-dev curl \

--- a/plugins/python-build/LICENSE
+++ b/plugins/python-build/LICENSE
@@ -1,3 +1,4 @@
+#
 Copyright (c) 2013 Yamashita, Yuu
 Copyright (c) 2012-2013 Sam Stephenson
 


### PR DESCRIPTION
These jobs are often run without any relevant changes, just to make sure nothing broke

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

### Tests
- [x] My PR adds the following unit tests (if any)
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `ccache` in macOS and Ubuntu CI builds to speed up repeated runs by caching compilation outputs. Use `hendrikmuhs/ccache-action@v1.2.23` with symlink mode and key `${{ github.job }}-${{ matrix.python-version }}`; include a no‑op change to trigger CI.

<sup>Written for commit 9228ed0c2ffb735c432d4ca3a154ba3e7b90798d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

