### PR TITLE
versions: fix --executables portability regression

### DIFF
--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -42,9 +42,15 @@ versions_dir="${PYENV_ROOT}/versions"
 if [[ -n "$executables" ]]; then
   if [ -d "$versions_dir" ]; then
     shopt -s dotglob nullglob
-    # MacOS 12+ and FreeBSD 15 support `xargs -r -0' and `basename -a'
-    # `sort -u` is simpler and a bit faster than `awk '!seen[$0]++'`, with the same result for rehash purposes
-    printf '%s\0' "$versions_dir"/*/bin/* "$versions_dir"/*/envs/*/bin/* | xargs -0 -r basename -a | sort -u
+    # Fast path for rehash: skip filtering and link resolution.
+    # Discover executables directly from the versions directory and
+    # deduplicate their basenames. Use bash 3.2 conventions to keep code portable.
+    for path in \
+      "$versions_dir"/*/bin/* \
+      "$versions_dir"/*/envs/*/bin/*
+    do
+      printf '%s\n' "${path##*/}"
+    done | sort -u
     shopt -u dotglob nullglob
   fi
   exit 0

--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -45,12 +45,10 @@ if [[ -n "$executables" ]]; then
     # Fast path for rehash: skip filtering and link resolution.
     # Discover executables directly from the versions directory and
     # deduplicate their basenames. Use bash 3.2 conventions to keep code portable.
-    for path in \
-      "$versions_dir"/*/bin/* \
-      "$versions_dir"/*/envs/*/bin/*
-    do
-      printf '%s\n' "${path##*/}"
-    done | sort -u
+    paths=( "$versions_dir"/*/bin/* "$versions_dir"/*/envs/*/bin/* )
+    if [ "${#paths[@]}" -gt 0 ]; then
+      printf '%s\n' "${paths[@]##*/}" | sort -u
+    fi
     shopt -u dotglob nullglob
   fi
   exit 0


### PR DESCRIPTION
### Prerequisite

* [x] Please consider implementing the feature as a hook script or plugin as a first step.

  * This fixes a portability regression in the internal `pyenv versions --executables` fast path used by `pyenv rehash`. A plugin or hook cannot correct the failing core command before it is invoked.

* [x] Please consider contributing the patch upstream to [[rbenv](https://github.com/rbenv/rbenv)](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.

  * The affected `--executables` fast path is specific to pyenv and was introduced in pyenv commit `8037f226`; `rbenv-versions` has no equivalent code path. However, this change is consistent with the implementation style already used by `rbenv-versions`, which uses Bash parameter expansion (`"${path##*/}"`) rather than relying on non-portable utility options.

  * This regression was introduced by pyenv-specific commit `8037f226`, which added the `pyenv versions --executables` path. The affected code does not appear to originate from rbenv.

* [ ] My PR addresses the following pyenv issue (if any)

  * No existing issue found.

### Description

* [x] Here are some details about my PR

Commit `8037f226` introduced a fast path for executable discovery using:

```sh
xargs -0 -r basename -a
```

These options are not portable across non-GNU userlands. The native illumos implementations support neither `xargs -r` nor `basename -a`. OpenBSD also does not support `basename -a`.

As a result, `pyenv rehash` fails, including when it is invoked during shell initialization.

This change replaces the non-portable utility options with Bash 3.2-compatible parameter expansion:

```sh
"${path##*/}"
```

The optimized behavior is retained: executable paths are discovered directly from the versions directory, filtering and link resolution are skipped, and the resulting basenames are sorted and deduplicated.

### Tests

* [x] My PR adds the following unit tests (if any)

No new unit tests were added because the existing executable-discovery behavior is unchanged.

The change was tested on:

* OmniOS/illumos
* OpenBSD

Testing included:

* Running `pyenv versions --executables`
* Running `pyenv rehash`
* Verifying shell initialization completes without utility-option errors
* Comparing the output against the previous implementation using GNU `xargs` and GNU `basename`
* Testing duplicate executable names, virtual-environment executables, dotfiles, filenames containing spaces, and an empty versions directory

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a portability regression in `pyenv versions --executables` that broke `pyenv rehash` on non-GNU systems by replacing GNU-specific tooling with Bash 3.2-safe parameter expansion while keeping the fast path.

- **Bug Fixes**
  - Replaced `xargs -r`/`basename -a` with array-based `"${paths[@]##*/}"` plus `sort -u`, and added a length check to avoid running with no matches.
  - Kept direct discovery from `versions/*/bin` and `versions/*/envs/*/bin`, restoring `pyenv rehash` during shell init on illumos and OpenBSD.

<sup>Written for commit bb07d2e18a5d62a03a1053cd62d2ff9dc74026de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

