### PR TITLE
Fix typo "spontaneouly" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ to `PATH` in the `<command>`'s environment, the same as what e.g. RVM does.
 ### Running nested shells from Python-based programs
 
 In addition to altering `PATH`, `pyenv exec` sets `PYENV_VERSION` in the
-executed program's environment to ensure that it won't spontaneouly switch to
+executed program's environment to ensure that it won't spontaneously switch to
 using a different Python version.
 
 Some Python-based programs (e.g. Jupyter) can spawn nested shell sessions.


### PR DESCRIPTION
Fix typo `spontaneouly` --> `spontaneously` in README.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a spelling error in README, changing "spontaneouly" to "spontaneously" in the `pyenv exec` section for clarity.

<sup>Written for commit 05e5ab75942f549935418c727d32f7c24cb9ec90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

