### PR TITLE
Add graalpy3.12-25.2.4

### DIFF
--- a/plugins/python-build/share/python-build/graalpy3.12-25.2.4
+++ b/plugins/python-build/share/python-build/graalpy3.12-25.2.4
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+VERSION='25.2.4'
+
+colorize 1 "GraalPy 23.1 and later installed by python-build use the faster Oracle GraalVM distribution" && echo
+colorize 1 "Oracle GraalVM uses the GFTC license, which is free for development and production use, see https://medium.com/graalvm/161527df3d76" && echo
+colorize 1 "The GraalVM Community Edition variant of GraalPy is also available, under the name graalpy3.12-community-${VERSION}" && echo
+
+
+graalpy_arch="$(graalpy_architecture 2>/dev/null || true)"
+
+case "$graalpy_arch" in
+"linux-amd64" )
+  checksum="b3d0766ae6d55daa15f0db1f6c884383d7eec506b186d0ba2f702523a78ff28d"
+  ;;
+"linux-aarch64" )
+  checksum="e57472272b1b659ae6ac972117723b0515a49cc9577688ed5563919793170d67"
+  ;;
+"macos-aarch64" )
+  checksum="79f0e1fefb42bb484122ae9e50cb21ce14541d18e6bd66c498e44b459ce652df"
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": No binary distribution of GraalPy is available for $(uname -sm)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac
+
+install_package "graalpy3.12-${VERSION}" "https://github.com/oracle/graalpython/releases/download/graal-${VERSION}/graalpy3.12-${VERSION}-${graalpy_arch}.tar.gz#${checksum}" "copy" ensurepip

--- a/plugins/python-build/share/python-build/graalpy3.12-community-25.2.4
+++ b/plugins/python-build/share/python-build/graalpy3.12-community-25.2.4
@@ -1,0 +1,44 @@
+# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+VERSION='25.2.4'
+
+graalpy_arch="$(graalpy_architecture 2>/dev/null || true)"
+
+case "$graalpy_arch" in
+"linux-amd64" )
+  checksum="98af303a6b714bde39077354733254f78023ddef06d61e14cb66a3a01f10ae82"
+  ;;
+"linux-aarch64" )
+  checksum="dda5e97c8b38158184dec189addaece57a37207a0dad38be162621d605f964f5"
+  ;;
+"macos-aarch64" )
+  checksum="76a182713660ce69f640b9666c2861ec8a5839637a972eaa80c6b5cf38f1357b"
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": No binary distribution of GraalPy is available for $(uname -sm)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac
+
+install_package "graalpy3.12-community-${VERSION}" "https://github.com/oracle/graalpython/releases/download/graal-${VERSION}/graalpy3.12-community-${VERSION}-${graalpy_arch}.tar.gz#${checksum}" "copy" ensurepip


### PR DESCRIPTION
Add newly released GraalPy-3.12 25.2.4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `graalpy3.12-25.2.4` and `graalpy3.12-community-25.2.4` to `python-build` so users can install GraalPy 3.12 (25.2.4) via binary distributions.

- **New Features**
  - Adds Oracle GraalVM build with license notice and `ensurepip`.
  - Adds Community build.
  - Provides SHA256 checksums and download URLs for `linux-amd64`, `linux-aarch64`, and `macos-aarch64`; shows an error for unsupported platforms.

<sup>Written for commit 3bdabfc093c55f908649e2d6fde539d63db5d4b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

