### PR TITLE
Fix linking against a keg_only Homebrew OpenSSL when a a non-keg_only one is also installed

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1721,22 +1721,28 @@ use_homebrew_openssl() {
     local ssldir="$(brew --prefix "${openssl}" || true)"
     if [ -d "$ssldir" ]; then
       echo "python-build: use ${openssl} from homebrew"
+      # Since 970acdcad3be4262451e9a5180a385dd2158eda3 (openssl@3 3.1.1),
+      # Homebrew's openssl@3 is no longer keg-only.
+      # Python's --with-openssl* appends flags to the compiler's command line,
+      # which in combination with adding Homebrew's general dir to flags
+      # always causes the build to link to the non-keg `openssl'
+      # when the non-keg-only formula is installed.
+      # To counter that, we have to prepend the openssl path to flags
+      # regardless of using Configure options.
       if [[ -n "${PYTHON_BUILD_CONFIGURE_WITH_OPENSSL:-}" ]]; then
         # configure script of newer CPython versions support `--with-openssl`
         # https://bugs.python.org/issue21541
         package_option python configure --with-openssl="${ssldir}"
-      else
-        export CPPFLAGS="-I$ssldir/include ${CPPFLAGS:+ $CPPFLAGS}"
-        export LDFLAGS="-L$ssldir/lib${LDFLAGS:+ $LDFLAGS}"
       fi
       # 3.10.0+ (https://github.com/python/cpython/pull/24820)
       # but has no effect until 3.11.0 (b9e9292d75fdea621e05e39b8629e6935d282d0d)
       # and broken in MacOS until 3.12.2 (cc13eabc7ce08accf49656e258ba500f74a1dae8)
       if [[ -n $PYTHON_BUILD_CONFIGURE_WITH_OPENSSL_RPATH ]]; then
         package_option python configure --with-openssl-rpath="${ssldir}/lib"
-      else
-        prepend_ldflags_libs "-Wl,-rpath,${ssldir}/lib"
       fi
+      export CPPFLAGS="-I${ssldir}/include ${CPPFLAGS:+ $CPPFLAGS}"
+      export LDFLAGS="-L${ssldir}/lib -Wl,-rpath,${ssldir}/lib${LDFLAGS:+ $LDFLAGS}"
+
       
       export PKG_CONFIG_PATH="$ssldir/lib/pkgconfig/:${PKG_CONFIG_PATH}"
       lock_in homebrew


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

Since `openssl3` 3.1.1 formula, Homebrew made it non-keg-only.
This causes builds to link to a wrong version if a different OpenSSL formula is selected for the build.

### Tests
- [x] My PR adds the following unit tests (if any)
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Python builds linking to the wrong OpenSSL when Homebrew’s non-keg `openssl@3` is installed alongside a keg-only OpenSSL. We now always prefer the selected Homebrew OpenSSL by prepending its paths to compiler and linker flags.

- **Bug Fixes**
  - Unconditionally set `CPPFLAGS` and `LDFLAGS` with `${ssldir}/include`, `${ssldir}/lib`, and `-Wl,-rpath,${ssldir}/lib` so the selected formula is used.
  - Keep using `--with-openssl` and optional `--with-openssl-rpath` when supported by CPython.

<sup>Written for commit 0470b60152ed0a7bfe74595eb2a2a9a5e2fcd050. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

