### PR TITLE
CI: publish Ubuntu binary packages

### DIFF
--- a/.github/workflows/publish_binary.yml
+++ b/.github/workflows/publish_binary.yml
@@ -25,6 +25,7 @@ jobs:
         env:
           PYTHON_CONFIGURE_OPTS: --enable-optimizations
         run: |
+          VERSION="${VERSION%%:*}"
           entry="$(./bin/pyenv binary package-name "$VERSION")"
           echo "entry=$entry" >> "$GITHUB_ENV"
           mkdir dist

--- a/.github/workflows/publish_binary.yml
+++ b/.github/workflows/publish_binary.yml
@@ -1,0 +1,69 @@
+name: Publish a binary package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: A CPython version accepted by `pyenv install`
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish_ubuntu:
+    runs-on: ubuntu-24.04
+    env:
+      PYENV_ROOT: ${{ github.workspace }}
+      VERSION: ${{ inputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install build prerequisites
+        run: ./bin/pyenv install-prerequisites
+      - name: Build package
+        env:
+          PYTHON_CONFIGURE_OPTS: --enable-optimizations
+        run: |
+          entry="$(./bin/pyenv binary package-name "$VERSION")"
+          echo "entry=$entry" >> "$GITHUB_ENV"
+          mkdir dist
+          cd dist
+          "$GITHUB_WORKSPACE/bin/pyenv" binary package --verbose \
+            "$VERSION:$entry" \
+            --archive-base-url https://pyenv.github.io/pythons/binaries
+
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@v3
+        id: generate-token
+        with:
+          app-id: ${{ vars.PYENV_BOT_APP_ID }}
+          private-key: ${{ secrets.PYENV_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: pyenv.github.io
+          permission-contents: write
+          permission-pull-requests: write
+      - uses: actions/checkout@v7
+        with:
+          repository: pyenv/pyenv.github.io
+          token: ${{ steps.generate-token.outputs.token }}
+          path: site
+      - name: Update downloads
+        run: |
+          mkdir -p site/pythons/binaries
+          cp "dist/$entry.tar.gz" "dist/$entry.meta" "dist/$entry" \
+            site/pythons/binaries/
+          cd site/pythons
+          ./update.sh
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          path: site
+          branch: auto_add_binary/${{ env.entry }}
+          title: Add CPython ${{ env.entry }}
+          commit-message: Add CPython ${{ env.entry }}
+          body: |
+            Built from pyenv/pyenv@${{ github.sha }} with profile-guided optimization enabled.
+
+            Part of pyenv/pyenv#2334.
+          token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
### Prerequisite

  * [x] Please consider implementing the feature as a hook script or plugin as a first step.
    * This workflow uses the existing `pyenv-binary` plugin to build the package, metadata and python-build definition.
  * [x] My PR addresses the following pyenv issue (if any)
    * Part of #2334. It does not close the issue.

  ### Description

  - [x] Here are some details about my PR
    * Adds a manually triggered workflow for publishing Ubuntu 24.04 x86_64 CPython packages.
    * Builds the requested version with profile-guided optimization using the existing prerequisite installer and binary packaging commands.
    * Copies the archive, metadata and definition to `pyenv/pyenv.github.io`, updates its download index and opens a pull request there.
    * Scopes the existing PYENV Bot token to `pyenv/pyenv.github.io` with contents and pull-request write access.

  ### Tests

  - [x] My PR adds the following unit tests (if any)
    * No new unit tests are needed for the workflow configuration.
    * The existing binary-package tests pass: 12/12.
    * The existing prerequisite-installer tests pass: 7/7.
    * Actionlint and ShellCheck pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manually triggered GitHub Actions workflow that builds and publishes Ubuntu 24.04 x86_64 CPython binary packages, addressing part of #2334.

- Accepts any CPython version accepted by `pyenv install` via a `workflow_dispatch` input and normalizes it before building.
- Builds the requested version with `--enable-optimizations` so the binary uses profile-guided optimization.
- Copies the archive, metadata, and python-build definition into `pyenv/pyenv.github.io` and opens a pull request there.
- Scopes the PYENV Bot token to `pyenv/pyenv.github.io` with contents and pull-request write permissions.

<sup>Written for commit 58a046220d1fbc8091cd47841bfd485b70302d3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv/pull/3539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

