### PR TITLE
Fix typo in pyenv-version-file

### DIFF
--- a/libexec/pyenv-version-file
+++ b/libexec/pyenv-version-file
@@ -11,7 +11,7 @@ find_local_version_file() {
   # Nonexistent paths are UB as of this writing.
   # Relative ones cause a failure but absolute ones don't
   [[ $root != /* ]] && root=$(CDPATH= cd -- "$root" && pwd)
-  # Original Rbenv code supports UNC notaion for Cygwin/MinGW
+  # Original Rbenv code supports UNC notation for Cygwin/MinGW
   # (https://github.com/rbenv/rbenv/pull/529)
   # POSIX.1-2024 still allows to treat //<name> in implementation-specific manner
   # (https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap04.html#tag_04_16)


### PR DESCRIPTION
Fixes a spelling error in pyenv-version-file, changing "notaion" to "notation"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects a typo in a comment in `libexec/pyenv-version-file` ("notaion" → "notation") to improve clarity. No runtime or behavior changes; this is a comment-only update.

<sup>Written for commit 49cc520c4673d3bc18e58ce4902222dff9e28fe0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

