### PR TITLE
Fix typo in pyenv-binary-generate-installer

### DIFF
--- a/plugins/pyenv-binary/libexec/pyenv-binary-generate-installer
+++ b/plugins/pyenv-binary/libexec/pyenv-binary-generate-installer
@@ -14,7 +14,7 @@
 #   into the definition; `pyenv binary save' writes the two together.
 #
 #   <metadata-file>       A .meta file written by `pyenv binary save'.
-#                         The corresponsing binary package written by `pyenv binary save'
+#                         The corresponding binary package written by `pyenv binary save'
 #                         needs to be present alongside it.
 #   --archive-url <url>   The URL for the resulting installation script to download
 #                         the package from.


### PR DESCRIPTION
Fixes a spelling error in pyenv-binary-generate-installer, changing "corresponsing" to "corresponding"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a typo in the `pyenv-binary` installer script, changing "corresponsing" to "corresponding" in its usage comment. No functional changes.

<sup>Written for commit 097149974a3ab864c9453ee8bc9ea35f050cf38b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

