### PR TITLE
Update graalpy URLs for 25.3.4.1

### DIFF
--- a/plugins/python-build/share/python-build/graalpy3.13-25.3.4.1
+++ b/plugins/python-build/share/python-build/graalpy3.13-25.3.4.1
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 VERSION='25.3.4.1'
+RELEASE_TAG='graal-25.3.4'
 
 colorize 1 "GraalPy 23.1 and later installed by python-build use the faster Oracle GraalVM distribution" && echo
 colorize 1 "Oracle GraalVM uses the GFTC license, which is free for development and production use, see https://medium.com/graalvm/161527df3d76" && echo
@@ -46,4 +47,4 @@ case "$graalpy_arch" in
   ;;
 esac
 
-install_package "graalpy3.13-${VERSION}" "https://github.com/oracle/graalpython/releases/download/graal-${VERSION}/graalpy3.13-${VERSION}-${graalpy_arch}.tar.gz#${checksum}" "copy" ensurepip
+install_package "graalpy3.13-${VERSION}" "https://github.com/oracle/graalpython/releases/download/${RELEASE_TAG}/graalpy3.13-${VERSION}-${graalpy_arch}.tar.gz#${checksum}" "copy" ensurepip

--- a/plugins/python-build/share/python-build/graalpy3.13-community-25.3.4.1
+++ b/plugins/python-build/share/python-build/graalpy3.13-community-25.3.4.1
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 VERSION='25.3.4.1'
+RELEASE_TAG='graal-25.3.4'
 
 graalpy_arch="$(graalpy_architecture 2>/dev/null || true)"
 
@@ -41,4 +42,4 @@ case "$graalpy_arch" in
   ;;
 esac
 
-install_package "graalpy3.13-community-${VERSION}" "https://github.com/oracle/graalpython/releases/download/graal-${VERSION}/graalpy3.13-community-${VERSION}-${graalpy_arch}.tar.gz#${checksum}" "copy" ensurepip
+install_package "graalpy3.13-community-${VERSION}" "https://github.com/oracle/graalpython/releases/download/${RELEASE_TAG}/graalpy3.13-community-${VERSION}-${graalpy_arch}.tar.gz#${checksum}" "copy" ensurepip


### PR DESCRIPTION
We had to change the release tag name because the four-component version broke most tools.

CC @timfel 

Fixes https://github.com/pyenv/pyenv/issues/3531

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates GraalPy 25.3.4.1 download URLs to use the renamed `graal-25.3.4` release tag, fixing installs for standard and community distributions.

- Keeps the artifact filenames on the full `25.3.4.1` version.

<sup>Written for commit 159d89334f98f51a8a430e914b3f2dfda66a5131. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

