### PR TITLE
Fix typo in test/test_helper.bash

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -35,7 +35,7 @@ setup() {
   unset xdg_var
 
   # Workaround for Powershell. When tests are run from a terminal,
-  # and running a script fron a here-document,
+  # and running a script from a here-document,
   # Powershell 7.5.4 erroneously prints ANSI escape sequences
   # even if its output is redirected, breaking the comparison logic
   export NO_COLOR=1


### PR DESCRIPTION
Fixes a spelling error in test/test_helper.bash, changing "fron" to "from"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix a comment typo in test/test_helper.bash, changing "fron" to "from" in the PowerShell workaround note for clarity. No behavior changes.

<sup>Written for commit 5f3aad8415bdba1385c87e05f5264b3fad885322. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

