### PR TITLE
Support 3.9 EOL Pip URL, consolidate tests

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2702,6 +2702,9 @@ if [ -z "${GET_PIP_URL}" ]; then
     3.8 | 3.8.* | pypy3.8 | pypy3.8-* | pyston* )
       GET_PIP_URL="https://bootstrap.pypa.io/pip/3.8/get-pip.py"
       ;;
+    3.9 | 3.9.* | pypy3.9 | pypy3.9-* )
+      GET_PIP_URL="https://bootstrap.pypa.io/pip/3.8/get-pip.py"
+      ;;
     * )
       GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"
       ;;

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -2703,7 +2703,7 @@ if [ -z "${GET_PIP_URL}" ]; then
       GET_PIP_URL="https://bootstrap.pypa.io/pip/3.8/get-pip.py"
       ;;
     3.9 | 3.9.* | pypy3.9 | pypy3.9-* )
-      GET_PIP_URL="https://bootstrap.pypa.io/pip/3.8/get-pip.py"
+      GET_PIP_URL="https://bootstrap.pypa.io/pip/3.9/get-pip.py"
       ;;
     * )
       GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -388,82 +388,35 @@ OUT
   assert_success
 }
 
-@test "use the custom GET_PIP_URL for 2.6 versions" {
-  run_inline_definition_with_name --name=2.6 <<OUT
-echo "\${GET_PIP_URL}"
-OUT
-  assert_output "https://bootstrap.pypa.io/pip/2.6/get-pip.py"
-  assert_success
-}
+@test "use custom GET_PIP_URLs" {
 
-@test "use the custom GET_PIP_URL for 2.7 versions" {
-  run_inline_definition_with_name --name=2.7 <<OUT
-echo "\${GET_PIP_URL}"
-OUT
-  assert_output "https://bootstrap.pypa.io/pip/2.7/get-pip.py"
-  assert_success
-}
+  declare -a name_subdir=(\
+  (2.6)
+  (2.7)
+  (3.2)
+  (3.3)
+  (3.4)
+  (3.5)
+  (3.6)
+  (3.7)
+  (3.8)
+  (3.9)
+  (pypy2.7-7.3.12 2.7)
+  (pypy3.5-7.0.0 3.5)
+  (pypy3.6-7.3.3 3.6)
+  (pypy3.8-7.3.3 3.8)
+  (pypy3.9-7.3.8 3.9)
+  (pypy3.9-7.3.16 3.9)
+  (pyston-2.3.5 3.8)
+  )
 
-@test "use the custom GET_PIP_URL for 3.2 versions" {
-  run_inline_definition_with_name --name=3.2 <<OUT
+  for item in "${name_subdir[@]}"; do
+    name="${item[0]}"
+    subdir="${item[1]:-$name}"
+    run_inline_definition_with_name --name="$name" <<OUT
 echo "\${GET_PIP_URL}"
 OUT
-  assert_output "https://bootstrap.pypa.io/pip/3.2/get-pip.py"
-  assert_success
-}
-
-@test "use the custom GET_PIP_URL for 3.3 versions" {
-  run_inline_definition_with_name --name=3.3 <<OUT
-echo "\${GET_PIP_URL}"
-OUT
-  assert_output "https://bootstrap.pypa.io/pip/3.3/get-pip.py"
-  assert_success
-}
-
-@test "use the custom GET_PIP_URL for 3.4 versions" {
-  run_inline_definition_with_name --name=3.4 <<OUT
-echo "\${GET_PIP_URL}"
-OUT
-  assert_output "https://bootstrap.pypa.io/pip/3.4/get-pip.py"
-  assert_success
-}
-
-@test "use the custom GET_PIP_URL for 3.5 versions" {
-  run_inline_definition_with_name --name=3.5 <<OUT
-echo "\${GET_PIP_URL}"
-OUT
-  assert_output "https://bootstrap.pypa.io/pip/3.5/get-pip.py"
-  assert_success
-}
-
-@test "use the custom GET_PIP_URL for 3.6 versions" {
-  run_inline_definition_with_name --name=3.6 <<OUT
-echo "\${GET_PIP_URL}"
-OUT
-  assert_output "https://bootstrap.pypa.io/pip/3.6/get-pip.py"
-  assert_success
-}
-
-@test "use the custom GET_PIP_URL for pypy2.7 versions" {
-  run_inline_definition_with_name --name=pypy2.7-7.3.12 <<OUT
-echo "\${GET_PIP_URL}"
-OUT
-  assert_output "https://bootstrap.pypa.io/pip/2.7/get-pip.py"
-  assert_success
-}
-
-@test "use the custom GET_PIP_URL for pypy3.5 versions" {
-  run_inline_definition_with_name --name=pypy3.5-7.0.0 <<OUT
-echo "\${GET_PIP_URL}"
-OUT
-  assert_output "https://bootstrap.pypa.io/pip/3.5/get-pip.py"
-  assert_success
-}
-
-@test "use the custom GET_PIP_URL for pypy3.6 versions" {
-  run_inline_definition_with_name --name=pypy3.6-7.3.3 <<OUT
-echo "\${GET_PIP_URL}"
-OUT
-  assert_output "https://bootstrap.pypa.io/pip/3.6/get-pip.py"
-  assert_success
+    assert_output "https://bootstrap.pypa.io/pip/$subdir/get-pip.py"
+    assert_success
+  done
 }

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -391,32 +391,35 @@ OUT
 @test "use custom GET_PIP_URLs" {
 
   declare -a name_subdir=(\
-  (2.6)
-  (2.7)
-  (3.2)
-  (3.3)
-  (3.4)
-  (3.5)
-  (3.6)
-  (3.7)
-  (3.8)
-  (3.9)
-  (pypy2.7-7.3.12 2.7)
-  (pypy3.5-7.0.0 3.5)
-  (pypy3.6-7.3.3 3.6)
-  (pypy3.8-7.3.3 3.8)
-  (pypy3.9-7.3.8 3.9)
-  (pypy3.9-7.3.16 3.9)
-  (pyston-2.3.5 3.8)
+  2.6
+  2.7
+  3.2
+  3.3
+  3.4
+  3.5
+  3.6
+  3.7
+  3.8
+  3.9
+
+  "pypy2.7-7.3.12   2.7"
+  "pypy3.5-7.0.0    3.5"
+  "pypy3.6-7.3.3    3.6"
+  "pypy3.7-7.3.3    3.7"
+  "pypy3.8-7.3.8    3.8"
+  "pypy3.9-7.3.16   3.9"
+
+  "pyston-2.3.5     3.8"
   )
 
-  for item in "${name_subdir[@]}"; do
+  for item_s in "${name_subdir[@]}"; do
+    item=($item_s)
     name="${item[0]}"
     subdir="${item[1]:-$name}"
     run_inline_definition_with_name --name="$name" <<OUT
-echo "\${GET_PIP_URL}"
+echo "\${DEFINITION_PATH##*/}:\${GET_PIP_URL}"
 OUT
-    assert_output "https://bootstrap.pypa.io/pip/$subdir/get-pip.py"
+    assert_output "$name:https://bootstrap.pypa.io/pip/$subdir/get-pip.py"
     assert_success
   done
 }


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR
subj

### Tests
- [x] My PR adds the following unit tests (if any)
consolidate copycat tests into a loop

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for Python 3.9 EOL pip bootstrap URLs in `python-build` and consolidate `GET_PIP_URL` tests into a single loop. This fixes pip bootstrapping for 3.9/PyPy 3.9 and reduces test duplication.

- **Bug Fixes**
  - Route Python 3.9 and PyPy 3.9 to https://bootstrap.pypa.io/pip/3.9/get-pip.py in `python-build`.

- **Refactors**
  - Replace many `GET_PIP_URL` tests with one parameterized test covering CPython 2.6–3.9, PyPy 2.7/3.5–3.9, and Pyston 3.8.

<sup>Written for commit b239d47b5936f9c9b5077efbfc0e065096478e00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

