### PR TITLE
Fix typos in docs, scripts, and tests

### DIFF
--- a/plugins/python-build/README.md
+++ b/plugins/python-build/README.md
@@ -269,7 +269,7 @@ would be to make symlinks at the mirror's root:
 ```
 
 The rationale is to abstract away difference between directory structures of sites
-of various Python flavors and their occasional changes as well as to accomodate
+of various Python flavors and their occasional changes as well as to accommodate
 people who only wish to cache some select downloads. This also allows to mirror multiple sites at once.
 
 If the mirror being used does not have the same checksum (*e.g.* with a

--- a/plugins/python-build/scripts/add_cpython.py
+++ b/plugins/python-build/scripts/add_cpython.py
@@ -506,7 +506,7 @@ class CPythonExistingScriptsDirectory(KeyedList[_CPythonExistingScriptInfo, pack
                 v = packaging.version.Version(entry_name)
                 if v < CUTOFF_VERSION:
                     continue
-                # branch tip scrpts are different from release scripts and thus unusable as a pattern
+                # branch tip scripts are different from release scripts and thus unusable as a pattern
                 if v.dev is not None:
                     continue
                 logger.debug(f"Existing version {v}")
@@ -748,5 +748,5 @@ if __name__ == "__main__":
     try:
         sys.exit(main())
     except Exception:
-        logging.exception("Unhandled exception occured")
+        logging.exception("Unhandled exception occurred")
         sys.exit(2)

--- a/test/which.bats
+++ b/test/which.bats
@@ -181,7 +181,7 @@ exit
   assert_success "version=3.4.2"
 }
 
-@test "skip advice supresses error messages" {
+@test "skip advice suppresses error messages" {
   bats_require_minimum_version 1.5.0
   create_alt_executable_in_version "2.7" "python"
   create_alt_executable_in_version "3.3" "py.test"


### PR DESCRIPTION
Fix four spelling mistakes found via codespell:

- `plugins/python-build/README.md` line 272: `accomodate` → `accommodate`
- `plugins/python-build/scripts/add_cpython.py` line 509: `scrpts` → `scripts` (comment)
- `plugins/python-build/scripts/add_cpython.py` line 751: `occured` → `occurred` (log message)
- `test/which.bats` line 184: `supresses` → `suppresses` (test name)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix four typos across docs, a script comment and log, and a test name to improve clarity and correct logging output.

- **Bug Fixes**
  - README: “accommodate” spelling fixed.
  - `plugins/python-build/scripts/add_cpython.py`: comment “scripts”; error log uses “occurred”.
  - `test/which.bats`: test name uses “suppresses”.

<sup>Written for commit 8a01e1e9612cd9fc7bb61f9fe29d52d03f3698fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

