### PR TITLE
pyenv-exec: add option to modify python runtime for the called execut…

### DIFF
--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -2,9 +2,9 @@
 #
 # Summary: Run an executable with the selected Python version
 #
-# Usage: pyenv exec [-E|--environment] <command> [arg1 arg2...]
+# Usage: pyenv exec [-N|--environment] <command> [arg1 arg2...]
 #
-#    -E  Set PYTHONHOME and LD_LIBRARY_PATH envvars for the running command.
+#    -N  Set PYTHONHOME and LD_LIBRARY_PATH envvars for the running command.
 #        This allows to run programs that embed Python without using rpath or
 #        exact library path.
 #        WARNING! For the running command and its child processes, this will
@@ -29,7 +29,7 @@ if [ "$1" = "--complete" ]; then
 fi
 
 unset MODIFY_ENV
-if [ "$1" = "-E" ] || [ "$1" = "--environment" ]; then
+if [ "$1" = "-N" ] || [ "$1" = "--environment" ]; then
   MODIFY_ENV=true
   shift
 fi

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -4,7 +4,8 @@
 #
 # Usage: pyenv exec [-E|--environment] <command> [arg1 arg2...]
 #
-#    -E  Modify Python runtime environment, such as $PYTHONHOME, for the called executable.
+#    -E  Set PYTHONHOME and LD_LIBRARY_PATH envvars for the running command. This allows to run programs that embed Python without using rpath or exact library path.
+#         WARNING! For the running command and its child processes, this will break linkage for programs that expect to be linked to system libpython!
 #
 # Runs an executable by first preparing PATH so that the selected Python
 # version's `bin' directory is at the front.

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -71,9 +71,9 @@ if [ -n "$MODIFY_ENV" ]; then
   # Check if multiple Python versions are selected
   VERSIONS=$(pyenv-prefix)
   if [[ "$VERSIONS" == *:* ]]; then
-    echo 'Warning: multiple Python versions are selected'
+    echo 'Warning: multiple Python versions are selected' >&2
     VERSION="${VERSIONS%%:*}"
-    echo "Using the first one available (${VERSION##*/})"
+    echo "Using the first one available (${VERSION##*/})" >&2
   else
     VERSION="$VERSIONS"
   fi

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -2,7 +2,9 @@
 #
 # Summary: Run an executable with the selected Python version
 #
-# Usage: pyenv exec <command> [arg1 arg2...]
+# Usage: pyenv exec [-E|--environment] <command> [arg1 arg2...]
+#
+#    -E  Modify Python runtime environment, such as $PYTHONHOME, for the called executable.
 #
 # Runs an executable by first preparing PATH so that the selected Python
 # version's `bin' directory is at the front.
@@ -18,7 +20,14 @@ set -e
 
 # Provide pyenv completions
 if [ "$1" = "--complete" ]; then
+  echo --environment
   exec pyenv-shims --short
+fi
+
+unset MODIFY_ENV
+if [ "$1" = "-E" ] || [ "$1" = "--environment" ]; then
+  MODIFY_ENV=true
+  shift
 fi
 
 PYENV_VERSION="$(pyenv-version-name -f)"
@@ -53,5 +62,9 @@ shift 1
 if [ "${PYENV_BIN_PATH#${PYENV_ROOT}}" != "${PYENV_BIN_PATH}" ]; then
   # Only add to $PATH for non-system version.
   export PATH="${PYENV_BIN_PATH}:${PATH}"
+fi
+if [ -n "$MODIFY_ENV" ]; then
+  export PYTHONHOME="$(pyenv-prefix)"
+  export LD_LIBRARY_PATH="${PYTHONHOME}/lib:${LD_LIBRARY_PATH}"
 fi
 exec "$PYENV_COMMAND_PATH" "$@"

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -4,8 +4,11 @@
 #
 # Usage: pyenv exec [-E|--environment] <command> [arg1 arg2...]
 #
-#    -E  Set PYTHONHOME and LD_LIBRARY_PATH envvars for the running command. This allows to run programs that embed Python without using rpath or exact library path.
-#         WARNING! For the running command and its child processes, this will break linkage for programs that expect to be linked to system libpython!
+#    -E  Set PYTHONHOME and LD_LIBRARY_PATH envvars for the running command.
+#        This allows to run programs that embed Python without using rpath or
+#        exact library path.
+#        WARNING! For the running command and its child processes, this will
+#        break linkage for programs that expect to be linked to system libpython!
 #
 # Runs an executable by first preparing PATH so that the selected Python
 # version's `bin' directory is at the front.

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -68,7 +68,18 @@ if [ "${PYENV_BIN_PATH#${PYENV_ROOT}}" != "${PYENV_BIN_PATH}" ]; then
   export PATH="${PYENV_BIN_PATH}:${PATH}"
 fi
 if [ -n "$MODIFY_ENV" ]; then
-  export PYTHONHOME="$(pyenv-prefix)"
+  # Check if multiple Python versions are selected
+  VERSIONS=$(pyenv-prefix)
+  if [[ "$VERSIONS" == *:* ]]; then
+    echo 'Warning: multiple Python versions are selected'
+    VERSION="${VERSIONS%%:*}"
+    echo "Using the first one available (${VERSION##*/})"
+  else
+    VERSION="$VERSIONS"
+  fi
+
+  # Assign the correct version of PYTHONHOME
+  export PYTHONHOME="$VERSION"
   export LD_LIBRARY_PATH="${PYTHONHOME}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 fi
 exec "$PYENV_COMMAND_PATH" "$@"

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -68,7 +68,12 @@ if [ "${PYENV_BIN_PATH#${PYENV_ROOT}}" != "${PYENV_BIN_PATH}" ]; then
   # Only add to $PATH for non-system version.
   export PATH="${PYENV_BIN_PATH}:${PATH}"
 fi
-if [ -n "$MODIFY_ENV" ] && [ "$(uname -s)" = Linux ]; then
+if [ -n "$MODIFY_ENV" ]; then
+  if [ "$(uname -s)" != Linux ]; then
+    echo 'Error: the -N option is supported only on Linux' >&2
+    exit 1
+  fi
+
   # Check if multiple Python versions are selected
   VERSIONS=$(pyenv-prefix)
   if [[ "$VERSIONS" == *:* ]]; then

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -9,6 +9,7 @@
 #        exact library path.
 #        WARNING! For the running command and its child processes, this will
 #        break linkage for programs that expect to be linked to system libpython!
+#        This option is Linux only.
 #
 # Runs an executable by first preparing PATH so that the selected Python
 # version's `bin' directory is at the front.
@@ -67,7 +68,7 @@ if [ "${PYENV_BIN_PATH#${PYENV_ROOT}}" != "${PYENV_BIN_PATH}" ]; then
   # Only add to $PATH for non-system version.
   export PATH="${PYENV_BIN_PATH}:${PATH}"
 fi
-if [ -n "$MODIFY_ENV" ]; then
+if [ -n "$MODIFY_ENV" ] && [ "$(uname -s)" = Linux ]; then
   # Check if multiple Python versions are selected
   VERSIONS=$(pyenv-prefix)
   if [[ "$VERSIONS" == *:* ]]; then

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -65,6 +65,6 @@ if [ "${PYENV_BIN_PATH#${PYENV_ROOT}}" != "${PYENV_BIN_PATH}" ]; then
 fi
 if [ -n "$MODIFY_ENV" ]; then
   export PYTHONHOME="$(pyenv-prefix)"
-  export LD_LIBRARY_PATH="${PYTHONHOME}/lib:${LD_LIBRARY_PATH}"
+  export LD_LIBRARY_PATH="${PYTHONHOME}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 fi
 exec "$PYENV_COMMAND_PATH" "$@"

--- a/libexec/pyenv-exec
+++ b/libexec/pyenv-exec
@@ -70,7 +70,7 @@ if [ "${PYENV_BIN_PATH#${PYENV_ROOT}}" != "${PYENV_BIN_PATH}" ]; then
 fi
 if [ -n "$MODIFY_ENV" ]; then
   if [ "$(uname -s)" != Linux ]; then
-    echo 'Error: the -N option is supported only on Linux' >&2
+    echo 'Error: the --environment option is supported only on Linux' >&2
     exit 1
   fi
 

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -34,6 +34,7 @@ EOF
   assert_success
   assert_output <<OUT
 --help
+--environment
 fab
 python
 OUT

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -140,3 +140,21 @@ $envvarname=/unusual/shim/location:/another/shim/location
 _PYENV_SHIM_PATH=
 !
 }
+
+@test "fails on non-Linux system" {
+  # Make sure to use the system version of Python
+  mkdir -p "$PYENV_TEST_DIR"
+  cd "$PYENV_TEST_DIR"
+  echo '' > .python-version
+
+  run uname -s
+  if [ "$output" != Linux ]; then
+    run pyenv-exec -N env
+    assert_failure
+    assert_output 'Error: the --environment option is supported only on Linux'
+  else
+    run pyenv-exec -N env
+    echo "$status"
+    assert_success
+  fi
+}


### PR DESCRIPTION
…able

The only variables modified are $PYTHONHOME and $LD_LIBRARY_PATH which will allow the executable to use the shared library of the Python version which is selected with pyenv.

Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] My PR addresses the following pyenv issue (if any)
  * Closes https://github.com/pyenv/pyenv/issues/2650

### Description
- [x] Here are some details about my PR

This PR allows to add option to pyenv-exec that sets the environment variables $PYTHONHOME and $LD_LIBRARY_PATH for the called executable. This way the executable which embeds the Python will be able to use the standard library of the Python's version which is selected with pyenv.

### Tests
- [x] My PR adds the following unit tests (if any)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `-N`/`--environment` flag to `pyenv exec` so called executables can use the pyenv-selected Python version's shared library.

- The flag sets `PYTHONHOME` and `LD_LIBRARY_PATH` for the executed command; without it, behavior is unchanged.
- This option is Linux-only and rejects other platforms with an error.
- When multiple Python versions are selected, it warns on stderr and uses the first one.
- For the command and its child processes, this can break linkage for programs that expect to link to the system libpython.

<sup>Written for commit fa03780a37386e3fb102c9d25830cd890c5db96d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



