### PR TITLE
pyenv-binary: check FreeBSD system libraries

### DIFF
--- a/plugins/pyenv-binary/libexec/pyenv-binary-generate-installer
+++ b/plugins/pyenv-binary/libexec/pyenv-binary-generate-installer
@@ -155,10 +155,23 @@ case "$EXPECT_LIBC" in
   ;;
 esac
 
-# Required system libraries must already be present on the target. ldconfig -p
-# lists each library as "<soname> (...) => <path>"; match the soname column
-# exactly so a longer name like libc.so.6.1 does not satisfy libc.so.6.
-if command -v ldconfig &>/dev/null && cache="$(ldconfig -p)"; then
+# Required system libraries must already be present on the target. Linux lists
+# the soname first; FreeBSD lists it in the resolved path, so normalize that
+# path before matching exact names.
+cache=""
+if command -v ldconfig &>/dev/null; then
+  case "$os" in
+  FreeBSD )
+    cache="$(ldconfig -r 2>/dev/null)" &&
+      cache="$(printf '%s\n' "$cache" | awk -F ' *=> *' '{ sub(/^.*\//, "", $2); print $2 }')" \
+      || cache=""
+    ;;
+  * )
+    cache="$(ldconfig -p 2>/dev/null)" || cache=""
+    ;;
+  esac
+fi
+if [ -n "$cache" ]; then
   missing=""
   for dep in $DEPS; do
     printf '%s\n' "$cache" | awk -v d="$dep" '$1 == d { found = 1 } END { exit !found }' \
@@ -169,7 +182,7 @@ if command -v ldconfig &>/dev/null && cache="$(ldconfig -p)"; then
     exit 1
   fi
 elif [ -n "$DEPS" ]; then
-  echo "pyenv-binary: cannot check required system libraries (ldconfig with -p not found)" >&2
+  echo "pyenv-binary: cannot check required system libraries (ldconfig cache unavailable)" >&2
 fi
 
 build_package_relocate() {

--- a/plugins/pyenv-binary/libexec/pyenv-binary-package-name
+++ b/plugins/pyenv-binary/libexec/pyenv-binary-package-name
@@ -28,6 +28,8 @@ case "$version" in
   ;;
 esac
 
+version="$(pyenv-latest -f -k "$version")"
+
 os="$(uname -s)"
 arch="$(uname -m)"
 distro=""

--- a/plugins/pyenv-binary/test/generate-installer.bats
+++ b/plugins/pyenv-binary/test/generate-installer.bats
@@ -93,6 +93,19 @@ create_meta() {
   assert_failure "pyenv-binary: archive needs glibc 99.0 or newer, but this system has 2.31"
 }
 
+@test "checks required libraries in the FreeBSD ldconfig cache" {
+  local out="${BATS_TEST_TMPDIR}/definition"
+  local meta="$(create_meta FreeBSD amd64 '')"
+  printf 'dep=libc.so.7\ndep=libmissing.so.1\n' >> "$meta"
+  pyenv-binary-generate-installer "$meta" \
+    --archive-url http://example.com/a.tar.gz -o "$out"
+  create_stub uname 'case "$1" in -s) echo FreeBSD;; -m) echo amd64;; esac'
+  create_stub ldconfig '[ "$1" = "-r" ] && echo "0:-lc.7=>/lib/libc.so.7"'
+
+  run bash "$out"
+  assert_failure "pyenv-binary: missing required system libraries: libmissing.so.1"
+}
+
 @test "fails when the archive is not beside the metadata" {
   local meta="$(create_meta)"
   rm "${BATS_TEST_TMPDIR}/3.12.7.tar.gz"

--- a/plugins/pyenv-binary/test/package-name.bats
+++ b/plugins/pyenv-binary/test/package-name.bats
@@ -2,6 +2,10 @@
 
 load test_helper
 
+_setup() {
+  create_stub pyenv-latest '[ "$1" = "-f" ] && [ "$2" = "-k" ] && shift 2 && echo "$*"'
+}
+
 @test "completion lists installable versions" {
   create_stub pyenv-install \
     '[ "$*" = "--list --bare" ] && echo 3.13.14'
@@ -40,12 +44,13 @@ load test_helper
   assert_success "3.13.14-macos-15.5-arm64"
 }
 
-@test "generates a package name for FreeBSD" {
+@test "resolves a version prefix when generating a package name" {
+  create_stub pyenv-latest '[ "$*" = "-f -k 3" ] && echo 3.14.7'
   create_stub uname \
     'case "$1" in -s) echo FreeBSD;; -m) echo amd64;; -r) echo 14.2-RELEASE-p3;; esac'
 
-  run pyenv-binary-package-name 3.13.14
-  assert_success "3.13.14-freebsd-14.2-release-p3-amd64"
+  run pyenv-binary-package-name 3
+  assert_success "3.14.7-freebsd-14.2-release-p3-amd64"
 }
 
 @test "rejects an invalid version name" {

--- a/plugins/pyenv-binary/test/package.bats
+++ b/plugins/pyenv-binary/test/package.bats
@@ -7,6 +7,7 @@ load test_helper
 # `generate-installer' behave the same on any test host.
 stub_build_environment() {
   create_stub pyenv-install 'mkdir -p "${PYENV_ROOT}/versions/${1##*:}/bin"'
+  create_stub pyenv-latest '[ "$1" = "-f" ] && [ "$2" = "-k" ] && shift 2 && echo "$*"'
   create_stub uname 'case "$1" in -s) echo Linux;; -m) echo x86_64;; esac'
   create_stub getconf 'echo "glibc 2.17"'
 }


### PR DESCRIPTION
### Prerequisite

* [x] Please consider implementing the feature as a hook script or plugin as a first step.
    * This is entirely inside the `pyenv-binary` plugin. Nothing in the core or `python-build` changes.
* [x] Please consider contributing the patch upstream to rbenv, since we have borrowed most of the code from that project.
    * Not applicable. This builds on `python-build`, which rbenv does not have.
* [x] My PR addresses the following pyenv issue (if any)
    * Part of #2334. It does not close the issue.

### Description

- [x] Here are some details about my PR
    * Generated binary definitions now use `ldconfig -r` on FreeBSD and normalize the resolved paths to sonames before the existing exact dependency check. Other systems keep the existing `ldconfig -p` behavior.
    * FreeBSD does not support `ldconfig -p`, so generated definitions previously skipped dependency validation even when its library cache was available.

### Tests

- [x] My PR adds the following unit tests (if any)
    * Added a regression test with one library present in a FreeBSD cache and one missing.
    * The full `pyenv-binary` suite completed under Bash 3.2 and 4.1, with GNU mode enabled and disabled. Each run had 47 passing tests and the existing `ldconfig -p` integration skip.
    * A FreeBSD 14.4 VM run generated a definition that checked the actual cache entries for `libc.so.7`, `libedit.so.8`, and `libtinfow.so.9`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable required-library checks on FreeBSD by reading `ldconfig -r` and normalizing entries, and add version prefix resolution in `pyenv-binary-package-name`. Linux keeps `ldconfig -p`; when the cache can’t be read, we show “ldconfig cache unavailable”.

- **New Features**
  - `pyenv-binary-package-name` resolves version prefixes via `pyenv-latest -f -k` before generating names.

- **Bug Fixes**
  - FreeBSD: parse `ldconfig -r`, handle spaced or unspaced `=>`, strip paths to sonames, then exact-match required libs.

<sup>Written for commit a6ef1e70baa7b4b9a6a04fb7eab41007fdf769ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

