### PR TITLE
tests: Fix "cd: null directory" in OpenSUSE

### DIFF
--- a/libexec/pyenv-version-file
+++ b/libexec/pyenv-version-file
@@ -38,7 +38,9 @@ find_local_version_file() {
 if [ -n "$target_dir" ]; then
   find_local_version_file "$target_dir"
 else
-  find_local_version_file "$PYENV_DIR" || {
+  # In tests, PYENV_DIR is not set, ultimately leading to "cd: null directory" in OpenSUSE
+  # While most `cd` implemntations treat an empty argument the same as missing, that's still wrong
+  find_local_version_file "${PYENV_DIR:=$PWD}" || {
     [ "$PYENV_DIR" != "$PWD" ] && find_local_version_file "$PWD"
   } || echo "${PYENV_ROOT}/version"
 fi


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] My PR addresses the following pyenv issue (if any)
  - Closes https://github.com/pyenv/pyenv/issues/3523

### Description
- [x] Here are some details about my PR

A workaround because tests don't use the Pyenv launcher and setting `PYENV_DIR` to `$PWD` at every `run` invocation is too cumbersome.

### Tests
- [x] My PR adds the following unit tests (if any)
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaults `PYENV_DIR` to `$PWD` in `libexec/pyenv-version-file` when it’s unset to stop “cd: null directory” errors on OpenSUSE during tests. Old behavior: the script attempted to `cd` into an empty `PYENV_DIR`; new behavior: it uses the current working directory by default; no change to version file lookup semantics for normal runs.

<sup>Written for commit e61323419681591b94d5a4c6c9c23f29fdd34e7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

