### PR TITLE
Fix typo "implemntations" in pyenv-version-file

### DIFF
--- a/libexec/pyenv-version-file
+++ b/libexec/pyenv-version-file
@@ -39,7 +39,7 @@ if [ -n "$target_dir" ]; then
   find_local_version_file "$target_dir"
 else
   # In tests, PYENV_DIR is not set, ultimately leading to "cd: null directory" in OpenSUSE
-  # While most `cd` implemntations treat an empty argument the same as missing, that's still wrong
+  # While most `cd` implementations treat an empty argument the same as missing, that's still wrong
   find_local_version_file "${PYENV_DIR:=$PWD}" || {
     [ "$PYENV_DIR" != "$PWD" ] && find_local_version_file "$PWD"
   } || echo "${PYENV_ROOT}/version"


### PR DESCRIPTION
Fixes a spelling error in pyenv-version-file, changing "implemntations" to "implementations"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the misspelling "implemntations" to "implementations" in a comment in `pyenv-version-file`. No behavior changes.

<sup>Written for commit a01f177cf8fb207f95e11400d73911aec9b084b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

