### PR TITLE
Fix typos in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,7 +387,7 @@
 * Add CPython 3.13.0a4 by @saaketp in https://github.com/pyenv/pyenv/pull/2903
 * Handle the case where `pyenv-commands --sh` returns nothing by @aphedges in https://github.com/pyenv/pyenv/pull/2908
 * Document default build configuration customizations by @native-api in https://github.com/pyenv/pyenv/pull/2911
-* Use Homebrew in Linux if Pyenv is installled with Homebrew by @native-api in https://github.com/pyenv/pyenv/pull/2906
+* Use Homebrew in Linux if Pyenv is installed with Homebrew by @native-api in https://github.com/pyenv/pyenv/pull/2906
 * Add miniforge and mambaforge 22.11.1-3, 22.11.1-4, 23.1.0-0 to 23.11.0-0 by @aphedges in https://github.com/pyenv/pyenv/pull/2909
 * Add miniconda3-24.1.2 by @binbjz in https://github.com/pyenv/pyenv/pull/2915
 * Minor grammar fix in libffi backport patch in 2.5.x by @cuinix in https://github.com/pyenv/pyenv/pull/2922
@@ -1523,7 +1523,7 @@
 * pyenv: Prefer gawk over awk if both are available.
 * python-build: Add new PyPy release; pypy-2.3, pypy-2.3-src (#162)
 * python-build: Add new Anaconda release; anaconda-1.9.2 (#155)
-* python-build: Add new Miniconda releases; miniconda-3.3.0, minoconda-3.4.2, miniconda3-3.3.0, miniconda3-3.4.2
+* python-build: Add new Miniconda releases; miniconda-3.3.0, miniconda-3.4.2, miniconda3-3.3.0, miniconda3-3.4.2
 * python-build: Add new Stackless releases; stackless-2.7.3, stackless-2.7.4, stackless-2.7.5, stackless-2.7.6, stackless-3.2.5, stackless-3.3.5 (#164)
 * python-build: Add IronPython versions (setuptools and pip will work); ironpython-2.7.4, ironpython-dev
 * python-build: Add new Jython beta release; jython-2.7-beta2


### PR DESCRIPTION
Fixes two spelling errors in CHANGELOG.md:
* `installled` to `installed`
* `minoconda-3.4.2` to `miniconda-3.4.2`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two typos in CHANGELOG.md to improve accuracy and readability. Corrects "installled" → "installed" and "minoconda-3.4.2" → "miniconda-3.4.2".

<sup>Written for commit 68736cbeca02540cf9a934cd1d45ee14e7e3c84f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

