### PR TITLE
pyenv-binary: record direct system dependencies in Linux/FreeBSD

### DIFF
--- a/plugins/pyenv-binary/libexec/pyenv-binary-save
+++ b/plugins/pyenv-binary/libexec/pyenv-binary-save
@@ -92,12 +92,16 @@ fi
 if [ "$os" = "Linux" ]; then
   libc="$(getconf GNU_LIBC_VERSION 2>/dev/null || true)"
 fi
+if [ "$os" != "Darwin" ] && ! LC_ALL=C readelf --version >/dev/null 2>&1; then
+  echo "pyenv-binary: need readelf to inspect shared libraries" >&2
+  exit 1
+fi
 
 # List the external shared libraries the install links against: those that
 # resolve outside its own prefix, so they must already exist on the target.
 # The interpreter plus every bundled shared object are inspected.
 system_deps() {
-  local f
+  local f needed
   {
     for f in "${prefix}"/bin/python*; do
       [ -e "$f" ] && printf '%s\n' "$f"
@@ -111,8 +115,15 @@ system_deps() {
       otool -L "$f" 2>/dev/null | tail -n +2 | awk -v pfx="${prefix}/" \
         '$1 !~ /^@/ && substr($1, 1, length(pfx)) != pfx { print $1 }'
     else
-      ldd "$f" 2>/dev/null | awk -v pfx="${prefix}/" \
-        '$2 == "=>" && $3 ~ /^\// && substr($3, 1, length(pfx)) != pfx { print $1 }'
+      needed="$(LC_ALL=C readelf -dW "$f" 2>/dev/null | awk \
+        '$2 == "(NEEDED)" || $2 == "NEEDED" { sub(/^.*\[/, ""); sub(/\].*$/, ""); print }' | tr '\n' ' ')"
+      LC_ALL=C ldd "$f" 2>/dev/null | awk -v needed="$needed" -v pfx="${prefix}/" '
+        BEGIN {
+          split(needed, deps, " ")
+          for (i in deps) direct[deps[i]] = 1
+        }
+        $1 in direct && $2 == "=>" && $3 ~ /^\// && substr($3, 1, length(pfx)) != pfx { print $1 }
+      '
     fi
   done | sort -u
 }

--- a/plugins/pyenv-binary/libexec/pyenv-binary-save
+++ b/plugins/pyenv-binary/libexec/pyenv-binary-save
@@ -115,8 +115,12 @@ system_deps() {
       otool -L "$f" 2>/dev/null | tail -n +2 | awk -v pfx="${prefix}/" \
         '$1 !~ /^@/ && substr($1, 1, length(pfx)) != pfx { print $1 }'
     else
+      # GNU binutils 2.44 writes "(NEEDED) ... [name]"; FreeBSD 15.1 writes
+      # "NEEDED ... [name]". readelf(1) documents -d, not its text format.
       needed="$(LC_ALL=C readelf -dW "$f" 2>/dev/null | awk \
         '$2 == "(NEEDED)" || $2 == "NEEDED" { sub(/^.*\[/, ""); sub(/\].*$/, ""); print }' | tr '\n' ' ')"
+      # Linux and FreeBSD ldd write resolved libraries as
+      # "name => /absolute/path (address)"; entries without "=>" are ignored.
       LC_ALL=C ldd "$f" 2>/dev/null | awk -v needed="$needed" -v pfx="${prefix}/" '
         BEGIN {
           split(needed, deps, " ")

--- a/plugins/pyenv-binary/libexec/pyenv-binary-save
+++ b/plugins/pyenv-binary/libexec/pyenv-binary-save
@@ -92,7 +92,7 @@ fi
 if [ "$os" = "Linux" ]; then
   libc="$(getconf GNU_LIBC_VERSION 2>/dev/null || true)"
 fi
-if [ "$os" != "Darwin" ] && ! LC_ALL=C readelf --version >/dev/null 2>&1; then
+if [ "$os" != "Darwin" ] && ! LC_ALL=C readelf --version &>/dev/null; then
   echo "pyenv-binary: need readelf to inspect shared libraries" >&2
   exit 1
 fi

--- a/plugins/pyenv-binary/test/package.bats
+++ b/plugins/pyenv-binary/test/package.bats
@@ -10,6 +10,7 @@ stub_build_environment() {
   create_stub pyenv-latest 'while (($#)); do case "$1" in -f|-k);; *)break;; esac; shift; done; echo "$*"'
   create_stub uname 'case "$1" in -s) echo Linux;; -m) echo x86_64;; esac'
   create_stub getconf 'echo "glibc 2.17"'
+  create_stub readelf true
 }
 
 @test "-v|--verbose runs pyenv install verbosely" {

--- a/plugins/pyenv-binary/test/save.bats
+++ b/plugins/pyenv-binary/test/save.bats
@@ -85,6 +85,7 @@ platform() {
 
 @test "fails when readelf is not available" {
   create_version "3.12.7"
+  create_stub uname 'case "$1" in -s) echo Linux;; -m) echo x86_64;; esac'
 
   PATH="$(path_without readelf)" run pyenv-binary-save "3.12.7" "${BATS_TEST_TMPDIR}/dist"
   assert_failure "pyenv-binary: need readelf to inspect shared libraries"

--- a/plugins/pyenv-binary/test/save.bats
+++ b/plugins/pyenv-binary/test/save.bats
@@ -86,8 +86,9 @@ platform() {
 @test "fails when readelf is not available" {
   create_version "3.12.7"
   create_stub uname 'case "$1" in -s) echo Linux;; -m) echo x86_64;; esac'
+  create_path_executable readelf "exit 1"
 
-  PATH="$(path_without readelf)" run pyenv-binary-save "3.12.7" "${BATS_TEST_TMPDIR}/dist"
+  run pyenv-binary-save "3.12.7" "${BATS_TEST_TMPDIR}/dist"
   assert_failure "pyenv-binary: need readelf to inspect shared libraries"
   assert [ ! -e "${BATS_TEST_TMPDIR}/dist/3.12.7-$(platform).tar.gz" ]
 }

--- a/plugins/pyenv-binary/test/save.bats
+++ b/plugins/pyenv-binary/test/save.bats
@@ -86,9 +86,8 @@ platform() {
 @test "fails when readelf is not available" {
   create_version "3.12.7"
   create_stub uname 'case "$1" in -s) echo Linux;; -m) echo x86_64;; esac'
-  create_path_executable readelf "exit 1"
 
-  run pyenv-binary-save "3.12.7" "${BATS_TEST_TMPDIR}/dist"
+  PATH="$(path_without readelf)" run pyenv-binary-save "3.12.7" "${BATS_TEST_TMPDIR}/dist"
   assert_failure "pyenv-binary: need readelf to inspect shared libraries"
   assert [ ! -e "${BATS_TEST_TMPDIR}/dist/3.12.7-$(platform).tar.gz" ]
 }

--- a/plugins/pyenv-binary/test/save.bats
+++ b/plugins/pyenv-binary/test/save.bats
@@ -2,6 +2,10 @@
 
 load test_helper
 
+_setup() {
+  create_path_executable readelf "exit 0"
+}
+
 create_version() {
   mkdir -p "${PYENV_ROOT}/versions/$1/bin"
 }
@@ -79,7 +83,15 @@ platform() {
   assert_line "archive=3.12.7-$(platform).tar.gz"
 }
 
-@test "records only the libraries ldd resolves outside the prefix" {
+@test "fails when readelf is not available" {
+  create_version "3.12.7"
+
+  PATH="$(path_without readelf)" run pyenv-binary-save "3.12.7" "${BATS_TEST_TMPDIR}/dist"
+  assert_failure "pyenv-binary: need readelf to inspect shared libraries"
+  assert [ ! -e "${BATS_TEST_TMPDIR}/dist/3.12.7-$(platform).tar.gz" ]
+}
+
+@test "records only direct libraries resolved outside the prefix" {
   create_version "3.12.7"
   touch "${PYENV_ROOT}/versions/3.12.7/bin/python3.12"
   create_path_executable uname <<'STUB'
@@ -98,12 +110,17 @@ cat <<EOF
 	/lib64/ld-linux-x86-64.so.2 (0x00007f4a3c200000)
 EOF
 STUB
+  create_path_executable readelf <<'STUB'
+cat <<EOF
+ 0x0000000000000001 (NEEDED)             Shared library: [libpython3.12.so.1.0]
+ 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
+EOF
+STUB
 
   run pyenv-binary-save "3.12.7" "${BATS_TEST_TMPDIR}/dist"
   assert_success
   run grep '^dep=' "${BATS_TEST_TMPDIR}/dist/"*.meta
-  assert_output "dep=libc.so.6
-dep=libm.so.6"
+  assert_output "dep=libm.so.6"
 }
 
 @test "records only the libraries otool resolves outside the prefix" {

--- a/plugins/pyenv-binary/test/save.bats
+++ b/plugins/pyenv-binary/test/save.bats
@@ -2,10 +2,6 @@
 
 load test_helper
 
-_setup() {
-  create_path_executable readelf "exit 0"
-}
-
 create_version() {
   mkdir -p "${PYENV_ROOT}/versions/$1/bin"
 }

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -12,7 +12,7 @@ FROM bash:$BASH
     apk add sed coreutils findutils \
   ;fi
   # Bats
-  RUN apk add --update parallel ncurses git \
+  RUN apk add --update parallel ncurses git binutils \
         && mkdir -p ~/.parallel \
         && touch ~/.parallel/will-cite
   COPY --from=bats /root/bats-core /root/bats-core

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -165,7 +165,7 @@ path_without() {
       if [ "$found" != "${PYENV_ROOT}/shims" ]; then
         alt="${PYENV_TEST_DIR}/$(echo "${found#/}" | tr '/' '-')"
         mkdir -p "$alt"
-        for util in bash head cut readlink greadlink tr sed xargs basename sort; do
+        for util in basename bash cut greadlink head mkdir readlink sed sort tr xargs; do
           if [ -x "${found}/$util" ]; then
             ln -s "${found}/$util" "${alt}/$util"
           fi

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -165,7 +165,7 @@ path_without() {
       if [ "$found" != "${PYENV_ROOT}/shims" ]; then
         alt="${PYENV_TEST_DIR}/$(echo "${found#/}" | tr '/' '-')"
         mkdir -p "$alt"
-        for util in basename bash cut greadlink head mkdir readlink sed sort tr xargs; do
+        for util in basename bash cut dirname find greadlink gzip head mkdir readlink sed sort tar tr xargs; do
           if [ -x "${found}/$util" ]; then
             ln -s "${found}/$util" "${alt}/$util"
           fi


### PR DESCRIPTION
 ### Prerequisite

  * [x] Please consider implementing the feature as a hook script or plugin as a first step.
    * This is implemented entirely inside the `pyenv-binary` plugin. Nothing in core or `python-build` changes.
  * [x] My PR addresses the following pyenv issue (if any)
    - Part of #2334. It does not close the issue.

  ### Description

  - [x] Here are some details about my PR
    - `pyenv binary save` now records only direct shared-library dependencies in package metadata.
    - For ELF files, it reads `DT_NEEDED` entries with `readelf` and matches them against the paths resolved by `ldd`. Libraries inside the packaged prefix and transitive dependencies are excluded.
    - The existing macOS `otool` path is unchanged.
    - The command fails before creating an archive when `readelf` is unavailable.

  ### Tests

  - [x] My PR adds the following unit tests (if any)
    - Added coverage for a missing `readelf` executable.
    - Updated the dependency test to distinguish direct, transitive, packaged, and system libraries.
    - The full `pyenv-binary` suite passed with Bash 3.2 and Bash 4.1 using both BusyBox and GNU tools: 200 passing tests and 4 expected `ldconfig -p` skips.
    - Verified on FreeBSD 15.1 that direct dependencies are retained and a transitive dependency is excluded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records only direct system shared-library dependencies in `pyenv-binary` metadata on ELF platforms. Previously all `ldd`-resolved libraries were recorded; now `pyenv-binary-save` filters by `readelf` DT_NEEDED and exits early if `readelf` is unavailable.

- Non-macOS builders must have `readelf` on PATH (install via `binutils`); the command fails before archiving if it is missing.
- Tests: add a failure case for missing `readelf`, update dependency expectations to direct-only, and stub `readelf` in package tests.
- CI: install `binutils` in the test Dockerfile and broaden `path_without` essentials; the script comments document the `readelf`/`ldd` formats parsed.

<sup>Written for commit 7e8a1b740f1e5640248e2fb70787f9b3a759028c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

