### PR TITLE
Add graalpy-3.12-25.1.3

### DIFF
--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -59,7 +59,7 @@ jobs:
               if name == 'anaconda3' and version >= packaging.version.Version('2025.12'):
                 result.append({'os':'macos-15-intel','python-version':line})
           
-            if m:=re.match(r'graalpy-(community-)?(\d+\.\d+.\d+)', line):
+            if m:=re.match(r'graalpy[^-]*-(community-)?(\d+\.\d+.\d+)', line):
               version = packaging.version.Version(m.group(2))
               
               # GraalPy dropped MacOS x64 support

--- a/plugins/python-build/share/python-build/graalpy3.12-25.1.3
+++ b/plugins/python-build/share/python-build/graalpy3.12-25.1.3
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+VERSION='25.1.3'
+BUILD=''
+
+colorize 1 "GraalPy 23.1 and later installed by python-build use the faster Oracle GraalVM distribution" && echo
+colorize 1 "Oracle GraalVM uses the GFTC license, which is free for development and production use, see https://medium.com/graalvm/161527df3d76" && echo
+colorize 1 "The GraalVM Community Edition variant of GraalPy is also available, under the name graalpy3.12-community-${VERSION}" && echo
+
+
+graalpy_arch="$(graalpy_architecture 2>/dev/null || true)"
+
+case "$graalpy_arch" in
+"linux-amd64" )
+  checksum="53d46f3ad78229699eb00677f4cb5e3cfe451b58c46970e4d4272a719b53ce82"
+  ;;
+"linux-aarch64" )
+  checksum="947170f0896c8acb02b364caad3e0c01439c12cbdad1b7605cff589b7dd5b26e"
+  ;;
+"macos-aarch64" )
+  checksum="adb17eb3aa3c5701cfc518af26bbaf4e5755ecb62a6a22d490af06523ea02913"
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": No binary distribution of GraalPy is available for $(uname -sm)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac
+
+if [ -n "${BUILD}" ]; then
+  { echo
+    colorize 1 "ERROR"
+    echo "Oracle GraalPy currently doesn't provide snapshot builds. Use graalpy3.12-community if you need snapshots."
+    echo
+  } >&2
+  exit 1
+fi
+
+url="https://github.com/oracle/graalpython/releases/download/graal-${VERSION}/graalpy3.12-${VERSION}-${graalpy_arch}.tar.gz#${checksum}"
+
+install_package "graalpy3.12-${VERSION}" "${url}" "copy" ensurepip

--- a/plugins/python-build/share/python-build/graalpy3.12-community-25.1.3
+++ b/plugins/python-build/share/python-build/graalpy3.12-community-25.1.3
@@ -1,0 +1,51 @@
+# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+VERSION='25.1.3'
+BUILD=''
+
+graalpy_arch="$(graalpy_architecture 2>/dev/null || true)"
+
+case "$graalpy_arch" in
+"linux-amd64" )
+  checksum="1705b59e5a3d04364b1fa4cbb31ad6c273b487a87dc67e336fc5476b599c8d3e"
+  ;;
+"linux-aarch64" )
+  checksum="2558dec612e02b1ce5d7807fdd338f2a65dd9a0e62913458a32202289cc211ac"
+  ;;
+"macos-aarch64" )
+  checksum="76c0ccde939b94e6669a0e7eb01df612a070a6dbb966ed70989a851a9b1066e8"
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": No binary distribution of GraalPy is available for $(uname -sm)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac
+
+if [ -n "${BUILD}" ]; then
+  url="https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/${VERSION}-dev-${BUILD}/graalpy3.12-community-dev-${graalpy_arch}.tar.gz"
+else
+  url="https://github.com/oracle/graalpython/releases/download/graal-${VERSION}/graalpy3.12-community-${VERSION}-${graalpy_arch}.tar.gz#${checksum}"
+fi
+
+install_package "graalpy3.12-community-${VERSION}${BUILD}" "${url}" "copy" ensurepip


### PR DESCRIPTION
Add newly released graalpy. Note that the versioning scheme changed upstream to start with the implemented python version, so instead of just graalpy-25.1.3, it's graalpy3.12-25.1.3.

CC @timfel 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GraalPy 3.12 (25.1.3) to python-build with Oracle GraalVM and Community variants. Also updates CI version detection to handle the new `graalpy3.12-*` naming.

- **New Features**
  - Added `graalpy3.12-25.1.3` (Oracle GraalVM) and `graalpy3.12-community-25.1.3`.
  - Supports `linux-amd64`, `linux-aarch64`, and `macos-aarch64` with verified checksums.
  - Uses official GitHub release URLs and installs with ensurepip; shows license/availability notes.

- **Migration**
  - Names now include the Python version: use `graalpy3.12-25.1.3` instead of `graalpy-25.1.3`.
  - Oracle build has no snapshots; use `graalpy3.12-community` for dev builds.

<sup>Written for commit 52b03c9a02474343cac27863b9e0ea8d5873fda8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

