### PR TITLE
realpath.c: fix obsolete syntax warning

### DIFF
--- a/src/realpath.c
+++ b/src/realpath.c
@@ -2,8 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-int realpath_builtin(list)
-WORD_LIST *list;
+int realpath_builtin(WORD_LIST *list)
 {
 	int es;
 	char *realbuf, *p;


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

fixes "warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C23"

### Tests
- [ ] My PR adds the following unit tests (if any)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update realpath_builtin in src/realpath.c to use a standard C prototype instead of K&R syntax. Removes the “function definition without a prototype” warning and keeps builds compatible with C23, with no behavior change.

<sup>Written for commit bf43036a012fb3ae29880a96a60ce9ca5a77bb16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

