### PR TITLE
Add miniconda3 26.5.3-1

### DIFF
--- a/plugins/python-build/share/python-build/miniconda3-3.10-26.5.3-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.10-26.5.3-1
@@ -1,0 +1,20 @@
+export CONDA_PLUGINS_AUTO_ACCEPT_TOS=true
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py310_26.5.3-1-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_26.5.3-1-Linux-aarch64.sh#d2988632a30ea71e158874b9c5386d016660908fec38ee58125af7783b1a0bf6" "miniconda" verify_py310
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py310_26.5.3-1-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_26.5.3-1-Linux-x86_64.sh#4a82fe0a50a28e8a9406b3ed8e465b7009aa7d0225566802c3370df96b10d834" "miniconda" verify_py310
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py310_26.5.3-1-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py310_26.5.3-1-MacOSX-arm64.sh#7868e87c7e1ecaa6ff25f5041e0abdf766e5e2d082788b26bcf57554d0036a2d" "miniconda" verify_py310
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.11-26.5.3-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.11-26.5.3-1
@@ -1,0 +1,20 @@
+export CONDA_PLUGINS_AUTO_ACCEPT_TOS=true
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py311_26.5.3-1-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_26.5.3-1-Linux-aarch64.sh#4a2e39642fcd0b25cf199f5ada4725120a9a40fa10e864d67b8f93e7f2f44dad" "miniconda" verify_py311
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py311_26.5.3-1-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_26.5.3-1-Linux-x86_64.sh#f1d308a450763ce617f4e4f1609521358f663b2d1c097cfcc11a1c1f09baf680" "miniconda" verify_py311
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py311_26.5.3-1-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py311_26.5.3-1-MacOSX-arm64.sh#721bccd83c53ff56e364faf883c5da9abfdf61daecb4863c533818851b33edc3" "miniconda" verify_py311
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.12-26.5.3-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.12-26.5.3-1
@@ -1,0 +1,20 @@
+export CONDA_PLUGINS_AUTO_ACCEPT_TOS=true
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py312_26.5.3-1-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_26.5.3-1-Linux-aarch64.sh#9e48caecbad9cc43d8a483584f0a5e1da2754189416a8811aaada3f58aceeb67" "miniconda" verify_py312
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py312_26.5.3-1-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_26.5.3-1-Linux-x86_64.sh#ecb43ee4ae30a7a5af87737e9548ceb21f0a10ec55b8dc40d247aa925b80bfec" "miniconda" verify_py312
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py312_26.5.3-1-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py312_26.5.3-1-MacOSX-arm64.sh#f5767f038d5aa8299254b96b7e0db4f086c29e4b3a620fc38fea51974f66abdd" "miniconda" verify_py312
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.13-26.5.3-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.13-26.5.3-1
@@ -1,0 +1,20 @@
+export CONDA_PLUGINS_AUTO_ACCEPT_TOS=true
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py313_26.5.3-1-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py313_26.5.3-1-Linux-aarch64.sh#4eaf1f2d83ede3ad010afa6ad19bef69893ca4667ba5996f51efb3080c08a70d" "miniconda" verify_py313
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py313_26.5.3-1-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py313_26.5.3-1-Linux-x86_64.sh#7358a5961dc6a4941d087281cd70313728fcc68695735e18a337321bc31c7f51" "miniconda" verify_py313
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py313_26.5.3-1-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py313_26.5.3-1-MacOSX-arm64.sh#c73b91d59c872f472d7a21dadaf0cc70dcff1fadf5bd98200bd15341be2bcbd0" "miniconda" verify_py313
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.14-26.5.3-1
+++ b/plugins/python-build/share/python-build/miniconda3-3.14-26.5.3-1
@@ -1,0 +1,20 @@
+export CONDA_PLUGINS_AUTO_ACCEPT_TOS=true
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-aarch64" )
+  install_script "Miniconda3-py314_26.5.3-1-Linux-aarch64" "https://repo.anaconda.com/miniconda/Miniconda3-py314_26.5.3-1-Linux-aarch64.sh#781abf4cec9b842f5ed508e7c364ed9951380ba11187b80fe5d9c3dbf9ffccea" "miniconda" verify_py314
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-py314_26.5.3-1-Linux-x86_64" "https://repo.anaconda.com/miniconda/Miniconda3-py314_26.5.3-1-Linux-x86_64.sh#42cfece170da342364a78d629e06b94dfd81b0f2717d7655729100d888d606b4" "miniconda" verify_py314
+  ;;
+"MacOSX-arm64" )
+  install_script "Miniconda3-py314_26.5.3-1-MacOSX-arm64" "https://repo.anaconda.com/miniconda/Miniconda3-py314_26.5.3-1-MacOSX-arm64.sh#0cb1e1d43810d3118f7b6cd0095aff48dbde8312a19cb8c44e9a79c38bb48be3" "miniconda" verify_py314
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR
Subj
### Tests
- [x] My PR adds the following unit tests (if any)
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `python-build` definitions for Miniconda3 26.5.3-1 covering CPython 3.10–3.14 on Linux x86_64, Linux aarch64, and macOS arm64. This enables installing the latest Miniconda3 builds via `pyenv install`.

- **New Features**
  - Added `miniconda3-3.10-26.5.3-1` through `miniconda3-3.14-26.5.3-1` with per-arch installers and SHA256 checks.
  - Set `CONDA_PLUGINS_AUTO_ACCEPT_TOS=true` and use `verify_py310`–`verify_py314` for installer validation.

<sup>Written for commit 5d6f87249ef1d56cd7fd5732648b8eec047503ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

