### PR TITLE
version-file: Fix infinite loop for a relative path argument

### DIFF
--- a/libexec/pyenv-version-file
+++ b/libexec/pyenv-version-file
@@ -11,12 +11,24 @@ find_local_version_file() {
   # Nonexistent paths are UB as of this writing.
   # Relative ones cause a failure but absolute ones don't
   [[ $root != /* ]] && root=$(CDPATH= cd -- "$root" && pwd)
-  while ! [[ "$root" =~ ^//[^/]*$ ]]; do
-    if [ -f "${root}/.python-version" ]; then
-      echo "${root}/.python-version"
+  # Original Rbenv code supports UNC notaion for Cygwin/MinGW
+  # (https://github.com/rbenv/rbenv/pull/529)
+  # POSIX.1-2024 still allows to treat //<name> in implementation-specific manner
+  # (https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap04.html#tag_04_16)
+  # even though few UNIX variants do that
+  local unc; [[ $root =~ ^//[^/] && ! / -ef // ]] && unc=1
+  # when testing root, $root is ""
+  while true; do
+    # don't test //.python-version if // is special
+    # as it's pointless and possibly very slow
+    # if it e.g. leads to a network search
+    [[ $unc && $root == / ]] && break
+    
+    if [[ -f $root/.python-version ]]; then
+      echo "$root/.python-version"
       return 0
     fi
-    [ -n "$root" ] || break
+    [[ -n $root ]] || break
     root="${root%/*}"
   done
   return 1

--- a/libexec/pyenv-version-file
+++ b/libexec/pyenv-version-file
@@ -17,6 +17,7 @@ find_local_version_file() {
   # (https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap04.html#tag_04_16)
   # even though few UNIX variants do that
   local unc; [[ $root =~ ^//[^/] && ! / -ef // ]] && unc=1
+  root="${root%/}"
   # when testing root, $root is ""
   while true; do
     # don't test //.python-version if // is special

--- a/libexec/pyenv-version-file
+++ b/libexec/pyenv-version-file
@@ -8,6 +8,9 @@ target_dir="$1"
 
 find_local_version_file() {
   local root="$1"
+  # Nonexistent paths are UB as of this writing.
+  # Relative ones cause a failure but absolute ones don't
+  [[ $root != /* ]] && root=$(CDPATH= cd -- "$root" && pwd)
   while ! [[ "$root" =~ ^//[^/]*$ ]]; do
     if [ -f "${root}/.python-version" ]; then
       echo "${root}/.python-version"

--- a/test/version-file.bats
+++ b/test/version-file.bats
@@ -73,3 +73,15 @@ create_file() {
   run pyenv-version-file "$PWD"
   assert_failure ""
 }
+
+@test "walks up beyond cwd for a relative path" {
+  create_file ".python-version"
+  mkdir -p project/subdir
+  cd project
+  # Run with CPU-time limit because this used to loop forever
+  run bash -c 'ulimit -t 5; pyenv-version-file .'
+  assert_success "${PYENV_TEST_DIR}/.python-version"
+
+  run pyenv-version-file ./subdir
+  assert_success "${PYENV_TEST_DIR}/.python-version"
+}


### PR DESCRIPTION
## What
`find_local_version_file` now terminates when `pyenv version-file` is given a relative argument without a slash (such as `.`), instead of looping forever.

## Why
`pyenv version-file .` — and ordinary shim resolution when `PWD`/`PYENV_DIR` is relative — spins at 100% CPU indefinitely. As analyzed in #3513, `${root%/*}` cannot reduce a slash-less value such as `.`, so `root` never changes and the `while` loop never exits.

## Root cause / regression history
A no-progress guard for this exact case was added back in 2014 (4c5ffc8d, then simplified in 71a916fa) and was removed unintentionally during the 2015 rbenv synchronization merge (8da37496). This restores an equivalent guard.

## How
Compute `parent="${root%/*}"` and `break` when it equals `root` (no progress), before reassigning. This is a direct restoration of the lost guard and matches the fix direction noted in the upstream rbenv issue (rbenv#525: *"check if `$root` contains a slash"*). Absolute-path traversal is unchanged — it already terminates when `root` becomes empty.

## Testing
- New `test/version-file.bats` test runs `pyenv-version-file .` under a CPU-time limit and asserts it exits `1` with no output. Before the fix the loop is killed by the limit (exit ≠ 1), so the test fails fast on a regression instead of stalling the whole suite.
- Manually verified: `pyenv version-file .` in an empty directory now returns immediately with exit `1` and no output; previously it spun until killed.

## Upstream note
The same bug is present in rbenv (pyenv's upstream), where rbenv#525 was closed as stale. I'm glad to open the equivalent fix in rbenv (with the reproduction test mislav asked for there) if you'd prefer it land upstream first — happy to follow your guidance.

Fixes #3513

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an infinite loop in `pyenv-version-file` for relative paths by normalizing inputs to absolute paths, trimming trailing slashes, and skipping `//` when it’s special. Adds CPU-time-guarded tests that confirm `.` and `./subdir` resolve the parent `.python-version`. Fixes #3513.

- **Bug Fixes**
  - Resolve non-absolute args via `CDPATH= cd -- "$root" && pwd`; trim trailing `/`; detect special `//` once and skip `//.python-version`; safely walk parents until root.
  - Tests: run relative lookups under a CPU-time limit; `.` and `./subdir` succeed when a parent has `.python-version`; `./nonexistent` exits 1 with no output.

<sup>Written for commit 1a591b3963a02ba7e3f9966b111578e61662ef21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

