### PR TITLE
CI: add ubuntu ARM images

### DIFF
--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -207,7 +207,9 @@ jobs:
         python-version: ${{fromJson(needs.discover_modified_scripts.outputs.versions)}}
         os:
           - ubuntu-22.04
+          - ubuntu-22.04-arm
           - ubuntu-24.04
+          - ubuntu-24.04-arm
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -272,8 +272,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ${{fromJson(needs.discover_modified_scripts.outputs.versions_cpython_only)}}
-        os: ["ubuntu-latest"]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - run: |

--- a/.github/workflows/pyenv_tests.yml
+++ b/.github/workflows/pyenv_tests.yml
@@ -14,7 +14,9 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
+          - ubuntu-22.04-arm
           - ubuntu-24.04
+          - ubuntu-24.04-arm
           - macos-14
           - macos-15
           - macos-15-intel

--- a/.github/workflows/pyenv_tests.yml
+++ b/.github/workflows/pyenv_tests.yml
@@ -24,25 +24,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
-      - run: |
+      - name: Install prerequisites
+        run: |
           if test "$RUNNER_OS" == "macOS"; then
             brew install coreutils fish
           fi
-      - run: pwd
-      - env:
-          PYENV_ROOT: /home/runner/work/pyenv/pyenv
-        run: |
-          echo $PYENV_ROOT
-          echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
-      - name: Run test on the host
+      - name: Run tests
         run: |
           make test
-      - name: Run test with docker
-        if: ${{ ! contains(matrix.os, 'macos') }}
-        run: |
-          make test-docker
       - env:
           PYENV_NATIVE_EXT: 1
         run: |
           (cd src; ./configure; make)
           bats/bin/bats test/{pyenv,hooks,versions}.bats
+  pyenv_tests_docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: |
+          make test-docker


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] My PR addresses the following pyenv issue (if any)
  - N/A

### Description
- [x] Here are some details about my PR

Subj. Now that they are available.

### Tests
- [x] My PR adds the following unit tests (if any)
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Ubuntu ARM64 runners (22.04, 24.04) and split Docker tests into a dedicated Ubuntu job. Previously CI ran only x86_64 and executed Docker tests inside the OS matrix; now we cover both architectures and run Docker tests once on ubuntu-latest to reduce duplication.

- Extend `modified_scripts_build` and `pyenv_tests` matrices with `ubuntu-22.04-arm` and `ubuntu-24.04-arm`; keep existing x86_64 and macOS runners.
- Move Docker tests to a new `pyenv_tests_docker` job on `ubuntu-latest`; remove the per-matrix Docker step.
- Simplify `pyenv_tests` steps: consolidate prerequisite install and keep the native-extension test path unchanged.
- Replace a single-item OS matrix with `runs-on: ubuntu-latest` where applicable (no behavior change).

<sup>Written for commit f11926a27496071001e34a342a647a6422ab8d70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

