### PR TITLE
CI: Add macos_26_intel

### DIFF
--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -2,7 +2,7 @@ name: modified_scripts
 on: [pull_request]
 jobs:
   discover_modified_scripts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       versions: ${{steps.modified-versions.outputs.versions}}
       versions_cpython_only: ${{steps.modified-versions.outputs.versions_cpython_only}}

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -279,7 +279,7 @@ jobs:
           export PYENV_ROOT="$GITHUB_WORKSPACE"
           echo "PYENV_ROOT=$PYENV_ROOT" >> $GITHUB_ENV
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
-          echo "_PYTHON_BUILD_FORCE_SKIP_XZ=1" >> $GITHUB_PATH
+          echo "_PYTHON_BUILD_FORCE_SKIP_XZ=1" >> $GITHUB_ENV
       - run: |
           #prerequisites
           sudo apt-get update -q; sudo apt-get install -yq make build-essential \

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -43,28 +43,32 @@ jobs:
           import packaging.version
           
           result=[]
+          def exclude_macos_intel(result, python_version):
+            result.append({'os':'macos-15-intel','python-version':python_version})
+            result.append({'os':'macos-26-intel','python-version':python_version})          
+          
           
           for line in os.environ['versions'].splitlines():
-            if m:=re.match(r'([^-]+)-(\d+\.\d+)-(\d+\.\d+.\d+)', line):
-              name, version = m.group(1), packaging.version.Version(m.group(3))
+            if m:=re.match(r'miniconda3-\d+\.\d+-(\d+\.\d+.\d+)', line):
+              version = packaging.version.Version(m.group(1))
               
               # Miniconda dropped MacOS x64 support
-              if (name == 'miniconda3' and version >= packaging.version.Version('25.9.1')):
-                result.append({'os':'macos-15-intel','python-version':line})
+              if version >= packaging.version.Version('25.9.1'):
+                exclude_macos_intel(result, line)
             
-            if m:=re.match(r'([^-]+)-(\d+\.\d+)', line):
-              name, version = m.group(1), packaging.version.Version(m.group(2))
+            if m:=re.match(r'anaconda3-(\d+\.\d+)', line):
+              version = packaging.version.Version(m.group(1))
               
               # Anaconda dropped MacOS x64 support
-              if name == 'anaconda3' and version >= packaging.version.Version('2025.12'):
-                result.append({'os':'macos-15-intel','python-version':line})
+              if version >= packaging.version.Version('2025.12'):
+                exclude_macos_intel(result, line)
           
             if m:=re.match(r'graalpy[^-]*-(community-)?(\d+\.\d+.\d+)', line):
               version = packaging.version.Version(m.group(2))
               
               # GraalPy dropped MacOS x64 support
               if version >= packaging.version.Version('25.0.2'):
-                result.append({'os':'macos-15-intel','python-version':line})
+                exclude_macos_intel(result, line)
               
           
           EOF = str(random.getrandbits(15*8))
@@ -91,6 +95,7 @@ jobs:
           - macos-15
           - macos-15-intel
           - macos-26
+          - macos-26-intel
         exclude: ${{fromJson(needs.discover_modified_scripts.outputs.versions_macos_build_exclude)}}
     runs-on: ${{ matrix.os }}
     steps:
@@ -153,7 +158,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ${{fromJson(needs.discover_modified_scripts.outputs.versions_cpython_only)}}
-        os: ["macos-14", "macos-15", "macos-15-intel"]
+        os:
+          - macos-14
+          - macos-15
+          - macos-15-intel
+          - macos-26
+          - macos-26-intel
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -165,7 +175,7 @@ jobs:
       - run: |
           #prerequisites
           brew install sqlite3 xz tcl-tk@8 libb2 zstd
-          "$GITHUB_WORKSPACE/.github/workflows/scripts/brew-uninstall-cascade.sh" openssl@3 openssl@1.1 readline
+          "$GITHUB_WORKSPACE/.github/workflows/scripts/brew-uninstall-cascade.sh" $(brew list | grep -E '^openssl(@|$)') readline
           if [[ "${{ matrix.python-version }}" =~ pypy.*-(src|dev) ]]; then
             export PYENV_BOOTSTRAP_VERSION=pypy2.7-7
             echo "PYENV_BOOTSTRAP_VERSION=$PYENV_BOOTSTRAP_VERSION" >> $GITHUB_ENV

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -49,7 +49,7 @@ jobs:
           
           
           for line in os.environ['versions'].splitlines():
-            if m:=re.match(r'miniconda3-\d+\.\d+-(\d+\.\d+.\d+)', line):
+            if m:=re.match(r'miniconda3-\d+\.\d+-(\d+\.\d+\.\d+)', line):
               version = packaging.version.Version(m.group(1))
               
               # Miniconda dropped MacOS x64 support
@@ -63,7 +63,7 @@ jobs:
               if version >= packaging.version.Version('2025.12'):
                 exclude_macos_intel(result, line)
           
-            if m:=re.match(r'graalpy[^-]*-(community-)?(\d+\.\d+.\d+)', line):
+            if m:=re.match(r'graalpy[^-]*-(community-)?(\d+\.\d+\.\d+)', line):
               version = packaging.version.Version(m.group(2))
               
               # GraalPy dropped MacOS x64 support

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -176,11 +176,6 @@ jobs:
           #prerequisites
           brew install sqlite3 xz tcl-tk@8 libb2 zstd
           "$GITHUB_WORKSPACE/.github/workflows/scripts/brew-uninstall-cascade.sh" $(brew list | grep -E '^openssl(@|$)') readline
-          if [[ "${{ matrix.python-version }}" =~ pypy.*-(src|dev) ]]; then
-            export PYENV_BOOTSTRAP_VERSION=pypy2.7-7
-            echo "PYENV_BOOTSTRAP_VERSION=$PYENV_BOOTSTRAP_VERSION" >> $GITHUB_ENV
-            pyenv install $PYENV_BOOTSTRAP_VERSION
-          fi
       - run: |
           #build
           pyenv --debug install ${{ matrix.python-version }} && rc=$? || rc=$?
@@ -289,13 +284,8 @@ jobs:
           #prerequisites
           sudo apt-get update -q; sudo apt-get install -yq make build-essential \
             libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
-            curl llvm libncurses5-dev libncursesw5-dev \
+            curl libncursesw5-dev \
             xz-utils tk-dev libffi-dev liblzma-dev
-          if [[ "${{ matrix.python-version }}" =~ pypy.*-(src|dev) ]]; then
-            export PYENV_BOOTSTRAP_VERSION=pypy2.7-7
-            echo "PYENV_BOOTSTRAP_VERSION=$PYENV_BOOTSTRAP_VERSION" >> $GITHUB_ENV
-            pyenv install $PYENV_BOOTSTRAP_VERSION
-          fi
       - run: |
           #build
           pyenv --debug install ${{ matrix.python-version }} && rc=$? || rc=$?


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

Subj.

### Tests
- [x] My PR adds the following unit tests (if any)
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `macos-26-intel` to CI, expands CPython-only runs to `macos-26`, and centralizes Intel macOS exclusions. Also fixes OpenSSL handling, regexes, and Ubuntu tar.gz builds, and runs the discover job on `ubuntu-slim`.

- **New Features**
  - Add `macos-26-intel` to macOS builds; include `macos-26` and `macos-26-intel` in CPython-only matrix.
  - Centralize Intel macOS exclusions for `miniconda3 >= 25.9.1`, `anaconda3 >= 2025.12`, and `graalpy >= 25.0.2` (exclude both `macos-15-intel` and `macos-26-intel`).
  - Run discover job on `ubuntu-slim`.

- **Bug Fixes**
  - Fix OpenSSL formula detection on macOS (including `macos-26-intel`) with `$(brew list | grep -E '^openssl(@|$)')`; include `readline` in the uninstall cascade.
  - Correct version-matching regexes for `miniconda3`, `anaconda3`, and `graalpy`.
  - Fix Ubuntu tar.gz builds by exporting `_PYTHON_BUILD_FORCE_SKIP_XZ=1` via `$GITHUB_ENV`; remove PyPy bootstrap and trim apt packages for CPython-only jobs.

<sup>Written for commit 9d6cf587b789d5b5ad9fa3072cfb60b7db273ca8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

