### PR TITLE
install: Add an ability to install a version under an alias

### DIFF
--- a/plugins/python-build/README.md
+++ b/plugins/python-build/README.md
@@ -67,6 +67,13 @@ exact name of the version you want to install. For example,
 Python versions will be installed into a directory of the same name under
 `~/.pyenv/versions`.
 
+To install a version under a different name -- for instance, to keep several
+builds of the same version side by side -- append `:<alias>` to the version:
+
+    pyenv install 3.12.0:3.12-custom
+
+This installs into `~/.pyenv/versions/3.12-custom`.
+
 To see a list of all available Python versions, run `pyenv install --list`. You
 may also tab-complete available Python versions if your pyenv installation is
 properly configured.

--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -20,6 +20,13 @@
 #   --version          Show version of python-build
 #   -g/--debug         Build a debug version
 #
+#   Append `:<alias>' to a version to install it under a custom name, so that
+#   several builds of the same version can coexist:
+#
+#       pyenv install 3.12.0:my-3.12
+#
+#   This installs into $PYENV_ROOT/versions/my-3.12.
+#
 # For detailed information on installing Python versions with
 # python-build, including a list of environment variables for adjusting
 # compilation, see: https://github.com/pyenv/pyenv#readme
@@ -123,6 +130,20 @@ DEFINITIONS=("${ARGUMENTS[@]}")
 [[ "${#DEFINITIONS[*]}" -eq 0 ]] && DEFINITIONS=($(pyenv-local 2>/dev/null || true))
 [[ "${#DEFINITIONS[*]}" -eq 0 ]] && usage 1 >&2
 
+# A `<version>:<alias>` argument installs <version> under the custom name
+# <alias>, so that several builds of the same version can coexist. The `latest`
+# suffix is reserved for latest-version resolution (see the `install` hook), so
+# it is left untouched here.
+declare -a ALIASES
+for i in "${!DEFINITIONS[@]}"; do
+  definition="${DEFINITIONS[$i]}"
+  alias="${definition##*:}"
+  if [[ "$definition" == *:* ]] && [ "$alias" != "latest" ]; then
+    DEFINITIONS[$i]="${definition%:*}"
+    ALIASES[$i]="$alias"
+  fi
+done
+
 # Define `before_install` and `after_install` functions that allow
 # plugin hooks to register a string of code for execution before or
 # after the installation process.
@@ -152,7 +173,9 @@ IFS="$OLDIFS"
 for script in "${scripts[@]}"; do source "$script"; done
 
 COMBINED_STATUS=0
-for DEFINITION in "${DEFINITIONS[@]}"; do
+for i in "${!DEFINITIONS[@]}"; do
+  DEFINITION="${DEFINITIONS[$i]}"
+  VERSION_ALIAS="${ALIASES[$i]}"
   STATUS=0
 
   # Try to resolve a prefix if user indeed gave a prefix.
@@ -161,9 +184,12 @@ for DEFINITION in "${DEFINITIONS[@]}"; do
   DEFINITION="$(pyenv-latest -f -k "$DEFINITION")"
 
   # Set VERSION_NAME from $DEFINITION. Then compute the installation prefix.
+  # With a `<version>:<alias>` argument, install under the alias instead;
+  # VERSION_NAME still reflects the real version so version-specific build logic
+  # (e.g. the bootstrap version detection below) keeps working.
   VERSION_NAME="${DEFINITION##*/}"
   [ -n "$DEBUG" ] && VERSION_NAME="${VERSION_NAME}-debug"
-  PREFIX="${PYENV_ROOT}/versions/${VERSION_NAME}"
+  PREFIX="${PYENV_ROOT}/versions/${VERSION_ALIAS:-$VERSION_NAME}"
 
   [ -d "${PREFIX}" ] && PREFIX_EXISTS=1
 
@@ -188,7 +214,7 @@ for DEFINITION in "${DEFINITIONS[@]}"; do
 
   # If PYENV_BUILD_ROOT is set, always pass keep options to python-build.
   if [ -n "${PYENV_BUILD_ROOT}" ]; then
-    export PYTHON_BUILD_BUILD_PATH="${PYENV_BUILD_ROOT}/${VERSION_NAME}"
+    export PYTHON_BUILD_BUILD_PATH="${PYENV_BUILD_ROOT}/${VERSION_ALIAS:-$VERSION_NAME}"
     KEEP="-k"
   fi
 

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -31,6 +31,32 @@ stub_python_build() {
   unstub python-build
 }
 
+@test "install a single version under an alias" {
+  stub_python_build_lib
+  stub_python_build
+
+  run pyenv-install 3.4.2:3.4.2-custom
+  assert_success "python-build 3.4.2 ${PYENV_ROOT}/versions/3.4.2-custom"
+
+  unstub python-build
+}
+
+@test "install multiple versions, each under its own alias" {
+  stub_python_build_lib
+  stub_python_build
+  stub_python_build
+
+  run pyenv-install 3.4.1:custom1 3.4.2:custom2
+  assert_success
+  assert_output <<OUT
+python-build 3.4.1 ${PYENV_ROOT}/versions/custom1
+python-build 3.4.2 ${PYENV_ROOT}/versions/custom2
+OUT
+
+  unstub python-build
+  unstub pyenv-latest
+}
+
 @test "install multiple versions" {
   stub_python_build_lib
   stub_python_build


### PR DESCRIPTION
### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/218
  - Addresses step 0 of https://github.com/pyenv/pyenv/issues/2334

### Description
- [x] Here are some details about my PR

Appending `:<alias>` to a version installs it under that custom name instead of the version number, so several builds of the same version can coexist:

```
pyenv install 3.12.0:my-3.12   # -> $PYENV_ROOT/versions/my-3.12
```

This implements the colon-separator syntax suggested in #2966 (preferred over the `VERSION_ALIAS` env var from that draft). Notes:

- The alias is split off in `pyenv-install` before the install hooks run, so each version in a multi-version install can carry its own alias, e.g. `pyenv install 3.11.0:a 3.12.0:b`. This sidesteps the array-option / argument-pairing question raised in #2966.
- `VERSION_NAME` still reflects the real version, so version-specific build logic (bootstrap-version detection, etc.) is unaffected — only the install directory is renamed.
- The `latest` suffix is reserved, so the existing `<prefix>:latest` resolution is untouched.

### Tests
- [x] My PR adds the following unit tests (if any)

- `install a version under an alias` (`3.4.2:3.4.2-custom`)
- `install multiple versions, each under its own alias` (`3.4.1:custom1 3.4.2:custom2`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add alias install syntax to `pyenv-install`: `<version>:<alias>` installs a version under a custom name so multiple builds can coexist. Keeps version-specific build logic and `<prefix>:latest` resolution unchanged.

- **New Features**
  - Installs into `$PYENV_ROOT/versions/<alias>` (e.g., `3.12.0:my-3.12`); works with multi-version calls since aliases are parsed before hooks.
  - `VERSION_NAME` stays the real version; only the install directory and `PYENV_BUILD_ROOT` path use the alias.
  - Updated `plugins/python-build/README.md` and added tests for single and multi-alias installs.

<sup>Written for commit 1ac5acdfb7cc7cea94e4c00c1369a623d30e1ab6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

