### PR TITLE
rehash: fix race condition in landlock writability check

### DIFF
--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -28,6 +28,8 @@ acquire_lock() {
       # So check for writablity by trying to write to a different file,
       # in a way that taxes the usual use case as little as possible.
       if [[ -z $tested_for_other_write_errors ]]; then
+        # if lots of (50+) rehashes run concurrentlty, another concurrent rehash
+        # may delete the temporary file in remove_*_shims() before we do so
         ( t="$(TMPDIR="$SHIM_PATH" mktemp)" && rm -f "$t" ) \
           && tested_for_other_write_errors=1 \
           || { echo "pyenv: cannot rehash: $SHIM_PATH isn't writable" >&2

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -28,7 +28,7 @@ acquire_lock() {
       # So check for writablity by trying to write to a different file,
       # in a way that taxes the usual use case as little as possible.
       if [[ -z $tested_for_other_write_errors ]]; then
-        # if lots of (50+) rehashes run concurrentlty, another concurrent rehash
+        # if lots of (50+) rehashes run concurrently, another concurrent rehash
         # may delete the temporary file in remove_*_shims() before we do so
         ( t="$(TMPDIR="$SHIM_PATH" mktemp)" && rm -f "$t" ) \
           && tested_for_other_write_errors=1 \

--- a/libexec/pyenv-rehash
+++ b/libexec/pyenv-rehash
@@ -28,7 +28,7 @@ acquire_lock() {
       # So check for writablity by trying to write to a different file,
       # in a way that taxes the usual use case as little as possible.
       if [[ -z $tested_for_other_write_errors ]]; then
-        ( t="$(TMPDIR="$SHIM_PATH" mktemp)" && rm "$t" ) \
+        ( t="$(TMPDIR="$SHIM_PATH" mktemp)" && rm -f "$t" ) \
           && tested_for_other_write_errors=1 \
           || { echo "pyenv: cannot rehash: $SHIM_PATH isn't writable" >&2
                set +o noclobber


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3482

### Description
Since the writable check has already succeeded once `mktemp` creates the temporary file, I think it should be safe to ignore a failure from `rm`.

I also considered other possible approaches, such as:

- excluding temporary files from removal in `remove_stale_shims` and similar functions
- using a different directory for temporary files created inside `acquire_lock`

However, these approaches may have a wider impact, so I think using `rm -f` is the smallest and least invasive change.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the rehash writable check that could falsely report `"$SHIM_PATH" isn't writable` during concurrent rehashes by tolerating the temp file being removed by another process.

- **Bug Fixes**
  - In `pyenv-rehash`’s `acquire_lock`, use `rm -f` on the temp file in `"$SHIM_PATH"` to avoid false failures if another rehash deletes it first; added and clarified an inline comment documenting this concurrency case.

<sup>Written for commit 19ae3820bdd612b982b64edbbec2bcf4803d5381. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



