### PR TITLE
Miniforge3 uses 'Darwin' instead of 'MacOSX' for naming scheme

### DIFF
--- a/plugins/python-build/share/python-build/miniforge3-latest
+++ b/plugins/python-build/share/python-build/miniforge3-latest
@@ -9,10 +9,10 @@ case "$(anaconda_architecture 2>/dev/null || true)" in
   install_script "Miniforge3-Linux-aarch64" "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh" "miniconda" verify_py3_latest
   ;;
 "MacOSX-arm64" )
-  install_script "Miniforge3-MacOSX-arm64" "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh" "miniconda" verify_py3_latest
+  install_script "Miniforge3-Darwin-arm64" "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Darwin-arm64.sh" "miniconda" verify_py3_latest
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniforge3-MacOSX-x86_64" "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh" "miniconda" verify_py3_latest
+  install_script "Miniforge3-Darwin-x86_64" "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Darwin-x86_64.sh" "miniconda" verify_py3_latest
   ;;
 * )
   { echo


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - No relevant open issue

### Description
- [x] Here are some details about my PR

If you run `pyenv install miniforge3-latest` you'll get quite an old version (when on macOS).  Some years ago, the file naming scheme for miniforge3-latest changes on macOS.

### Tests
- [x] My PR adds the following unit tests (if any) - None


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch macOS Miniforge3 asset names from "MacOSX" to "Darwin" to match upstream, so `pyenv install miniforge3-latest` fetches the current macOS build on both arm64 and x86_64.

<sup>Written for commit 4ff711bf2d474625a0807af4022e1ce411e1067f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

