### PR TITLE
version-name: skip redundant checks

### DIFF
--- a/libexec/pyenv-version-name
+++ b/libexec/pyenv-version-name
@@ -46,19 +46,21 @@ versions=()
 OLDIFS="$IFS"
 { IFS=:
   any_not_installed=0
+  normalization_done=
   # Unquoted $VAR does glob expansion (against the current dir's contents) after IFS-splitting
   # which is undesired
   set -f
   for version in ${PYENV_VERSION}; do
     # Remove the explicit 'python-' prefix from versions like 'python-3.12'.
     normalised_version="${version#python-}"
-    if version_exists "${version}" || [ "$version" = "system" ]; then
-      versions+=("${version}")
-    elif version_exists "${normalised_version}"; then
+    [[ $version != "${normalised_version}" ]] && normalization_done=1
+    if [[ $version == "system" ]] || version_exists "${normalised_version}" ; then
       versions+=("${normalised_version}")
-    elif resolved_version="$(pyenv-latest -b "${version}")"; then
-      versions+=("${resolved_version}")
+    elif [[ -n $normalization_done ]] && version_exists "${version}"; then
+      versions+=("${version}")
     elif resolved_version="$(pyenv-latest -b "${normalised_version}")"; then
+      versions+=("${resolved_version}")
+    elif [[ -n $normalization_done ]] && resolved_version="$(pyenv-latest -b "${version}")"; then
       versions+=("${resolved_version}")
     else
       if [[ -n $FORCE ]]; then


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

* Rearrange checks so that likely ones are in front
* Avoid doing certain checks 2 times if normalization is not done (extremely likely)

### Tests
- [ ] My PR adds the following unit tests (if any)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered checks in `libexec/pyenv-version-name` to prefer normalized names (including `system`) and only try the original name if normalization changed it. This removes redundant `version_exists`/`pyenv-latest` calls by checking the normalized form first and using the original only when needed, speeding up common-case resolution without changing behavior.

<sup>Written for commit b3a8af602b3fae8fcadb6ae3954250704d3fc584. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

