### PR TITLE
Add miniforge3-26.3.2-2, 26.3.2-3

### DIFF
--- a/plugins/python-build/share/python-build/miniforge3-26.3.2-2
+++ b/plugins/python-build/share/python-build/miniforge3-26.3.2-2
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-26.3.2-2-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-2/Miniforge3-26.3.2-2-Linux-aarch64.sh#f4096a92482b30f04534cddb63d8bc929118318deffac71d90fb89dc52359d22" "miniconda" verify_py313
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-26.3.2-2-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-2/Miniforge3-26.3.2-2-Linux-ppc64le.sh#8b3527cd4c70e6eb4a6c2c4c41de34c2480f0a5200de2ecb7fe385d186af0869" "miniconda" verify_py313
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-26.3.2-2-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-2/Miniforge3-26.3.2-2-Linux-x86_64.sh#42260ffe3830fb953d5eee1bbb32229ff06aa7c3833c1ed7a9a0420a95685d94" "miniconda" verify_py313
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-26.3.2-2-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-2/Miniforge3-26.3.2-2-MacOSX-arm64.sh#2657d94152343cff7c06159ac9fc09624d7879fa9575c5a0a324c571c4df0ade" "miniconda" verify_py313
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-26.3.2-2-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-2/Miniforge3-26.3.2-2-MacOSX-x86_64.sh#a755192103de19bb2782685ac78820c2e00702e5f33e6e4f0a3bf3c214f45d69" "miniconda" verify_py313
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniforge3-26.3.2-3
+++ b/plugins/python-build/share/python-build/miniforge3-26.3.2-3
@@ -1,0 +1,25 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniforge3-26.3.2-3-Linux-aarch64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-3/Miniforge3-26.3.2-3-Linux-aarch64.sh#2c113a69297e612b01ca0f320c22a3107a11f2ab9b573d79ac868a175945ce29" "miniconda" verify_py313
+  ;;
+"Linux-ppc64le" )
+  install_script "Miniforge3-26.3.2-3-Linux-ppc64le.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-3/Miniforge3-26.3.2-3-Linux-ppc64le.sh#df7e80ee070ccc6031e2710eb4cf81ee0012264b587306b5aa3890d3d89edd97" "miniconda" verify_py313
+  ;;
+"Linux-x86_64" )
+  install_script "Miniforge3-26.3.2-3-Linux-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-3/Miniforge3-26.3.2-3-Linux-x86_64.sh#848194851a98903134187fbb4ab50efe87b003e0c0f808f97644b7524a62bf2c" "miniconda" verify_py313
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniforge3-26.3.2-3-MacOSX-arm64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-3/Miniforge3-26.3.2-3-MacOSX-arm64.sh#59168f1e24d0a4ad9932021170809fca836cd240e183eeeb331d5bcfc0098168" "miniconda" verify_py313
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniforge3-26.3.2-3-MacOSX-x86_64.sh" "https://github.com/conda-forge/miniforge/releases/download/26.3.2-3/Miniforge3-26.3.2-3-MacOSX-x86_64.sh#39273e4c89a0a1af4538010615d44ae8f44e1af41007e02def593d20f316b003" "miniconda" verify_py313
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniforge is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR
subj

### Tests
- [x] My PR adds the following unit tests (if any)
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `python-build` definitions for `Miniforge3` 26.3.2-2 and 26.3.2-3. Enables installs on Linux (aarch64, ppc64le, x86_64) and macOS (arm64, x86_64) with checksum verification and Python 3.13 validation.

- **New Features**
  - Added `miniforge3-26.3.2-2` and `miniforge3-26.3.2-3` install scripts with architecture-specific URLs and SHA256 hashes.
  - Uses `miniconda` install type and `verify_py313` to ensure Python 3.13 is available.

<sup>Written for commit d61c037fbe2d7ff9c51e6c8ad31b7494fb9e831c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

